### PR TITLE
Do Not Merge: review and discuss adding tor onion transport

### DIFF
--- a/p2p/net/swarm/addr/addr.go
+++ b/p2p/net/swarm/addr/addr.go
@@ -3,6 +3,7 @@ package addrutil
 import (
 	"fmt"
 
+	onion "github.com/david415/ipfs-onion-transport"
 	logging "github.com/ipfs/go-log"
 	ma "github.com/jbenet/go-multiaddr"
 	manet "github.com/jbenet/go-multiaddr-net"
@@ -21,6 +22,7 @@ var SupportedTransportStrings = []string{
 	"/ip6/udp/utp",
 	// "/ip4/udp/udt", disabled because the lib doesnt work on arm
 	// "/ip6/udp/udt", disabled because the lib doesnt work on arm
+	"/onion",
 }
 
 // SupportedTransportProtocols is the list of supported transports for the swarm.

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -111,10 +111,18 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 	}
 
 	// POC setup for onion transport
+
+	// The Tor socks user and password can be set to random values
+	// to tell little-t tor to make a new circuit.
+	// It's probably OK to leave them blank because when connecting
+	// to a new onion a new tor circuit will have to be created anyway.
 	auth := proxy.Auth{
 		User:     "",
 		Password: "",
 	}
+
+	// XXX FIXME: The tor control net and addr should be user specified!
+	// Note: for sandboxing purposes UNIX domain sockets are preferred instead of TCP.
 	controlNet := "tcp"
 	controlAddr := "127.0.0.1:9051"
 	onionTransport := NewOnionTransport(controlNet, controlAddr, nil, &auth)


### PR DESCRIPTION
The user needs to be able to specify the tor connection information; either an IP addr and TCP port or a UNIX domain socket. Here in this proof of concept I've hardcoded the tor control port addr/port. Terrabad. Let's fix it... I haven't looked at how yet. I just now wrote the onion transport. It has some problems which I hope to discuss in another code review.
