### PR TITLE
swarm: pass in stream muxer on construct

### DIFF
--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -145,9 +145,9 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 	return s, nil
 }
 
-func NewBlankSwarm(ctx context.Context, id peer.ID, privkey ci.PrivKey) *Swarm {
+func NewBlankSwarm(ctx context.Context, id peer.ID, privkey ci.PrivKey, pstpt pst.Transport) *Swarm {
 	s := &Swarm{
-		swarm:       ps.NewSwarm(PSTransport),
+		swarm:       ps.NewSwarm(pstpt),
 		local:       id,
 		peers:       pstore.NewPeerstore(),
 		ctx:         ctx,

--- a/package.json
+++ b/package.json
@@ -129,9 +129,9 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmduCCgTaLnxwwf9RFQy2PMUytrKcEH9msohtVxSBZUdgu",
+      "hash": "QmRmFKJgjjQhrT1uDyhpS87kE5M9YbMT8RBWam5uk8o4uH",
       "name": "go-peerstream",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
This lets the 'empty' swarm constructor take in the stream muxer to use, also giving us the option to pass in 'nil' to avoid set up stream multiplexing (for use in the justtcp) example