### PR TITLE
swarm: add optimized method for checking connectedness to peer

### DIFF
--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -286,6 +286,15 @@ func (s *Swarm) ConnectionsToPeer(p peer.ID) []*Conn {
 	return wrapConns(ps.ConnsWithGroup(p, s.swarm.Conns()))
 }
 
+func (s *Swarm) HaveConnsToPeer(p peer.ID) bool {
+	for _, c := range s.swarm.Conns() {
+		if c.InGroup(p) {
+			return true
+		}
+	}
+	return false
+}
+
 // Connections returns a slice of all connections.
 func (s *Swarm) Connections() []*Conn {
 	return wrapConns(s.swarm.Conns())

--- a/p2p/net/swarm/swarm_net.go
+++ b/p2p/net/swarm/swarm_net.go
@@ -123,8 +123,7 @@ func (n *Network) InterfaceListenAddresses() ([]ma.Multiaddr, error) {
 // Connectedness returns a state signaling connection capabilities
 // For now only returns Connected || NotConnected. Expand into more later.
 func (n *Network) Connectedness(p peer.ID) inet.Connectedness {
-	c := n.Swarm().ConnectionsToPeer(p)
-	if len(c) > 0 {
+	if n.Swarm().HaveConnsToPeer(p) {
 		return inet.Connected
 	}
 	return inet.NotConnected


### PR DESCRIPTION
We call connectedness quite a lot, at least once every time we get a findPeer DHT rpc. Optimizing this saves us a lot of small objects that need to be garbage collected and map accesses