### PR TITLE
identify: send + consume public keys too

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -164,6 +164,17 @@ func (ids *IDService) populateMessage(mes *pb.Identify, c inet.Conn) {
 	}
 	log.Debugf("%s sent listen addrs to %s: %s", c.LocalPeer(), c.RemotePeer(), laddrs)
 
+	ownKey := ids.Host.Peerstore().PubKey(ids.Host.ID())
+	if ownKey == nil {
+		log.Errorf("did not have own public key in Peerstore")
+	} else {
+		if kb, err := ownKey.Bytes(); err != nil {
+			log.Errorf("failed to convert key to bytes")
+		} else {
+			mes.PublicKey = kb
+		}
+	}
+
 	// set protocol versions
 	pv := LibP2PVersion
 	av := ClientVersion


### PR DESCRIPTION
   d767ab5 (jbenet, 73 seconds ago)
      identify: tests verify we have public keys

   d58b668 (jbenet, 2 minutes ago)
      identify: consume public key in message.

      Make sure to verify that our keys match. In the rare event they do not,
      make sure to investigate what's wrong, and log errors.

   65273ab (jbenet, 2 minutes ago)
      identify: send public key in message