### PR TITLE
Fix libp2p spec link

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -5,7 +5,7 @@ before reporting things, and help us with the open ones.
 
 Guidelines:
 
-- read the [libp2p spec](https://github.com/ipfs/specs/tree/master/libp2p)
+- read the [libp2p spec](https://github.com/libp2p/specs)
 - please make branches + pull-request, even if working on the main repository
 - ask questions or talk about things in [Issues](https://github.com/ipfs/go-ipfs/issues) or #ipfs on freenode.
 - ensure you are able to contribute (no legal issues please-- we use the DCO)

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -5,7 +5,7 @@ before reporting things, and help us with the open ones.
 
 Guidelines:
 
-- read the [libp2p spec](https://github.com/ipfs/specs/tree/master/protocol/network)
+- read the [libp2p spec](https://github.com/ipfs/specs/tree/master/libp2p)
 - please make branches + pull-request, even if working on the main repository
 - ask questions or talk about things in [Issues](https://github.com/ipfs/go-ipfs/issues) or #ipfs on freenode.
 - ensure you are able to contribute (no legal issues please-- we use the DCO)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[libp2p](https://github.com/ipfs/specs/tree/master/libp2p) implementation in Go.
+[libp2p](https://github.com/libp2p/specs) implementation in Go.
 ===================
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
@@ -12,13 +12,13 @@
 
 # Description
 
-[libp2p](https://github.com/ipfs/specs/tree/master/libp2p) is a networking stack and library modularized out of [The IPFS Project](https://github.com/ipfs/ipfs), and bundled separately for other tools to use.
+[libp2p](https://github.com/libp2p/specs) is a networking stack and library modularized out of [The IPFS Project](https://github.com/ipfs/ipfs), and bundled separately for other tools to use.
 >
 libp2p is the product of a long, and arduous quest of understanding -- a deep dive into the internet's network stack, and plentiful peer-to-peer protocols from the past. Building large scale peer-to-peer systems has been complex and difficult in the last 15 years, and libp2p is a way to fix that. It is a "network stack" -- a protocol suite -- that cleanly separates concerns, and enables sophisticated applications to only use the protocols they absolutely need, without giving up interoperability and upgradeability. libp2p grew out of IPFS, but it is built so that lots of people can use it, for lots of different projects.
 >
 > We will be writing a set of docs, posts, tutorials, and talks to explain what p2p is, why it is tremendously useful, and how it can help your existing and new projects. But in the meantime, check out
 >
-> - [**The IPFS Network Spec**](https://github.com/ipfs/specs/tree/master/libp2p), which grew into libp2p
+> - [**The IPFS Network Spec**](https://github.com/libp2p/specs), which grew into libp2p
 > - [**go-libp2p implementation**](https://github.com/ipfs/go-libp2p)
 > - [**js-libp2p implementation**](https://github.com/diasdavid/js-libp2p)
 
@@ -55,7 +55,7 @@ $ go test ./p2p/<path of module you want to run tests for>
 
 
 ## Links
-- [**Specs**](https://github.com/ipfs/specs/tree/master/libp2p)
+- [**Specs**](https://github.com/libp2p/specs)
 - [**Website**](https://github.com/diasdavid/libp2p-website)
 
 


### PR DESCRIPTION
Addresses https://github.com/libp2p/go-libp2p/issues/41