### PR TITLE
don't block on DiscoverHandler

### DIFF
--- a/p2p/discovery/mdns_test.go
+++ b/p2p/discovery/mdns_test.go
@@ -1,0 +1,51 @@
+package discovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	host "github.com/libp2p/go-libp2p/p2p/host"
+	netutil "github.com/libp2p/go-libp2p/p2p/test/util"
+
+	pstore "github.com/ipfs/go-libp2p-peerstore"
+)
+
+type DiscoveryNotifee struct {
+	h host.Host
+}
+
+func (n *DiscoveryNotifee) HandlePeerFound(pi pstore.PeerInfo) {
+	n.h.Connect(context.Background(), pi)
+}
+
+func TestMdnsDiscovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := netutil.GenHostSwarm(t, ctx)
+	b := netutil.GenHostSwarm(t, ctx)
+
+	sa, err := NewMdnsService(ctx, a, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sb, err := NewMdnsService(ctx, b, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = sb
+
+	n := &DiscoveryNotifee{a}
+
+	sa.RegisterNotifee(n)
+
+	time.Sleep(time.Second * 2)
+
+	err = a.Connect(ctx, pstore.PeerInfo{ID: b.ID()})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The current code runs the `Connect` calls for each peer discovered over mdns in the same goroutine. If a connect call starts to hang, then it gums up the entire mdns discovery process.