### PR TITLE
Update go-reuseport

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,9 +190,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXHZVjWjAgLXTBrH9LZ3u1VRiQBsmaPnd8ZWJG8jTTQNC",
+      "hash": "QmXFU6HbpMaxJ3wtw96aSSqBcdJJqtuE2ipMopmh1T3be8",
       "name": "go-tcp-transport",
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ],
   "gxVersion": "0.4.0",
@@ -202,3 +202,4 @@
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "version": "3.5.4"
 }
+


### PR DESCRIPTION
for more info: https://github.com/libp2p/go-tcp-transport/pull/2