### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ libp2p is the product of a long, and arduous quest of understanding -- a deep di
 > We will be writing a set of docs, posts, tutorials, and talks to explain what p2p is, why it is tremendously useful, and how it can help your existing and new projects. But in the meantime, check out
 >
 > - [**The IPFS Network Spec**](https://github.com/libp2p/specs), which grew into libp2p
-> - [**go-libp2p implementation**](https://github.com/ipfs/go-libp2p)
-> - [**js-libp2p implementation**](https://github.com/diasdavid/js-libp2p)
+> - [**go-libp2p implementation**](https://github.com/libp2p/go-libp2p)
+> - [**js-libp2p implementation**](https://github.com/libp2p/js-libp2p)
 
 # Contribute
 
@@ -56,7 +56,7 @@ $ go test ./p2p/<path of module you want to run tests for>
 
 ## Links
 - [**Specs**](https://github.com/libp2p/specs)
-- [**Website**](https://github.com/diasdavid/libp2p-website)
+- [**Website**](https://github.com/libp2p/website)
 
 
 ## Extracting packages from go-libp2p


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/diasdavid/js-libp2p | https://github.com/libp2p/js-libp2p 
https://github.com/diasdavid/libp2p-website | https://github.com/libp2p/website 
https://github.com/ipfs/go-libp2p | https://github.com/libp2p/go-libp2p 
