### PR TITLE
Readme.md: point to the right location for examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ make
 
 # Examples
 
-Examples can be found on the [libp2p-examples repo](https://github.com/whyrusleeping/libp2p-examples/)
+Examples can be found on the [examples folder](examples).
 
 # Run tests
 


### PR DESCRIPTION
The linked repo seems to have been left behind vs the examples folder which contains working examples.