### PR TITLE
add negotiate timeout option to basichost

### DIFF
--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -85,6 +85,7 @@ func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps pstore.Peerstore) (host.Ho
 	}
 
 	h := bhost.New(n)
+	h.NegotiateTimeout = 0
 
 	mn.proc.AddChild(n.proc)
 


### PR DESCRIPTION
We get a fair number of goroutines hanging in negotiate here. This should at least help prevent the buildup.