### PR TITLE
if protocol selection fails, reset remembered protocols

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -2,6 +2,7 @@ package basichost
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -219,7 +220,17 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 	}
 
 	if pref != "" {
-		return h.newStream(ctx, p, pref)
+		s, err := h.newStream(ctx, p, pref)
+		if err != msmux.ErrNotSupported {
+			return s, err
+		}
+
+		log.Warning("protocol preference selection failed: %s [%s] %s", p, pids, pref)
+
+		// protocol selection failed, clear ALL remembered protocols for them
+		if err := h.Peerstore().SetProtocols(p); err != nil {
+			return nil, fmt.Errorf("clearing peerstore protocols: %s", err)
+		}
 	}
 
 	var protoStrs []string


### PR DESCRIPTION
I beleive this happens if a node downgrades to an older version, and then restarts and reconnects quickly, and then bitswap tries to open a new stream on a misremembered protocol before the identify handshake can complete.

This wouldnt be a problem if identify was inline...

I'll see about adding a test soon, but if anyone has good ideas on how to easily test this first let me know.