### PR TITLE
identify: make agent version mutable

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -30,7 +30,8 @@ const ID = "/ipfs/id/1.0.0"
 // LibP2PVersion holds the current protocol version for a client running this code
 // TODO(jbenet): fix the versioning mess.
 const LibP2PVersion = "ipfs/0.1.0"
-const ClientVersion = "go-libp2p/3.3.4"
+
+var ClientVersion = "go-libp2p/3.3.4"
 
 // IDService is a structure that implements ProtocolIdentify.
 // It is a trivial service that gives the other peer some


### PR DESCRIPTION
We're starting to have non-standard libp2p nodes in the network, this should help differentiate things for easier testing.