### PR TITLE
gx: update go-libp2p-peerstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,9 +139,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmNUVzEjq3XWJ89hegahPvyfJbTXgTaom48pLb7YBD9gHQ",
+      "hash": "QmXZSd1qR5BxZkPyuwfT5jpqQFScZccoZvDneXsKzCNHWX",
       "name": "go-libp2p-peerstore",
-      "version": "1.4.6"
+      "version": "1.4.8"
     },
     {
       "author": "whyrusleeping",
@@ -193,15 +193,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVHSBsn8LEeay8m5ERebgUVuhzw838PsyTttCmP6GMJkg",
+      "hash": "QmRscs8KxrSmSv4iuevHv8JfuUzHBMoqiaHzxfDRiksd6e",
       "name": "go-libp2p-net",
-      "version": "1.6.9"
+      "version": "1.6.11"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVMbSdq6PbznPC83SENVhH7JZn3BqqxkKgrHJFN2RuARf",
+      "hash": "QmdibiN2wzuuXXz4JvqQ1ZGW3eUkoAy1AWznHFau6iePCc",
       "name": "go-libp2p-metrics",
-      "version": "1.6.7"
+      "version": "1.6.9"
     },
     {
       "author": "whyrusleeping",
@@ -211,15 +211,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcyNeWPsoFGxThGpV8JnJdfUNankKhWCTrbrcFRQda4xR",
+      "hash": "QmUywuGNZoUKV8B9iyvup9bPkLiMrhTsyVMkeSXW5VxAfC",
       "name": "go-libp2p-host",
-      "version": "1.3.13"
+      "version": "1.3.14"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmeo7oJxR65PLPx68KPFi8rjzcEmmWN2dL66fPuq9nVMv8",
+      "hash": "QmVkDnNm71vYyY6s6rXwtmyDYis3WkKyrEhMECwT6R12uJ",
       "name": "go-libp2p-swarm",
-      "version": "1.6.14"
+      "version": "1.6.15"
     },
     {
       "author": "whyrusleeping",
@@ -229,15 +229,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcCgouQ5iXfmxmVNc1fpXLacRSPMNHx4tzqDpou6XNvvd",
+      "hash": "Qma2j8dYePrvN5DoNgwh1uAuu3FFtEtrUQFmr737ws8nCp",
       "name": "go-libp2p-netutil",
-      "version": "0.2.14"
+      "version": "0.2.15"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSwzyZ4zfHD9j4JZdXuzbWH4gXuDfZ7CdfMzpfqrMVcrz",
+      "hash": "Qma4Xhhqtr9tpV814eNjbLHzjuDaRjs96XLcZPJiR742ZV",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.12"
+      "version": "0.1.13"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-net/pull/7
- https://github.com/libp2p/go-libp2p-metrics/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/3
- https://github.com/libp2p/go-libp2p-swarm/pull/22
- https://github.com/libp2p/go-libp2p-netutil/pull/4
- https://github.com/libp2p/go-libp2p-blankhost/pull/1