### PR TITLE
basichost: refactor BasicHost construction

### DIFF
--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -84,8 +84,10 @@ func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps pstore.Peerstore) (host.Ho
 		return nil, err
 	}
 
-	h := bhost.New(n)
-	h.NegotiateTimeout = 0
+	opts := &bhost.HostOpts{
+		NegotiationTimeout: -1,
+	}
+	h := bhost.NewHost(n, opts)
 
 	mn.proc.AddChild(n.proc)
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -55,6 +55,8 @@ type IDService struct {
 	observedAddrs ObservedAddrSet
 }
 
+// NewIDService constructs a new *IDService and activates it by
+// attaching its stream handler to the given host.Host.
 func NewIDService(h host.Host) *IDService {
 	s := &IDService{
 		Host:   h,


### PR DESCRIPTION
- I'd like to do a similar thing with Swarm
- The first commit (allow overriding Addrs) is from an unrelated PR (#196)

---

There were previously 4 different ways of passing various options
into BasicHost construction.

1. Function parameters to New
2. Option parameters to New
3. Global variables, e.g. NegotiateTimeout
4. Options struct, in the calling code in go-ipfs

This changeset deprecates all of these, and introduces the HostOpts
struct to replace them. It also introduces a new constructor called
NewHost, which accepts a *HostOpts.

The old New constructor continues to work the same way,
but is from now on deprecated too.