### PR TITLE
gx: update go-addr-util, go-libp2p-swarm

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,9 +169,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbH3urJHTrZSUETgvQRriWM6mMFqyNSwCqnhknxfSGVWv",
+      "hash": "QmZdjsvjKB6vjkWnaN7MXk33kkZEaGUvEkEQ8nPdSaqrvG",
       "name": "go-addr-util",
-      "version": "1.1.5"
+      "version": "1.1.6"
     },
     {
       "author": "whyrusleeping",
@@ -181,9 +181,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSqJFpQ1VQtuhkntP9tMhTexipzpXAHtgSi4UYWFwjUZx",
+      "hash": "QmYNUuivS62tkjy3Uw5VF5GeVCcKV43DQtGHGtHZgGYJou",
       "name": "go-libp2p-conn",
-      "version": "1.6.2"
+      "version": "1.6.3"
     },
     {
       "author": "whyrusleeping",
@@ -211,9 +211,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVkDnNm71vYyY6s6rXwtmyDYis3WkKyrEhMECwT6R12uJ",
+      "hash": "QmbLpTGb9Y6Yh3KondeFx1RibwUmKomwNVX38HigZfbiZz",
       "name": "go-libp2p-swarm",
-      "version": "1.6.15"
+      "version": "1.6.17"
     },
     {
       "author": "whyrusleeping",
@@ -223,9 +223,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qma2j8dYePrvN5DoNgwh1uAuu3FFtEtrUQFmr737ws8nCp",
+      "hash": "QmbED8x6RYDbHRsGfBjPxG3Lw15GjKCPLgoyokhpk9xNgW",
       "name": "go-libp2p-netutil",
-      "version": "0.2.15"
+      "version": "0.2.16"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/10
- https://github.com/libp2p/go-libp2p-swarm/pull/24
- https://github.com/libp2p/go-libp2p-netutil/pull/5


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace