### PR TITLE
Circuit Relay integration with basic_host

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -107,7 +107,7 @@ type HostOpts struct {
 }
 
 // NewHost constructs a new *BasicHost and activates it by attaching its stream and connection handlers to the given inet.Network.
-func NewHost(net inet.Network, opts *HostOpts) (*BasicHost, error) {
+func NewHost(ctx context.Context, net inet.Network, opts *HostOpts) (*BasicHost, error) {
 	h := &BasicHost{
 		network:    net,
 		mux:        msmux.NewMultistreamMuxer(),
@@ -167,7 +167,7 @@ func NewHost(net inet.Network, opts *HostOpts) (*BasicHost, error) {
 	net.SetStreamHandler(h.newStreamHandler)
 
 	if opts.EnableRelay {
-		relayCtx, relayCancel = context.WithCancel(context.Background())
+		relayCtx, relayCancel = context.WithCancel(ctx)
 		err := circuit.AddRelayTransport(relayCtx, h, opts.RelayOpts...)
 		if err != nil {
 			h.Close()
@@ -200,7 +200,7 @@ func New(net inet.Network, opts ...interface{}) *BasicHost {
 		}
 	}
 
-	h, err := NewHost(net, hostopts)
+	h, err := NewHost(context.Background(), net, hostopts)
 	if err != nil {
 		// this cannot happen with legacy options
 		// plus we want to keep the (deprecated) legacy interface unchanged

--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -88,7 +88,7 @@ func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps pstore.Peerstore) (host.Ho
 		NegotiationTimeout: -1,
 	}
 
-	h, err := bhost.NewHost(n, opts)
+	h, err := bhost.NewHost(mn.ctx, n, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -87,7 +87,11 @@ func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps pstore.Peerstore) (host.Ho
 	opts := &bhost.HostOpts{
 		NegotiationTimeout: -1,
 	}
-	h := bhost.NewHost(n, opts)
+
+	h, err := bhost.NewHost(n, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	mn.proc.AddChild(n.proc)
 

--- a/package.json
+++ b/package.json
@@ -271,9 +271,9 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmP8i7FhM3jjciE34U9MZTnyD21BpxTinTzTcmVkvfM6tv",
+      "hash": "QmVEPsD9h95ToAC7NJpYopFcXyjVJm35xV4tw43J5JdCnL",
       "name": "go-libp2p-circuit",
-      "version": "1.0.0"
+      "version": "1.1.1"
     }
   ],
   "gxVersion": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -268,6 +268,12 @@
       "hash": "QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB",
       "name": "go-libp2p-peer",
       "version": "2.2.0"
+    },
+    {
+      "author": "vyzo",
+      "hash": "QmP8i7FhM3jjciE34U9MZTnyD21BpxTinTzTcmVkvfM6tv",
+      "name": "go-libp2p-circuit",
+      "version": "1.0.0"
     }
   ],
   "gxVersion": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -271,9 +271,9 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmVEPsD9h95ToAC7NJpYopFcXyjVJm35xV4tw43J5JdCnL",
+      "hash": "QmYv8PxtikjeL6AfsheUiJfoFRzKvx8hdwRf4odBWH7mQx",
       "name": "go-libp2p-circuit",
-      "version": "1.1.1"
+      "version": "1.1.3"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
Integrates Circuit Relay as a transport option in basic_host.NewHost.
See #209 