### PR TITLE
gx: update go-testutil

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,15 +175,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ",
+      "hash": "QmZJD56ZWLViJAVkvLc7xbbDerHzUMLr2X4fLRYfbxZWDN",
       "name": "go-testutil",
-      "version": "1.1.9"
+      "version": "1.1.10"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qme3UxGLY8Q5hbw53nbXYe7E1CoqvHQNVRCR4MYEBjwGWd",
+      "hash": "QmQCeEJu7KJm2v29cQi1yg7Xa5tXGCzeenvKNyD9bZb5Mo",
       "name": "go-libp2p-conn",
-      "version": "1.6.7"
+      "version": "1.6.8"
     },
     {
       "author": "whyrusleeping",
@@ -205,15 +205,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmeqtv7ASvepCpUDxysK2oP1urtEr5eMNMxbhTJYJziAGo",
+      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
       "name": "go-libp2p-host",
-      "version": "1.3.17"
+      "version": "1.3.18"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW8QNRUf1nqeRxZdhGg5DVcxHMwxuuNt7AWfmDi2a8JE2",
+      "hash": "QmfGXKgqQmaPHDHPSG3Y9vCVtFZtFeRZJW7N1anXB5biRu",
       "name": "go-libp2p-swarm",
-      "version": "1.7.2"
+      "version": "1.7.3"
     },
     {
       "author": "whyrusleeping",
@@ -223,15 +223,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmPVjuusqQxSZrE3e35qvnge8n7Hs7NnfkHyFdkaBkWQdB",
+      "hash": "QmZG4W8GR9FpC4z69Vab9ENtEoxKjDnTym5oa7Q3Yr7P4o",
       "name": "go-libp2p-netutil",
-      "version": "0.2.20"
+      "version": "0.2.21"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmRCK8YSxVuHayP3s9bpLRB5Ty7tsjAfgf16aJCNSuV7kS",
+      "hash": "QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     {
       "author": "whyrusleeping",
@@ -259,9 +259,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZg566m6GTANKnweD63nLao2J5qgFVSKscHqrNyVUzwDA",
+      "hash": "QmdjeSxRchVsQ2ftrZyvVmFqoJ1QbJZ2PgugBsZ58TZZqQ",
       "name": "go-libp2p-connmgr",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "author": "whyrusleeping",
@@ -271,9 +271,9 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmYv8PxtikjeL6AfsheUiJfoFRzKvx8hdwRf4odBWH7mQx",
+      "hash": "QmbVTkb8ihJNudRL4Vf9wjxMAapWxYdehrS7XBij31AGKM",
       "name": "go-libp2p-circuit",
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     {
       "author": "lgierth",


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/12
- https://github.com/libp2p/go-libp2p-connmgr/pull/3
- https://github.com/libp2p/go-libp2p-host/pull/6
- https://github.com/libp2p/go-libp2p-swarm/pull/28
- https://github.com/libp2p/go-libp2p-netutil/pull/8
- https://github.com/libp2p/go-libp2p-blankhost/pull/3
- https://github.com/libp2p/go-libp2p-circuit/pull/10


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace