### PR TITLE
gx: update go-cid, go-multibase, base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-4.5.2: QmZyngpQxUGyx1T2bzEcst6YzERkvVwDzBMbsSQF4f1smE
+4.5.3: QmbRT4BwPQEx4CPCd8LKYL46tFWYneGswQnHFdsuiczJRL

--- a/package.json
+++ b/package.json
@@ -175,15 +175,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZJD56ZWLViJAVkvLc7xbbDerHzUMLr2X4fLRYfbxZWDN",
+      "hash": "QmWRCn8vruNAzHx8i6SAXinuheRitKEGu8c7m26stKvsYx",
       "name": "go-testutil",
-      "version": "1.1.10"
+      "version": "1.1.11"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcYU4bjgs7dACwDWzfeYKgqkgbd5mKk2ZUCepYXhbtRSB",
+      "hash": "Qme5sn4UKuxq2aJhTgLec2EZHBzMkEAMaGZJU1SgwZD2cq",
       "name": "go-libp2p-conn",
-      "version": "1.6.9"
+      "version": "1.6.10"
     },
     {
       "author": "whyrusleeping",
@@ -205,15 +205,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
+      "hash": "QmUwW8jMQDxXhLD2j4EfWqLEMX3MsvyWcWGvJPVDh1aTmu",
       "name": "go-libp2p-host",
-      "version": "1.3.18"
+      "version": "1.3.19"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVJefKHXEx28RFpmj5GeRg43AqeBH3npPwvgJ875fBPm7",
+      "hash": "QmQ8c9nscf6kxoxCoXGxuXWB4ruQ1ttfRG5gKcQbNgJvGr",
       "name": "go-libp2p-swarm",
-      "version": "1.7.4"
+      "version": "1.7.5"
     },
     {
       "author": "whyrusleeping",
@@ -223,15 +223,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYdcTdkuCvFXLj2uejJF5aY3HWhtd8JLT4BjPxF9BNPYf",
+      "hash": "QmYTeBaLWbFKQAtVTHbxvTbKfgqrGJUupK4UwjeugownfD",
       "name": "go-libp2p-netutil",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu",
+      "hash": "QmSmgF5Nnmf1Ygkv96xCmUdPk4QPx3JotTA7sqwXpoxCV2",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     {
       "author": "whyrusleeping",
@@ -259,9 +259,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdjeSxRchVsQ2ftrZyvVmFqoJ1QbJZ2PgugBsZ58TZZqQ",
+      "hash": "QmTuwwqGf4NH2Jj3opKtaKx45ge4RiXSCtvUkb7a4gk2ua",
       "name": "go-libp2p-connmgr",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "author": "whyrusleeping",
@@ -271,9 +271,9 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmYBGpZ3hV89RZTd3CTjjgjgcX64QnbcBS9dCqU7mCgS1n",
+      "hash": "QmY8a2Zohd4Jxgj5BEfcWQtR1Q3jUsvkgMLc5sBn8nqpWS",
       "name": "go-libp2p-circuit",
-      "version": "1.1.5"
+      "version": "1.1.6"
     },
     {
       "author": "lgierth",
@@ -287,6 +287,6 @@
   "license": "MIT",
   "name": "go-libp2p",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "4.5.2"
+  "version": "4.5.3"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-testutil/pull/12
- https://github.com/libp2p/go-libp2p-conn/pull/15
- https://github.com/libp2p/go-libp2p-connmgr/pull/5
- https://github.com/libp2p/go-libp2p-host/pull/8
- https://github.com/libp2p/go-libp2p-swarm/pull/32
- https://github.com/libp2p/go-libp2p-netutil/pull/11
- https://github.com/libp2p/go-libp2p-blankhost/pull/5
- https://github.com/libp2p/go-libp2p-circuit/pull/14


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace