### PR TITLE
Fix the go get command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ There is currently only one bundle of `go-libp2p`, this package. This bundle is 
 ### Install
 
 ```bash
-> go get -d github.com/libp2p/go-libp2p
+> go get -d github.com/libp2p/go-libp2p/...
 > cd $GOPATH/src/github.com/libp2p/go-libp2p
 > make
 > make deps


### PR DESCRIPTION
We need to download dependencies for all packages in the repo, not just the
root (there are no packages at the root).

fixes #219