### PR TITLE
Protocol Multiplexing Example: Fixing build instruction so copy and pasting from the Readme works

### DIFF
--- a/examples/protocol-multiplexing-with-multicodecs/README.md
+++ b/examples/protocol-multiplexing-with-multicodecs/README.md
@@ -12,7 +12,7 @@ From `go-libp2p` base folder:
 
 ```
 > make deps-protocol-muxing
-> go build ./examples/protocol-multiplexing-with-multicodecs
+> go build -o multicodecs ./examples/protocol-multiplexing-with-multicodecs
 ```
 
 ## Usage


### PR DESCRIPTION
As is go build ./examples/protocol-multiplexing-with-multicodecs
will make the binary name protocol-multiplexing-with-multicodecs
so the next command ./multicodecs won't run
using -o will name the outputfile 