### PR TITLE
update go-stream-muxer

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-4.5.5: QmXZyBQMkqSYigxhJResC6fLWDGFhbphK67eZoqMDUvBmK
+5.0.0: QmTykKqiBX2QyDjrJDKX6qzwU2ybMtWqaLET23mgyDSojx

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -134,8 +134,12 @@ func main() {
 	// a user-defined protocol name.
 	ha.SetStreamHandler("/echo/1.0.0", func(s net.Stream) {
 		log.Println("Got a new stream!")
-		defer s.Close()
-		doEcho(s)
+		if err := doEcho(s); err != nil {
+			log.Println(err)
+			s.Reset()
+		} else {
+			s.Close()
+		}
 	})
 
 	if *target == "" {
@@ -194,18 +198,14 @@ func main() {
 }
 
 // doEcho reads a line of data a stream and writes it back
-func doEcho(s net.Stream) {
+func doEcho(s net.Stream) error {
 	buf := bufio.NewReader(s)
 	str, err := buf.ReadString('\n')
 	if err != nil {
-		log.Println(err)
-		return
+		return err
 	}
 
 	log.Printf("read: %s\n", str)
 	_, err = s.Write([]byte(str))
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	return err
 }

--- a/examples/http-proxy/proxy.go
+++ b/examples/http-proxy/proxy.go
@@ -109,6 +109,7 @@ func streamHandler(stream inet.Stream) {
 	// Read the HTTP request from the buffer
 	req, err := http.ReadRequest(buf)
 	if err != nil {
+		stream.Reset()
 		log.Println(err)
 		return
 	}
@@ -132,6 +133,7 @@ func streamHandler(stream inet.Stream) {
 	fmt.Printf("Making request to %s\n", req.URL)
 	resp, err := http.DefaultTransport.RoundTrip(outreq)
 	if err != nil {
+		stream.Reset()
 		log.Println(err)
 		return
 	}
@@ -176,6 +178,7 @@ func (p *ProxyService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// r.Write() writes the HTTP request to the stream.
 	err = r.Write(stream)
 	if err != nil {
+		stream.Reset()
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
@@ -186,6 +189,7 @@ func (p *ProxyService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	buf := bufio.NewReader(stream)
 	resp, err := http.ReadResponse(buf, r)
 	if err != nil {
+		stream.Reset()
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -240,7 +240,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 	if h.negtimeout > 0 {
 		if err := s.SetDeadline(time.Now().Add(h.negtimeout)); err != nil {
 			log.Error("setting stream deadline: ", err)
-			s.Close()
+			s.Reset()
 			return
 		}
 	}
@@ -257,7 +257,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 		} else {
 			log.Warning("protocol mux failed: %s (took %s)", err, took)
 		}
-		s.Close()
+		s.Reset()
 		return
 	}
 
@@ -269,7 +269,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 	if h.negtimeout > 0 {
 		if err := s.SetDeadline(time.Time{}); err != nil {
 			log.Error("resetting stream deadline: ", err)
-			s.Close()
+			s.Reset()
 			return
 		}
 	}
@@ -364,7 +364,7 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 
 	selected, err := msmux.SelectOneOf(protoStrs, s)
 	if err != nil {
-		s.Close()
+		s.Reset()
 		return nil, err
 	}
 	selpid := protocol.ID(selected)

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -180,7 +180,7 @@ func TestHostProtoMismatch(t *testing.T) {
 
 	h1.SetStreamHandler("/super", func(s inet.Stream) {
 		t.Error("shouldnt get here")
-		s.Close()
+		s.Reset()
 	})
 
 	_, err := h2.NewStream(ctx, h1.ID(), "/foo", "/bar", "/baz/1.0.0")

--- a/p2p/net/mock/mock_conn.go
+++ b/p2p/net/mock/mock_conn.go
@@ -2,12 +2,7 @@ package mocknet
 
 import (
 	"container/list"
-	"fmt"
-	"os"
-	"os/signal"
-	"runtime"
 	"sync"
-	"syscall"
 
 	process "github.com/jbenet/goprocess"
 	ic "github.com/libp2p/go-libp2p-crypto"
@@ -15,19 +10,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
-
-func init() {
-	go func() {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGQUIT)
-		buf := make([]byte, 1<<20)
-		for {
-			<-sigs
-			stacklen := runtime.Stack(buf, true)
-			fmt.Printf("=== received SIGQUIT ===\n*** goroutine dump...\n%s\n*** end\n", buf[:stacklen])
-		}
-	}()
-}
 
 // conn represents one side's perspective of a
 // live connection between two peers.

--- a/p2p/net/mock/mock_conn.go
+++ b/p2p/net/mock/mock_conn.go
@@ -2,7 +2,12 @@ package mocknet
 
 import (
 	"container/list"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
 	"sync"
+	"syscall"
 
 	process "github.com/jbenet/goprocess"
 	ic "github.com/libp2p/go-libp2p-crypto"
@@ -10,6 +15,19 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
+
+func init() {
+	go func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGQUIT)
+		buf := make([]byte, 1<<20)
+		for {
+			<-sigs
+			stacklen := runtime.Stack(buf, true)
+			fmt.Printf("=== received SIGQUIT ===\n*** goroutine dump...\n%s\n*** end\n", buf[:stacklen])
+		}
+	}()
+}
 
 // conn represents one side's perspective of a
 // live connection between two peers.
@@ -54,7 +72,7 @@ func (c *conn) Close() error {
 
 func (c *conn) teardown() error {
 	for _, s := range c.allStreams() {
-		s.Close()
+		s.Reset()
 	}
 	c.net.removeConn(c)
 	c.net.notifyAll(func(n inet.Notifiee) {

--- a/p2p/net/mock/mock_link.go
+++ b/p2p/net/mock/mock_link.go
@@ -2,7 +2,7 @@ package mocknet
 
 import (
 	//	"fmt"
-	"net"
+	"io"
 	"sync"
 	"time"
 
@@ -45,11 +45,12 @@ func (l *link) newConnPair(dialer *peernet) (*conn, *conn) {
 }
 
 func (l *link) newStreamPair() (*stream, *stream) {
-	a, b := net.Pipe()
+	ra, wb := io.Pipe()
+	rb, wa := io.Pipe()
 
-	s1 := NewStream(a)
-	s2 := NewStream(b)
-	return s1, s2
+	sa := NewStream(wa, ra)
+	sb := NewStream(wb, rb)
+	return sa, sb
 }
 
 func (l *link) Networks() []inet.Network {

--- a/p2p/test/reconnects/reconnect_test.go
+++ b/p2p/test/reconnects/reconnect_test.go
@@ -31,8 +31,12 @@ func EchoStreamHandler(stream inet.Stream) {
 	c := stream.Conn()
 	log.Debugf("%s echoing %s", c.LocalPeer(), c.RemotePeer())
 	go func() {
-		defer stream.Close()
-		io.Copy(stream, stream)
+		_, err := io.Copy(stream, stream)
+		if err == nil {
+			stream.Close()
+		} else {
+			stream.Reset()
+		}
 	}()
 }
 

--- a/package.json
+++ b/package.json
@@ -109,9 +109,9 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmVNPgPmEG4QKaDKkxMPKY34Z53n8efzv1sEh4NTsdhto7",
+      "hash": "QmTMNkpso2WRMevXC8ZxgyBhJvoEHvk24SNeUr9Mf9UM1a",
       "name": "go-peerstream",
-      "version": "1.7.0"
+      "version": "2.0.2"
     },
     {
       "author": "whyrusleeping",
@@ -151,9 +151,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdQcv14hCd41WEzNA4avJohJR5sdPqVgFtXZtDz6MTCKx",
+      "hash": "QmbrUTiVDSK3WGePN18qVjpGYmvXQt6YVPyyGoXWx593uq",
       "name": "go-tcp-transport",
-      "version": "1.2.2"
+      "version": "1.2.3"
     },
     {
       "author": "whyrusleeping",
@@ -181,21 +181,21 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmX49btJy5UQuHYmWxrNTmpcnUE5a4upGS6xPYH7mPE46D",
+      "hash": "QmTi4629yyHJ8qW9sXFjvxJpYcN499tHhERLZYdUqwRU9i",
       "name": "go-libp2p-conn",
-      "version": "1.6.12"
+      "version": "1.6.13"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmahYsGWry85Y7WUe2SX5G4JkH2zifEQAUtJVLZ24aC9DF",
+      "hash": "QmNa31VPzC561NWwRsJLE7nGYZYuuD2QfpK2b1q9BK54J1",
       "name": "go-libp2p-net",
-      "version": "1.6.12"
+      "version": "2.0.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVjRAPfRtResCMCE4eBqr4Beoa6A89P1YweG9wUS6RqUL",
+      "hash": "QmQbh3Rb7KM37As3vkHYnEFnzkVXNCP8EYGtHz6g2fXk14",
       "name": "go-libp2p-metrics",
-      "version": "1.6.10"
+      "version": "2.0.0"
     },
     {
       "author": "whyrusleeping",
@@ -205,15 +205,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmUwW8jMQDxXhLD2j4EfWqLEMX3MsvyWcWGvJPVDh1aTmu",
+      "hash": "QmaSxYRuMq4pkpBBG2CYaRrPx2z7NmMVEs34b9g61biQA6",
       "name": "go-libp2p-host",
-      "version": "1.3.19"
+      "version": "2.0.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmQUmDr1DMDDy6KMSsJuyV9nVD7dJZ9iWxXESQWPvte2NP",
+      "hash": "QmW97nvnsknsoN8NUz8CUF5hVVaicLgNaEb6EZMk3oB943",
       "name": "go-libp2p-swarm",
-      "version": "1.7.7"
+      "version": "2.0.2"
     },
     {
       "author": "whyrusleeping",
@@ -223,15 +223,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmQ1bJEsmdEiGfTQRoj6CsshWmAKduAEDEbwzbvk5QT5Ui",
+      "hash": "QmP4cEjmvf8tC6ykxKXrvmYLo8vqtGsgduMatjbAKnBzv8",
       "name": "go-libp2p-netutil",
-      "version": "0.2.25"
+      "version": "0.3.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSmgF5Nnmf1Ygkv96xCmUdPk4QPx3JotTA7sqwXpoxCV2",
+      "hash": "QmPZRCaYeNLMo5GfcRS2rv9ZxVuXXt6MFg9dWLmgsdXKCw",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.18"
+      "version": "0.2.0"
     },
     {
       "author": "whyrusleeping",
@@ -241,9 +241,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmbn7RYyWzBVXiUp9jZ1dA4VADHy9DtS7iZLwfhEUQvm3U",
+      "hash": "QmfTJ3UpS5ycNX7uQvPUSSRjGxk9EhUG7SyCstX6tCoNXS",
       "name": "go-smux-yamux",
-      "version": "1.2.0"
+      "version": "2.0.0"
     },
     {
       "author": "whyrusleeping",
@@ -253,15 +253,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmRVYfZ7tWNHPBzWiG6KWGzvT2hcGems8srihsQE29x1U5",
+      "hash": "QmVniQJkdzLZaZwzwMdd3dJTvWiJ1DQEkreVy6hs6h7Vk5",
       "name": "go-smux-multistream",
-      "version": "1.5.5"
+      "version": "2.0.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTuwwqGf4NH2Jj3opKtaKx45ge4RiXSCtvUkb7a4gk2ua",
+      "hash": "QmYUpfXEBqLdtiSUDzzc8hLfcELPHiPtANF12EpEX1WCVB",
       "name": "go-libp2p-connmgr",
-      "version": "0.1.3"
+      "version": "0.2.0"
     },
     {
       "author": "whyrusleeping",
@@ -271,9 +271,9 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmYkTCcfrPdR5QMasnhh3FVRVNEKzH3YsvuBPpB4YPgwWC",
+      "hash": "QmVXc7cgEkxWDELn9sGV9r1HbqfQR9YCUmbsrkp1rcXSjn",
       "name": "go-libp2p-circuit",
-      "version": "1.1.8"
+      "version": "2.0.1"
     },
     {
       "author": "lgierth",

--- a/package.json
+++ b/package.json
@@ -287,6 +287,6 @@
   "license": "MIT",
   "name": "go-libp2p",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "4.5.5"
+  "version": "5.0.0"
 }
 


### PR DESCRIPTION
* Fix the tests to work with separate reset/close methods.
* Fix the examples.
* Ensure we interrupt writes on reset.
* Always delay the proper time even if we're sending short messages.
* Copy buffers as we send them. `Write` is not allowed to hang onto buffers. If
  we run into performance issues, we can always add a buffer pool.