### PR TITLE
basic_host: fix warning message

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -255,7 +255,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 			}
 			logf("protocol EOF: %s (took %s)", s.Conn().RemotePeer(), took)
 		} else {
-			log.Warning("protocol mux failed: %s (took %s)", err, took)
+			log.Warningf("protocol mux failed: %s (took %s)", err, took)
 		}
 		s.Close()
 		return


### PR DESCRIPTION
The warning message is malformed; clear intention was to use `log.Warningf`:
```
12:07:34.885 WARNI  basichost: protocol mux failed: %s (took %s)connection reset 70.660962ms basic_host.go:258
```
