### PR TITLE
allow tag to be passed into NewMdnsService

### DIFF
--- a/p2p/discovery/mdns_test.go
+++ b/p2p/discovery/mdns_test.go
@@ -28,12 +28,12 @@ func TestMdnsDiscovery(t *testing.T) {
 	a := bhost.New(netutil.GenSwarmNetwork(t, ctx))
 	b := bhost.New(netutil.GenSwarmNetwork(t, ctx))
 
-	sa, err := NewMdnsService(ctx, a, time.Second)
+	sa, err := NewMdnsService(ctx, a, time.Second, "someTag")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sb, err := NewMdnsService(ctx, b, time.Second)
+	sb, err := NewMdnsService(ctx, b, time.Second, "someTag")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The current implementation uses the constant ServiceTag which is set to an ipfs specific value.  As a generalized p2p library this value should be settable by the caller to NewMdnsService.