### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-5.0.7: QmTzs3Gp2rU3HuNayjBVG7qBgbaKWE8bgtwJ7faRxAe9UP
+5.0.8: Qma23bpHwQrQyvKeBemaeJh7sAoRHggPkgnge1B9489ff5

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
       "version": "0.0.3"
     },
     {
-      "hash": "QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU",
+      "hash": "QmPsAfmDBnZN3kZGSuNwvCNDZiHneERSKmRcFyG3UkvcT3",
       "name": "go-ipfs-util",
-      "version": "1.2.5"
+      "version": "1.2.6"
     },
     {
       "hash": "QmUusaX99BZoELh7dmPgirqRQ1FAmMnmnBn3oiqDFGBUSc",
@@ -54,14 +54,14 @@
       "version": "1.2.0"
     },
     {
-      "hash": "QmX3U3YXCQ6UYBxq2LVWF8dARS1hPUTEYLrSx654Qyxyw6",
+      "hash": "QmSGL5Uoa6gKHgBBwQG8u1CWKUC8ZnwaZiLgFVTFBR2bxr",
       "name": "go-multiaddr-net",
-      "version": "1.5.5"
+      "version": "1.5.6"
     },
     {
-      "hash": "QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P",
+      "hash": "QmYeKnKpubCMRiq3PGZcTREErthbb5Q9cXsCoSkD9bjEBd",
       "name": "go-multihash",
-      "version": "1.0.5"
+      "version": "1.0.6"
     },
     {
       "hash": "QmSMZwvs3n4GBikZ7hKzT17c3bk65FmyZo2JqtJ16swqCv",
@@ -84,9 +84,9 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji",
+      "hash": "QmW8s4zTsUoX1Q6CeYxVKPyqSKbF7H1YDUyTostBtZ8DaG",
       "name": "go-multiaddr",
-      "version": "1.2.4"
+      "version": "1.2.5"
     },
     {
       "hash": "QmeYJHEk8UjVVZ4XCRTZe6dFQrb8pGWD81LYCgeLp8CvMB",
@@ -109,15 +109,15 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmfT8oJ8o8AY417RNu1bUYsnDPipPHSCdVcWjYRsDNFL4M",
+      "hash": "QmRaUZYeJjrUzJr3aTHxUfFjWVzyBzhf6f1SuLTt8Q7Zui",
       "name": "go-peerstream",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZQa5J7j7kd44GGC4aKX8J9JGGzCMqwGzcEFqGV1YD57A",
+      "hash": "QmUfnfCzL17Lfft4NtZZGGU34PP72xgecFVfusYt6WNwYx",
       "name": "mafmt",
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     {
       "author": "whyrusleeping",
@@ -127,39 +127,39 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmT4PgCNdv73hnFAqzHqwW44q7M9PWpykSswHDxndquZbc",
+      "hash": "QmSvcDkiRwB8LuMhUtnvhum2C851Mproo75ZDD19jx43tD",
       "name": "go-libp2p-loggables",
-      "version": "1.1.8"
+      "version": "1.1.9"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbSkjJvDuxaZYtR46sF9ust7XY1hcg7DrA6Mxu4UiSWqs",
+      "hash": "QmcfPte5kiCnjKVYELbDdHpuzh4avabCbg2WBjzXcHGTHN",
       "name": "go-libp2p-secio",
-      "version": "1.2.2"
+      "version": "1.2.3"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr",
+      "hash": "QmYijbtjCxFEjSXaudaQAUz3LN5VKLssm8WCUsRoqzXmQR",
       "name": "go-libp2p-peerstore",
-      "version": "1.4.9"
+      "version": "1.4.10"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qme2XMfKbWzzYd92YvA1qnFMe3pGDR86j5BcFtx4PwdRvr",
+      "hash": "QmQGRkVSA5vTXt9WpJ6nBGnrvq9zRNsfjoNPq8uQrhnBoq",
       "name": "go-libp2p-transport",
-      "version": "2.2.9"
+      "version": "2.2.10"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTvzVdANd5UWYxEqV9czC9gPZX6k7BCSVYcz91Gwz6J7A",
+      "hash": "QmRi4eiWUxrJeAcRBBuUfNDCMavQKBbUxLvWEH35evf3cb",
       "name": "go-tcp-transport",
-      "version": "1.2.5"
+      "version": "1.2.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmQBB2dQLmQHJgs2gqZ3iqL2XiuCtUCvXzWt5kMXDf5Zcr",
+      "hash": "QmcrNvQBZkpbT7zLcGyjdPCiCHLVtaYeg4UVUH7XLfWJWy",
       "name": "go-maddr-filter",
-      "version": "1.1.4"
+      "version": "1.1.5"
     },
     {
       "author": "whyrusleeping",
@@ -169,69 +169,69 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcNdF325V5LjhHowoZJvby7Y3xB7kNUMPj6Ve7VPzdQ9Z",
+      "hash": "Qmcxa9y1KVC51TVicSKomsnunJGSA9UJSuBvJc28JCip4H",
       "name": "go-addr-util",
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmQgLZP9haZheimMHqqAjJh2LhRmNfEoZDfbtkpeMhi9xK",
+      "hash": "QmeDA8gNhvRTsbrjEieay5wezupJDiky8xvCzDABbsGzmp",
       "name": "go-testutil",
-      "version": "1.1.12"
+      "version": "1.1.13"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWUMfzE2RikVCwAtUCiZu7KijhnqRXKxriad9g6WaKgby",
+      "hash": "QmVR9e9iMhmrWZD4sAZ1MVbzThFYLcjgooWczZ8JgKuy65",
       "name": "go-libp2p-conn",
-      "version": "1.7.1"
+      "version": "1.7.2"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbD5yKbXahNvoMqzeuNyKQA9vAs9fUvJg2GXeWU1fVqY5",
+      "hash": "QmU4vCDZTPLDqSDKguWbHCiUe46mZUtmM2g2suBZ9NE8ko",
       "name": "go-libp2p-net",
+      "version": "2.0.3"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmaL2WYJGbWKqHoLujoi9GQ5jj4JVFrBqHUBWmEYzJPVWT",
+      "name": "go-libp2p-metrics",
       "version": "2.0.2"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbXmeK6KgUAkbyVGRxXknupmWAHnt6ryghT8BFSsEh2sB",
-      "name": "go-libp2p-metrics",
-      "version": "2.0.1"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmZD7kdgd6eiBCvNbyvsFQ11h3ainoCJpJRbecDx3CPcbZ",
+      "hash": "Qmf82zCaYV8bkztRRoGwwSHVkaYtP2UKBnhpjJz1uFGJjQ",
       "name": "go-libp2p-interface-conn",
-      "version": "0.4.9"
+      "version": "0.4.10"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmRS46AyqtpJBsf1zmQdeizSDEzo1qkWR7rdEuPFAv8237",
+      "hash": "QmP46LGWhzVZTMmt5akNNLfoV8qL4h5wTwmzQxLyDafggd",
       "name": "go-libp2p-host",
+      "version": "2.1.3"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmUhvp4VoQ9cKDVLqAxciEKdm8ymBx2Syx4C1Tv6SmSTPa",
+      "name": "go-libp2p-swarm",
       "version": "2.1.2"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmU219N3jn7QadVCeBUqGnAkwoXoUomrCwDuVQVuL7PB5W",
-      "name": "go-libp2p-swarm",
-      "version": "2.1.1"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmeXm9iwA4cURNmexpuBucDWcV38jNHdqpGcb7yoyP6e4G",
+      "hash": "QmShsDUywWAeeUZXzp5EuZg5S94hWxw5C4mwag6NDr7a7e",
       "name": "go-libp2p-nat",
-      "version": "0.0.4"
+      "version": "0.0.5"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmUUNDRYXgfqdjxTg79ogkciczU5y4WY1tKMU2vEX9CRN7",
+      "hash": "QmZTcPxK6VqrwY94JpKZPvEqAZ6tEr1rLrpcqJbbRZbg2V",
       "name": "go-libp2p-netutil",
-      "version": "0.3.5"
+      "version": "0.3.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmb37wDRoh9VZMZXmmZktN35szvj9GeBYDtA9giDmXwwd7",
+      "hash": "QmYmhgAcvmDGXct1qBvc1kz9BxQSit1XBrTeiGZp2FvRyn",
       "name": "go-libp2p-blankhost",
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     {
       "author": "whyrusleeping",
@@ -259,27 +259,27 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB",
+      "hash": "QmWNY7dV54ZDYmTA1ykVdwNCqC11mpU4zSUp6XDpLTH9eG",
       "name": "go-libp2p-peer",
-      "version": "2.2.0"
+      "version": "2.2.1"
     },
     {
       "author": "vyzo",
-      "hash": "QmUZJUk816s2aWLqWKYKAJWADdfftzUEtBA32mrz1EyjpT",
+      "hash": "QmVqNgx6RByRcnLVsr9spbo5ScomJyDZrb9Gz4XMWkYB7Z",
       "name": "go-libp2p-circuit",
-      "version": "2.0.6"
+      "version": "2.0.7"
     },
     {
       "author": "lgierth",
-      "hash": "QmS7xUmsTdVNU2t1bPV6o9aXuXfufAjNGYgh2bcN2z9DAs",
+      "hash": "QmVHpaAVserMwuVXRJ7otLMro1D8qZQ5STSFfeK5eXTGy4",
       "name": "go-multiaddr-dns",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "author": "why",
-      "hash": "QmWfkNorhirGE1Qp3VwBWcnGaj4adv4hNqCYwabMrEYc21",
+      "hash": "QmSAJm4QdTJ3EGF2cvgNcQyXTEbxqWSW1x4kCVV1aJQUQr",
       "name": "go-libp2p-interface-connmgr",
-      "version": "0.0.3"
+      "version": "0.0.4"
     }
   ],
   "gxVersion": "0.4.0",
@@ -287,6 +287,6 @@
   "license": "MIT",
   "name": "go-libp2p",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "5.0.7"
+  "version": "5.0.8"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4
- https://github.com/libp2p/go-ws-transport/pull/28
- https://github.com/libp2p/go-addr-util/pull/9
- https://github.com/ipfs/go-cid/pull/39
- https://github.com/libp2p/go-testutil/pull/15
- https://github.com/libp2p/go-libp2p-interface-conn/pull/4
- https://github.com/libp2p/go-libp2p-interface-pnet/pull/6
- https://github.com/libp2p/go-libp2p-conn/pull/21
- https://github.com/libp2p/go-libp2p-net/pull/15
- https://github.com/libp2p/go-libp2p-metrics/pull/7
- https://github.com/libp2p/go-libp2p-interface-connmgr/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/10
- https://github.com/libp2p/go-libp2p-swarm/pull/46
- https://github.com/libp2p/go-libp2p-nat/pull/4
- https://github.com/libp2p/go-libp2p-netutil/pull/16
- https://github.com/libp2p/go-libp2p-blankhost/pull/7
- https://github.com/libp2p/go-libp2p-circuit/pull/24
- https://github.com/multiformats/go-multiaddr-dns/pull/6


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace