### PR TITLE
fix peerstore apocalypse redux

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -65,6 +65,7 @@ func NewIDService(h host.Host) *IDService {
 		currid: make(map[inet.Conn]chan struct{}),
 	}
 	h.SetStreamHandler(ID, s.RequestHandler)
+	h.Network().Notify((*netNotifiee)(s))
 	return s
 }
 


### PR DESCRIPTION
This commit

1. Registers the identify service for disconnect notifications (so we don't just keep all observed addresses indefinitely).
2. Prevents us from repeatedly extending the lifetimes (on disconnect) of all observed addresses if a peer keeps on reconnecting.

It also fixes two race conditions:

1. We may end up processing a disconnect after a re-connect and may accidentally give the addresses associated with that peer a RecentlyConnectedAddrTTL instead of a ConnectedAddrTTL.
2. We may end up processing a connect after the associated disconnect storing the associated peer addresses indefinitely.