### PR TITLE
discovery: swap mdns lib for grandcat/zeroconf

### DIFF
--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -180,16 +180,20 @@ func (m *mdnsService) handleEntry(e *mdns.ServiceEntry) {
 		return
 	}
 
+	addrs := make([]net.IP, len(e.AddrIPv4)+len(e.AddrIPv6))
+	copy(addrs, e.AddrIPv4)
+	copy(addrs[len(e.AddrIPv4):], e.AddrIPv6)
+
 	var pi pstore.PeerInfo
-	for _, ipv4 := range e.AddrIPv4 {
-		log.Debugf("Handling MDNS entry: %s:%d %s", ipv4, e.Port, e.Text[0])
+	for _, ip := range addrs {
+		log.Debugf("Handling MDNS entry: %s:%d %s", ip, e.Port, e.Text[0])
 
 		maddr, err := manet.FromNetAddr(&net.TCPAddr{
-			IP:   ipv4,
+			IP:   ip,
 			Port: e.Port,
 		})
 		if err != nil {
-			log.Errorf("error creating multiaddr from mdns entry (%s:%d): %s", ipv4, e.Port, err)
+			log.Errorf("error creating multiaddr from mdns entry (%s:%d): %s", ip, e.Port, err)
 			return
 		}
 		pi.Addrs = append(pi.Addrs, maddr)

--- a/p2p/discovery/mdns_test.go
+++ b/p2p/discovery/mdns_test.go
@@ -8,9 +8,9 @@ import (
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 
 	host "github.com/libp2p/go-libp2p-host"
-	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
-
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 type DiscoveryNotifee struct {
@@ -19,6 +19,51 @@ type DiscoveryNotifee struct {
 
 func (n *DiscoveryNotifee) HandlePeerFound(pi pstore.PeerInfo) {
 	n.h.Connect(context.Background(), pi)
+}
+
+func TestGetBestPort(t *testing.T) {
+	port, err := getBestPort([]ma.Multiaddr{ma.StringCast("/ip4/1.2.3.4/tcp/2222"), ma.StringCast("/ip4/0.0.0.0/tcp/1234")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 1234 {
+		t.Errorf("expected port 1234, got port %d", port)
+	}
+
+	port, err = getBestPort([]ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/2222"), ma.StringCast("/ip4/0.0.0.0/tcp/1234")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 1234 {
+		t.Errorf("expected port 1234, got port %d", port)
+	}
+
+	port, err = getBestPort([]ma.Multiaddr{ma.StringCast("/ip4/1.2.3.4/tcp/2222"), ma.StringCast("/ip4/127.0.0.1/tcp/1234")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 2222 {
+		t.Errorf("expected port 2222, got port %d", port)
+	}
+	port, err = getBestPort([]ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/1234"), ma.StringCast("/ip4/1.2.3.4/tcp/2222")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 2222 {
+		t.Errorf("expected port 2222, got port %d", port)
+	}
+	port, err = getBestPort([]ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/1234")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 1234 {
+		t.Errorf("expected port 1234, got port %d", port)
+	}
+
+	_, err = getBestPort([]ma.Multiaddr{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
 }
 
 func TestMdnsDiscovery(t *testing.T) {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,6 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmNeRzgrSpwbMU7VKLRyfvbqf1nRrAiQ7fEXaBxWGT5Ygr",
-      "name": "mdns",
-      "version": "0.1.3"
-    },
-    {
       "hash": "QmPdKqUcHGFdeSpvjVoaTRPPstGif9GBZb5Q56RVw9o69A",
       "name": "go-ipfs-util",
       "version": "1.2.8"
@@ -249,6 +244,12 @@
       "hash": "QmSSeQqc5QeuefkaM6JFV5tSF9knLUkXKVhW1eYRiqe72W",
       "name": "uuid",
       "version": "0.1.0"
+    },
+    {
+      "author": "grandcat",
+      "hash": "QmUTmYpDk9jVk7PeBgmr3n1oGmLJ6yEuSVqyZaWUpF13f3",
+      "name": "zeroconf",
+      "version": "0.2.0"
     }
   ],
   "gxVersion": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -247,9 +247,9 @@
     },
     {
       "author": "grandcat",
-      "hash": "QmUTmYpDk9jVk7PeBgmr3n1oGmLJ6yEuSVqyZaWUpF13f3",
+      "hash": "QmWrJTtJCQ6kCCTtLBM82Cx9h52QMQ5hcbrsePFuRSHuWC",
       "name": "zeroconf",
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
Specifically addressing the request here: https://github.com/libp2p/go-libp2p/issues/257

This commit makes the minimal amount of changes to switch us from
whyrusleeping/mdns to grandcat/zeroconf. Of note, rather than asking the
`host.Host` which `addrs` we can listen on, we push this to the
zeroconf library (which runs across available ifaces).

I haven't had a chance to test this on something complicated to see if it retains the desired behavior (to be honest, still new to this codebase, unsure of what all of those would be!), but tests pass locally. 

TODO: 
 - [x] Revert PORT behavior
 - [x] ensure that grandcat/zerconf dep is in gx; tests pass