### PR TITLE
Fix contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ List of packages currently in existence for libp2p:
 
 # Contribute
 
-go-libp2p is part of [The IPFS Project](https://github.com/ipfs/ipfs), and is MIT licensed open source software. We welcome contributions big and small! Take a look at the [community contributing notes](https://github.com/ipfs/community/blob/master/contributing.md). Please make sure to check the [issues](https://github.com/ipfs/go-libp2p/issues). Search the closed ones before reporting things, and help us with the open ones.
+go-libp2p is part of [The IPFS Project](https://github.com/ipfs/ipfs), and is MIT licensed open source software. We welcome contributions big and small! Take a look at the [community contributing notes](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md). Please make sure to check the [issues](https://github.com/ipfs/go-libp2p/issues). Search the closed ones before reporting things, and help us with the open ones.
 
 Guidelines:
 


### PR DESCRIPTION
Looks like it was changed from lowercase to uppercase recently in
https://github.com/ipfs/community/commit/ff38ebf65448353587e938e61ca36829fbecc8b4