### PR TITLE
added NAT traversal option and constructor test

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -1,0 +1,34 @@
+package libp2p
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	crypto "github.com/libp2p/go-libp2p-crypto"
+	host "github.com/libp2p/go-libp2p-host"
+)
+
+func TestNewHost(t *testing.T) {
+	_, err := makeRandomHost(t, 9000)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func makeRandomHost(t *testing.T, port int) (host.Host, error) {
+	ctx := context.Background()
+	priv, _, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := []Option{
+		ListenAddrStrings(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", port)),
+		Identity(priv),
+		Muxer(DefaultMuxer()),
+		NATPortMap(),
+	}
+
+	return New(ctx, opts...)
+}


### PR DESCRIPTION
This change adds an option to enable NAT traversal by including `NATPortMap()` in the `[]Option`. I also went ahead and added a basic test for the constructor, although I noticed this package does not yet have any, and wonder if that might be intentional. I also switched to the `basichost.NewHost` constructor, since `New` is depreciated.