### PR TITLE
misc: downgrade a warning to info

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -250,7 +250,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 			}
 			logf("protocol EOF: %s (took %s)", s.Conn().RemotePeer(), took)
 		} else {
-			log.Warningf("protocol mux failed: %s (took %s)", err, took)
+			log.Infof("protocol mux failed: %s (took %s)", err, took)
 		}
 		s.Reset()
 		return


### PR DESCRIPTION
It is source of most warning noise in Warning channel and we would like
to enable warning channel some time in future by default