### PR TITLE
Updated host example README to match code

### DIFF
--- a/examples/libp2p-host/README.md
+++ b/examples/libp2p-host/README.md
@@ -4,7 +4,7 @@ For most applications, the host is the basic building block you'll need to get s
 
 The host is an abstraction that manages services on top of a swarm. It provides a clean interface to connect to a service on a given remote peer.
 
-First, you'll need an ID, and a place to store that ID. To generate an ID, you can do the following:
+First, you'll need an ID. A host's ID is the hash of its public key. To generate an ID, you can do the following:
 
 ```go
 import (
@@ -26,15 +26,50 @@ pid, err := peer.IDFromPublicKey(pub)
 if err != nil {
 	panic(err)
 }
-
-// We've created the identity, now we need to store it.
-// A peerstore holds information about peers, including your own
-ps := pstore.NewPeerstore()
-ps.AddPrivKey(pid, priv)
-ps.AddPubKey(pid, pub)
 ```
 
-Next, you'll need at least one address that you want to listen on. You can go from a string to a multiaddr like this:
+Now you know who you are. The next step is to create a libp2p host. The host object abstracts all of the work of setting up a 'swarm network' to handle the peers you will connect to, incoming connections from other peers, and negotiation of new outbound connections.
+
+In its simplest form, the host constructor can be invoked with no arguments to use the default settings:
+
+```go
+import (
+	"context"
+	libp2p "github.com/libp2p/go-libp2p"
+)
+
+// Make a context to govern the lifespan of the swarm
+ctx := context.Background()
+
+// To construct a simple host with all the default settings, just use `New`
+h, err := libp2p.New(ctx)
+if err != nil {
+	panic(err)
+}
+
+fmt.Printf("Hello World, my hosts ID is %s\n", h.ID())
+
+```
+
+Let's look at a slightly more complex example that actually uses the identity we created earlier and specifies where to listen for incoming connections:
+
+```go
+	h2, err := libp2p.New(ctx,
+		// Use your own created keypair
+		libp2p.Identity(priv),
+
+		// Set your own listen address
+		// The config takes an array of addresses, specify as many as you want.
+		libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/9000"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Hello World, my second hosts ID is %s\n", h2.ID())
+```
+
+Above we have shown two examples of the host constructor `libp2p.New()`.  The simplicity of the host constructor actually elides over two important implementation details.  First, note that internally the call `libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/9000")` is creating a `multiaddr` from a string; the manual equivalent would look like this:
 
 ```go
 import ma "github.com/multiformats/go-multiaddr"
@@ -47,33 +82,21 @@ if err != nil {
 }
 ```
 
-Now you know who you are, and where you live (in a manner of speaking). The next step is setting up a 'swarm network' to handle all the peers you will connect to. The swarm handles incoming connections from other peers, and handles the negotiation of new outbound connections.
+You could then pass `maddr` directly to `libp2p.New()`.
+
+Second, another important implementation detail hidden within the host constructor is the notion of a `peerstore`: a place where host IDs are stored.  Internally, `libp2p.New()` is creating a peerstore in a manner similar to this:
 
 ```go
 import (
-	"context"
-	swarm "github.com/libp2p/go-libp2p-swarm"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
 )
 
-// Make a context to govern the lifespan of the swarm
-ctx := context.Background()
-
-// Put all this together
-netw, err := swarm.NewNetwork(ctx, []ma.Multiaddr{maddr}, pid, ps, nil)
-if err != nil {
-	panic(err)
-}
+// We've created the identity, now we need to store it.
+// A peerstore holds information about peers, including your own
+ps := pstore.NewPeerstore()
+ps.AddPrivKey(pid, priv)
+ps.AddPubKey(pid, pub)
 ```
-
-At this point, we have everything needed to finally construct a host. That call is the simplest one so far:
-
-```go
-import bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
-
-myhost := bhost.New(netw)
-```
-
-And thats it, you have a libp2p host and you're ready to start doing some awesome p2p networking!
 
 In future guides we will go over ways to use hosts, configure them differently (hint: there are a huge number of ways to set these up), and interesting ways to apply this technology to various applications you might want to build.
 


### PR DESCRIPTION
The README.md text of the `examples/libp2p-host` tutorial does not match the code provided in the corresponding `host.go`.  It looks like the README.md is outdated.  At some point we simplified the host constructor to hide implementation details like:

* `peerstore`
* the storing of defaults in `github.com/libp2p/go-libp2p/p2p/host/basic`
* any explicit reference to multiaddrs

These are great simplifications to the libp2p API, and the README.md should reflect them.

However, I didn't want to completely remove the concepts of `peerstore` and `multiaddr`, since these concepts may be exposed to users of the API elsewhere.  So, what I did was move that stuff to a section at the end of the README that basically explains that `libp2p.New()` is doing this stuff behind the scenes.

I would appreciate a review for accuracy of the updated README content.
