### PR TITLE
Add configured transports to swarm

### DIFF
--- a/libp2p.go
+++ b/libp2p.go
@@ -200,12 +200,17 @@ func newWithCfg(ctx context.Context, cfg *Config) (host.Host, error) {
 		ps.AddPubKey(pid, cfg.PeerKey.GetPublic())
 	}
 
-	swrm, err := swarm.NewSwarmWithProtector(ctx, cfg.ListenAddrs, pid, ps, cfg.Protector, muxer, cfg.Reporter)
+	swrm, err := swarm.NewSwarmWithProtector(ctx, nil, pid, ps, cfg.Protector, muxer, cfg.Reporter)
+
 	if err != nil {
 		return nil, err
 	}
 
 	netw := (*swarm.Network)(swrm)
+	for _, tpt := range cfg.Transports {
+		swrm.AddTransport(tpt)
+	}
+	swrm.Listen(cfg.ListenAddrs...)
 
 	hostOpts := &bhost.HostOpts{}
 


### PR DESCRIPTION
Not sure if we want to merge this, but this patch enables user-configured `Transport`s by actually adding them to the `Swarm`. Note that in order to avoid invalid errors when binding listen addresses, I defer calling `Listen` (passing `nil` to the swarm initializer instead) until after the transports have been added.

I know this will be deprecated by the upcoming transport refactor, but figured it could be useful in the meantime!