### PR TITLE
reduce error to warning and log the error

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -255,7 +255,7 @@ func (ids *IDService) consumeReceivedPubKey(c inet.Conn, kb []byte) {
 
 	newKey, err := ic.UnmarshalPublicKey(kb)
 	if err != nil {
-		log.Errorf("%s cannot unmarshal key from remote peer: %s", lp, rp)
+		log.Warningf("%s cannot unmarshal key from remote peer: %s, %s", lp, rp, err)
 		return
 	}
 


### PR DESCRIPTION
This happens all the time in tests where we intentionally use fake keys for
performance.

Anyways, users probably don't want their logs spammed with errors they can't do
anything about.