### PR TITLE
[muxer] set mplex version to 6.7.0

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -27,7 +27,7 @@ var DefaultSecurity = Security(secio.ID, secio.New)
 // libp2p instead of replacing them.
 var DefaultMuxers = ChainOptions(
 	Muxer("/yamux/1.0.0", yamux.DefaultTransport),
-	Muxer("/mplex/6.3.0", mplex.DefaultTransport),
+	Muxer("/mplex/6.7.0", mplex.DefaultTransport),
 )
 
 // DefaultTransports are the default libp2p transports.


### PR DESCRIPTION
- set mplex protocol version to 6.7.0 to fix the problem described [here](https://github.com/libp2p/go-libp2p/issues/384) and [here](https://github.com/libp2p/js-libp2p-mplex/issues/81)