### PR TITLE
when we do a nat port mapping, explicitly remember the mapped address

### DIFF
--- a/p2p/host/basic/natmgr.go
+++ b/p2p/host/basic/natmgr.go
@@ -8,6 +8,7 @@ import (
 	lgbl "github.com/libp2p/go-libp2p-loggables"
 	inat "github.com/libp2p/go-libp2p-nat"
 	inet "github.com/libp2p/go-libp2p-net"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -186,6 +187,9 @@ func addPortMapping(nmgr *natManager, intaddr ma.Multiaddr) {
 		lm["error"] = err
 		return
 	}
+
+	// TODO: make these temporary and rediscover them.
+	nmgr.net.Peerstore().AddAddr(nmgr.net.LocalPeer(), extaddr, pstore.PermanentAddrTTL)
 
 	lm["outcome"] = "success"
 	lm["externalAddr"] = func() interface{} { return extaddr.String() }


### PR DESCRIPTION
related to #383

I won't call this *fixed* yet but it should help.