### PR TITLE
Revert "Merge pull request #386 from libp2p/fix/correct-external-addr"

### DIFF
--- a/p2p/host/basic/natmgr.go
+++ b/p2p/host/basic/natmgr.go
@@ -8,7 +8,6 @@ import (
 	lgbl "github.com/libp2p/go-libp2p-loggables"
 	inat "github.com/libp2p/go-libp2p-nat"
 	inet "github.com/libp2p/go-libp2p-net"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -187,9 +186,6 @@ func addPortMapping(nmgr *natManager, intaddr ma.Multiaddr) {
 		lm["error"] = err
 		return
 	}
-
-	// TODO: make these temporary and rediscover them.
-	nmgr.net.Peerstore().AddAddr(nmgr.net.LocalPeer(), extaddr, pstore.PermanentAddrTTL)
 
 	lm["outcome"] = "success"
 	lm["externalAddr"] = func() interface{} { return extaddr.String() }


### PR DESCRIPTION
This reverts commit aca83b9b6302000167c95dfb96eb4812cf1c0e93, reversing
changes made to 86b8929d4ddf3d38d4ee4cca6651abb9d05f16da.

This was is not the correct fix. We already expose these addresses via the
host's AllAddrs method. The real problem is probably that we just don't ever
tell anyone about them (unless we disconnect and reconnect to our nearby DHT
nodes).

We need an address gossip protocol.