### PR TITLE
Issue #370 Check if empty peer ID

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -307,6 +307,11 @@ func (h *BasicHost) RemoveStreamHandler(pid protocol.ID) {
 // to create one. If ProtocolID is "", writes no header.
 // (Threadsafe)
 func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (inet.Stream, error) {
+	err := p.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	pref, err := h.preferredProtocol(p, pids)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
On trying to open a new stream against an empty peer ID, we get an
error saying that failed to dial a peer.

This commit changes that to a more informative error message:
`Empty peer ID`

Should be merged after https://github.com/libp2p/go-libp2p-peer/pull/34
Fixes #370 