### PR TITLE
add options for disabling the default listen address/transports

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -9,6 +9,7 @@ import (
 
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	host "github.com/libp2p/go-libp2p-host"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
 	"github.com/libp2p/go-tcp-transport"
 )
 
@@ -29,6 +30,41 @@ func TestBadTransportConstructor(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "libp2p_test.go") {
 		t.Error("expected error to contain debugging info")
+	}
+}
+
+func TestNoListenAddrs(t *testing.T) {
+	ctx := context.Background()
+	h, err := New(ctx, NoListenAddrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+	if len(h.Addrs()) != 0 {
+		t.Fatal("expected no addresses")
+	}
+}
+
+func TestNoTransports(t *testing.T) {
+	ctx := context.Background()
+	a, err := New(ctx, NoTransports)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+
+	b, err := New(ctx, ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	err = a.Connect(ctx, pstore.PeerInfo{
+		ID:    b.ID(),
+		Addrs: b.Addrs(),
+	})
+	if err == nil {
+		t.Error("dial should have failed as no transports have been configured")
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -242,11 +242,11 @@ func NATManager(nm config.NATManagerC) Option {
 	}
 }
 
-// NoListen will configure libp2p to not listen by default.
+// NoListenAddrs will configure libp2p to not listen by default.
 //
 // This will both clear any configured listen addrs and prevent libp2p from
 // applying the default listen address option.
-var NoListen = func(cfg *Config) error {
+var NoListenAddrs = func(cfg *Config) error {
 	cfg.ListenAddrs = []ma.Multiaddr{}
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -241,3 +241,21 @@ func NATManager(nm config.NATManagerC) Option {
 		return nil
 	}
 }
+
+// NoListen will configure libp2p to not listen by default.
+//
+// This will both clear any configured listen addrs and prevent libp2p from
+// applying the default listen address option.
+var NoListen = func(cfg *Config) error {
+	cfg.ListenAddrs = []ma.Multiaddr{}
+	return nil
+}
+
+// NoTransports will configure libp2p to not enable any transports.
+//
+// This will both clear any configured transports (specified in prior libp2p
+// options) and prevent libp2p from applying the default transports.
+var NoTransports = func(cfg *Config) error {
+	cfg.Transports = []config.TptC{}
+	return nil
+}


### PR DESCRIPTION
So, in go-ipfs at least, we *don't* pass the listen addresses into the libp2p constructor. Instead, we specify them later.

This option allows us to tell libp2p to not listen by default.

The alternative is to just revert that PR and tell users that they need to configure libp2p to listen on some port. The question is really: "what's more surprising?"