### PR TITLE
Ensure duplicate transports are filtered

### DIFF
--- a/config/muxer.go
+++ b/config/muxer.go
@@ -50,6 +50,7 @@ func makeMuxer(h host.Host, tpts []MsMuxC) (mux.Transport, error) {
 		if _, ok := transportSet[tptC.ID]; ok {
 			return nil, fmt.Errorf("duplicate muxer transport: %s", tptC.ID)
 		}
+		transportSet[tptC.ID] = struct{}{}
 	}
 	for _, tptC := range tpts {
 		tpt, err := tptC.MuxC(h)

--- a/config/muxer_test.go
+++ b/config/muxer_test.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"context"
 	"testing"
 
+	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
+	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
+	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	mux "github.com/libp2p/go-stream-muxer"
 	yamux "github.com/whyrusleeping/go-smux-yamux"
 )
@@ -50,5 +54,48 @@ func TestMuxerBadTypes(t *testing.T) {
 		if _, err := MuxerConstructor(f); err == nil {
 			t.Fatalf("constructor %d with type %T should have failed", i, f)
 		}
+	}
+}
+
+func TestCatchDuplicateTransportsMuxer(t *testing.T) {
+	ctx := context.Background()
+	h := bhost.New(swarmt.GenSwarm(t, ctx))
+	yamuxMuxer, err := MuxerConstructor(yamux.DefaultTransport)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tests = map[string]struct {
+		h             host.Host
+		transports    []MsMuxC
+		expectedError string
+	}{
+		"no duplicate transports": {
+			h:             h,
+			transports:    []MsMuxC{MsMuxC{yamuxMuxer, "yamux"}},
+			expectedError: "",
+		},
+		"duplicate transports": {
+			h: h,
+			transports: []MsMuxC{
+				MsMuxC{yamuxMuxer, "yamux"},
+				MsMuxC{yamuxMuxer, "yamux"},
+			},
+			expectedError: "duplicate muxer transport: yamux",
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			_, err = makeMuxer(test.h, test.transports)
+			if err != nil {
+				if err.Error() != test.expectedError {
+					t.Errorf(
+						"\nexpected: [%v]\nactual:   [%v]\n",
+						test.expectedError,
+						err,
+					)
+				}
+			}
+		})
 	}
 }

--- a/config/security.go
+++ b/config/security.go
@@ -61,6 +61,7 @@ func makeSecurityTransport(h host.Host, tpts []MsSecC) (security.Transport, erro
 		if _, ok := transportSet[tptC.ID]; ok {
 			return nil, fmt.Errorf("duplicate security transport: %s", tptC.ID)
 		}
+		transportSet[tptC.ID] = tptC
 	}
 	for _, tptC := range tpts {
 		tpt, err := tptC.SecC(h)

--- a/config/security.go
+++ b/config/security.go
@@ -61,7 +61,7 @@ func makeSecurityTransport(h host.Host, tpts []MsSecC) (security.Transport, erro
 		if _, ok := transportSet[tptC.ID]; ok {
 			return nil, fmt.Errorf("duplicate security transport: %s", tptC.ID)
 		}
-		transportSet[tptC.ID] = tptC
+		transportSet[tptC.ID] = struct{}{}
 	}
 	for _, tptC := range tpts {
 		tpt, err := tptC.SecC(h)


### PR DESCRIPTION
Without adding the transport to the set, we'll never identify if there
are duplicates in the slice of secure transports provided by the config.