### PR TITLE
implement ping/2.0.0, which uses a new stream for every ping

### DIFF
--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -12,7 +12,6 @@ import (
 	host "github.com/libp2p/go-libp2p-host"
 	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
-	multistream "github.com/multiformats/go-multistream"
 )
 
 var log = logging.Logger("ping")
@@ -61,12 +60,12 @@ func (ps *PingService) PingHandler(s inet.Stream) {
 // It first attempts to use ping/2.0.0, and falls back to ping/1.0.0
 // if the peer doesn't support it yet.
 func (ps *PingService) Ping(ctx context.Context, p peer.ID) (<-chan time.Duration, error) {
-	s, err := ps.Host.NewStream(ctx, p, ID)
-	if err == multistream.ErrNotSupported {
-		return ps.PingLegacy(ctx, p)
-	}
+	s, err := ps.Host.NewStream(ctx, p, ID, IDLegacy)
 	if err != nil {
 		return nil, err
+	}
+	if s.Protocol() == IDLegacy {
+		return ps.PingLegacy(ctx, p)
 	}
 
 	out := make(chan time.Duration)

--- a/p2p/protocol/ping/ping_legacy.go
+++ b/p2p/protocol/ping/ping_legacy.go
@@ -1,0 +1,113 @@
+package ping
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	u "github.com/ipfs/go-ipfs-util"
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+const pingTimeout = 60 * time.Second
+
+// PingHandlerLegacy handles a ping/1.0.0 ping.
+func (ps *PingService) PingHandlerLegacy(s inet.Stream) {
+	buf := make([]byte, PingSize)
+
+	errCh := make(chan error, 1)
+	defer close(errCh)
+	timer := time.NewTimer(pingTimeout)
+	defer timer.Stop()
+
+	go func() {
+		select {
+		case <-timer.C:
+			log.Debug("ping timeout")
+		case err, ok := <-errCh:
+			if ok {
+				log.Debug(err)
+			} else {
+				log.Error("ping loop failed without error")
+			}
+		}
+		s.Reset()
+	}()
+
+	for {
+		_, err := io.ReadFull(s, buf)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		_, err = s.Write(buf)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		timer.Reset(pingTimeout)
+	}
+}
+
+// PingLegacy pings a peer using ping/1.0.0
+func (ps *PingService) PingLegacy(ctx context.Context, p peer.ID) (<-chan time.Duration, error) {
+	s, err := ps.Host.NewStream(ctx, p, IDLegacy)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan time.Duration)
+	go func() {
+		defer close(out)
+		defer s.Reset()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				t, err := pingLegacy(s)
+				if err != nil {
+					log.Debugf("ping error: %s", err)
+					return
+				}
+
+				ps.Host.Peerstore().RecordLatency(p, t)
+				select {
+				case out <- t:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+func pingLegacy(s inet.Stream) (time.Duration, error) {
+	buf := make([]byte, PingSize)
+	u.NewTimeSeededRand().Read(buf)
+
+	before := time.Now()
+	_, err := s.Write(buf)
+	if err != nil {
+		return 0, err
+	}
+
+	rbuf := make([]byte, PingSize)
+	_, err = io.ReadFull(s, rbuf)
+	if err != nil {
+		return 0, err
+	}
+
+	if !bytes.Equal(buf, rbuf) {
+		return 0, errors.New("ping packet was incorrect!")
+	}
+
+	return time.Since(before), nil
+}


### PR DESCRIPTION
Fixes #391.

This PR adds a new ping protocol `ping/2.0.0`. This ping protocol uses a separate stream for every ping, thereby getting rid of the head-of-line blocking present in `ping/1.0.0`, where all pings were sent on the same stream. Obviously, this will only make any real-world difference when using QUIC, since multiplexing streams on a single TCP connection reintroduces head-of-line blocking between streams.

In order to not break compatibility, nodes still support both the `ping/1.0.0` and the `ping/2.0.0` stream handler for incoming pings. For incoming pings, we first try `ping/2.0.0`, and if that fails fall back to `ping/1.0.0`. We should remove the `ping/1.0.0` code in a later release, when we're confident that the majority of nodes was upgraded to support `ping/2.0.0`.