### PR TITLE
use the new DisableLogging mdns option, don't turn off logging globally

### DIFF
--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
-	golog "log"
 	"net"
 	"sync"
 	"time"
@@ -64,8 +62,8 @@ func getDialableListenAddrs(ph host.Host) ([]*net.TCPAddr, error) {
 
 func NewMdnsService(ctx context.Context, peerhost host.Host, interval time.Duration, serviceTag string) (Service, error) {
 
-	// TODO: dont let mdns use logging...
-	golog.SetOutput(ioutil.Discard)
+	// don't let mdns use logging...
+	mdns.DisableLogging = true
 
 	var ipaddrs []net.IP
 	port := 4001

--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -17,6 +17,11 @@ import (
 	"github.com/whyrusleeping/mdns"
 )
 
+func init() {
+	// don't let mdns use logging...
+	mdns.DisableLogging = true
+}
+
 var log = logging.Logger("mdns")
 
 const ServiceTag = "_ipfs-discovery._udp"
@@ -61,9 +66,6 @@ func getDialableListenAddrs(ph host.Host) ([]*net.TCPAddr, error) {
 }
 
 func NewMdnsService(ctx context.Context, peerhost host.Host, interval time.Duration, serviceTag string) (Service, error) {
-
-	// don't let mdns use logging...
-	mdns.DisableLogging = true
 
 	var ipaddrs []net.IP
 	port := 4001

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmNeRzgrSpwbMU7VKLRyfvbqf1nRrAiQ7fEXaBxWGT5Ygr",
+      "hash": "QmekaTKpWkYGcn4ZEC5PwJDRCQHapwugmmG86g2Xpz5GBH",
       "name": "mdns",
-      "version": "0.1.3"
+      "version": "0.2.0"
     },
     {
       "hash": "QmPdKqUcHGFdeSpvjVoaTRPPstGif9GBZb5Q56RVw9o69A",


### PR DESCRIPTION
Fixes #392. Depends on https://github.com/whyrusleeping/mdns/pull/3.

We should merge this *before* rolling out an IPFS release with QUIC support. This fix is necessary to be able to activate QUIC logging.