### PR TITLE
Sync observed addresses with port mapping configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	filter "github.com/libp2p/go-maddr-filter"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -29,7 +30,7 @@ var log = logging.Logger("p2p-config")
 type AddrsFactory = bhost.AddrsFactory
 
 // NATManagerC is a NATManager constructor.
-type NATManagerC func(inet.Network) bhost.NATManager
+type NATManagerC func(inet.Network, *identify.IDService) bhost.NATManager
 
 // Config describes a set of settings for a libp2p node
 //

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -93,7 +93,7 @@ type HostOpts struct {
 
 	// NATManager takes care of setting NAT port mappings, and discovering external addresses.
 	// If omitted, this will simply be disabled.
-	NATManager func(inet.Network) NATManager
+	NATManager func(inet.Network, *identify.IDService) NATManager
 
 	// ConnManager is a libp2p connection manager
 	ConnManager ifconnmgr.ConnManager
@@ -136,7 +136,7 @@ func NewHost(ctx context.Context, net inet.Network, opts *HostOpts) (*BasicHost,
 	}
 
 	if opts.NATManager != nil {
-		h.natmgr = opts.NATManager(net)
+		h.natmgr = opts.NATManager(net, h.ids)
 	}
 
 	if opts.MultiaddrResolver != nil {

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -205,7 +205,7 @@ func (ids *IDService) consumeMessage(mes *pb.Identify, c inet.Conn) {
 		lmaddrs = append(lmaddrs, maddr)
 	}
 
-	// if the address reported by the connection roughly matches their annoucned
+	// if the address reported by the connection roughly matches their announced
 	// listener addresses, its likely to be an external NAT address
 	if HasConsistentTransport(c.RemoteMultiaddr(), lmaddrs) {
 		lmaddrs = append(lmaddrs, c.RemoteMultiaddr())

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -14,7 +14,7 @@ const ActivationThresh = 4
 // We only use addresses that:
 // - have been observed at least 4 times in last 1h. (counter symmetric nats)
 // - have been observed at least once recently (1h), because our position in the
-//   network, or network port mapppings, may have changed.
+//   network, or network port mappings, may have changed.
 type ObservedAddr struct {
 	Addr      ma.Multiaddr
 	SeenBy    map[string]time.Time


### PR DESCRIPTION
The situation is found and described in https://github.com/ipfs/go-ipfs/issues/5411. The 4001 port on external IP address is mapped automatically when IPFS node try to `connect` to another node, so is observed by peers. But in-bound connections cannot use this port to connect. Turns out many NAT devices have asymmetric port mappings, we need to explicitly configure in-bound mappings even if out-bound connections have been established.

This patch
- add observed port mappings not configured
- removes port mappings not observed for a consecutive amount of times

depends on https://github.com/libp2p/go-libp2p-nat/pull/8