### PR TITLE
downgrade protocol mux failure log to debug

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -223,7 +223,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 			}
 			logf("protocol EOF: %s (took %s)", s.Conn().RemotePeer(), took)
 		} else {
-			log.Infof("protocol mux failed: %s (took %s)", err, took)
+			log.Debugf("protocol mux failed: %s (took %s)", err, took)
 		}
 		s.Reset()
 		return


### PR DESCRIPTION
There is no real information conveyed (so it's really not INFO) and there is tons of it.

The more pertinent question is why I see so many of them -- probably because of prevalence of undialable addrs