### PR TITLE
autorelay

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	relay "github.com/libp2p/go-libp2p/p2p/host/relay"
+	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
 
 	logging "github.com/ipfs/go-log"
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	crypto "github.com/libp2p/go-libp2p-crypto"
+	discovery "github.com/libp2p/go-libp2p-discovery"
 	host "github.com/libp2p/go-libp2p-host"
 	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
 	pnet "github.com/libp2p/go-libp2p-interface-pnet"
@@ -16,6 +19,7 @@ import (
 	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	routing "github.com/libp2p/go-libp2p-routing"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
 	filter "github.com/libp2p/go-maddr-filter"
@@ -30,6 +34,13 @@ type AddrsFactory = bhost.AddrsFactory
 
 // NATManagerC is a NATManager constructor.
 type NATManagerC func(inet.Network) bhost.NATManager
+
+type Routing interface {
+	routing.ContentRouting
+	routing.PeerRouting
+}
+
+type RoutingC func(host.Host) (Routing, error)
 
 // Config describes a set of settings for a libp2p node
 //
@@ -58,6 +69,8 @@ type Config struct {
 	Reporter    metrics.Reporter
 
 	DisablePing bool
+
+	Routing RoutingC
 }
 
 // NewNode constructs a new libp2p Host from the Config.
@@ -99,8 +112,8 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		swrm.Filters = cfg.Filters
 	}
 
-	// TODO: make host implementation configurable.
-	h, err := bhost.NewHost(ctx, swrm, &bhost.HostOpts{
+	var h host.Host
+	h, err = bhost.NewHost(ctx, swrm, &bhost.HostOpts{
 		ConnManager:  cfg.ConnManager,
 		AddrsFactory: cfg.AddrsFactory,
 		NATManager:   cfg.NATManager,
@@ -158,7 +171,34 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		return nil, err
 	}
 
-	// TODO: Configure routing (it's a pain to setup).
+	if cfg.Routing != nil {
+		router, err := cfg.Routing(h)
+		if err != nil {
+			h.Close()
+			return nil, err
+		}
+
+		if cfg.Relay {
+			discovery := discovery.NewRoutingDiscovery(router)
+
+			hop := false
+			for _, opt := range cfg.RelayOpts {
+				if opt == circuit.OptHop {
+					hop = true
+					break
+				}
+			}
+
+			if hop {
+				h = relay.NewRelayHost(swrm.Context(), h.(*bhost.BasicHost), discovery)
+			} else {
+				h = relay.NewAutoRelayHost(swrm.Context(), h.(*bhost.BasicHost), discovery)
+			}
+		}
+
+		h = routed.Wrap(h, router)
+	}
+
 	// TODO: Bootstrapping.
 
 	return h, nil

--- a/config/config.go
+++ b/config/config.go
@@ -35,12 +35,12 @@ type AddrsFactory = bhost.AddrsFactory
 // NATManagerC is a NATManager constructor.
 type NATManagerC func(inet.Network) bhost.NATManager
 
-type Routing interface {
+type BasicRouting interface {
 	routing.ContentRouting
 	routing.PeerRouting
 }
 
-type RoutingC func(host.Host) (Routing, error)
+type RoutingC func(host.Host) (BasicRouting, error)
 
 // Config describes a set of settings for a libp2p node
 //

--- a/libp2p.go
+++ b/libp2p.go
@@ -15,6 +15,9 @@ type Config = config.Config
 // (`libp2p.New`).
 type Option = config.Option
 
+// BasicRouting is the combination of PeerRouting and ContentRouting
+type BasicRouting = config.BasicRouting
+
 // ChainOptions chains multiple options into a single option.
 func ChainOptions(opts ...Option) Option {
 	return func(cfg *Config) error {

--- a/libp2p.go
+++ b/libp2p.go
@@ -15,9 +15,6 @@ type Config = config.Config
 // (`libp2p.New`).
 type Option = config.Option
 
-// BasicRouting is the combination of PeerRouting and ContentRouting
-type BasicRouting = config.BasicRouting
-
 // ChainOptions chains multiple options into a single option.
 func ChainOptions(opts ...Option) Option {
 	return func(cfg *Config) error {

--- a/options.go
+++ b/options.go
@@ -260,6 +260,17 @@ func Ping(enable bool) Option {
 	}
 }
 
+// Routing will configure libp2p to use routing.
+func Routing(rt config.RoutingC) Option {
+	return func(cfg *Config) error {
+		if cfg.Routing != nil {
+			return fmt.Errorf("cannot specified multiple routing options")
+		}
+		cfg.Routing = rt
+		return nil
+	}
+}
+
 // NoListenAddrs will configure libp2p to not listen by default.
 //
 // This will both clear any configured listen addrs and prevent libp2p from

--- a/options.go
+++ b/options.go
@@ -264,7 +264,7 @@ func Ping(enable bool) Option {
 func Routing(rt config.RoutingC) Option {
 	return func(cfg *Config) error {
 		if cfg.Routing != nil {
-			return fmt.Errorf("cannot specified multiple routing options")
+			return fmt.Errorf("cannot specify multiple routing options")
 		}
 		cfg.Routing = rt
 		return nil

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -59,9 +59,10 @@ type BasicHost struct {
 	ids        *identify.IDService
 	pings      *ping.PingService
 	natmgr     NATManager
-	addrs      AddrsFactory
 	maResolver *madns.Resolver
 	cmgr       ifconnmgr.ConnManager
+
+	AddrsFactory AddrsFactory
 
 	negtimeout time.Duration
 
@@ -106,11 +107,11 @@ type HostOpts struct {
 // NewHost constructs a new *BasicHost and activates it by attaching its stream and connection handlers to the given inet.Network.
 func NewHost(ctx context.Context, net inet.Network, opts *HostOpts) (*BasicHost, error) {
 	h := &BasicHost{
-		network:    net,
-		mux:        msmux.NewMultistreamMuxer(),
-		negtimeout: DefaultNegotiationTimeout,
-		addrs:      DefaultAddrsFactory,
-		maResolver: madns.DefaultResolver,
+		network:      net,
+		mux:          msmux.NewMultistreamMuxer(),
+		negtimeout:   DefaultNegotiationTimeout,
+		AddrsFactory: DefaultAddrsFactory,
+		maResolver:   madns.DefaultResolver,
 	}
 
 	h.proc = goprocessctx.WithContextAndTeardown(ctx, func() error {
@@ -136,7 +137,7 @@ func NewHost(ctx context.Context, net inet.Network, opts *HostOpts) (*BasicHost,
 	}
 
 	if opts.AddrsFactory != nil {
-		h.addrs = opts.AddrsFactory
+		h.AddrsFactory = opts.AddrsFactory
 	}
 
 	if opts.NATManager != nil {
@@ -254,6 +255,11 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 	log.Debugf("protocol negotiation took %s", took)
 
 	go handle(protoID, s)
+}
+
+// PushIdentify pushes an identify update through the identify push protocol
+func (h *BasicHost) PushIdentify() {
+	h.ids.Push()
 }
 
 // ID returns the (local) peer.ID associated with this Host
@@ -474,7 +480,7 @@ func (h *BasicHost) ConnManager() ifconnmgr.ConnManager {
 // Addrs returns listening addresses that are safe to announce to the network.
 // The output is the same as AllAddrs, but processed by AddrsFactory.
 func (h *BasicHost) Addrs() []ma.Multiaddr {
-	return h.addrs(h.AllAddrs())
+	return h.AddrsFactory(h.AllAddrs())
 }
 
 // mergeAddrs merges input address lists, leave only unique addresses

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -258,6 +258,7 @@ func (h *BasicHost) newStreamHandler(s inet.Stream) {
 }
 
 // PushIdentify pushes an identify update through the identify push protocol
+// Warning: this interface is unstable and may disappear in the future.
 func (h *BasicHost) PushIdentify() {
 	h.ids.Push()
 }

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -116,7 +116,8 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 	h.mx.Unlock()
 
 	limit := 20
-	for ; need > limit; limit *= 2 {
+	if need > limit/2 {
+		limit = 2 * need
 	}
 
 	dctx, cancel := context.WithTimeout(ctx, 60*time.Second)

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -220,6 +220,7 @@ func (h *AutoRelayHost) doUpdateAddrs() {
 		}
 	}
 
+	// add relay specific addrs to the list
 	for _, pi := range h.relays {
 		circuit, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit", pi.ID.Pretty()))
 		if err != nil {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	RelayRenezvous = "/libp2p/relay"
+	RelayRendezvous = "/libp2p/relay"
 )
 
 var (
@@ -125,7 +125,7 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 	}
 
 	dctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	pis, err := discovery.FindPeers(dctx, h.discover, RelayRenezvous, limit)
+	pis, err := discovery.FindPeers(dctx, h.discover, RelayRendezvous, limit)
 	cancel()
 	if err != nil {
 		log.Debugf("error discovering relays: %s", err.Error())

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -184,6 +184,15 @@ func (h *AutoRelayHost) updateAddrs() {
 	h.PushIdentify()
 }
 
+// This function updates our NATed advertised addrs (h.addrs)
+// The public addrs are rewritten so that they only retain the public IP part; they
+// become undialable but are useful as a hint to the dialer to determine whether or not
+// to dial private addrs.
+// The non-public addrs are included verbatim so that peers behind the same NAT/firewall
+// can still dial us directly.
+// On top of those, we add the relay-specific addrs for the relays to which we are
+// connected. For each non-private relay addr, we encapsulate the p2p-circuit addr
+// through which we can be dialed.
 func (h *AutoRelayHost) doUpdateAddrs() {
 	h.mx.Lock()
 	defer h.mx.Unlock()

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -1,0 +1,252 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	basic "github.com/libp2p/go-libp2p/p2p/host/basic"
+
+	autonat "github.com/libp2p/go-libp2p-autonat"
+	discovery "github.com/libp2p/go-libp2p-discovery"
+	host "github.com/libp2p/go-libp2p-host"
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr-net"
+)
+
+var DesiredRelays = 3
+
+// AutoRelayHost is a Host that uses relays for connectivity when a NAT is detected.
+type AutoRelayHost struct {
+	*basic.BasicHost
+	discover discovery.Discoverer
+	autonat  autonat.AutoNAT
+	addrsF   basic.AddrsFactory
+
+	disconnect chan struct{}
+
+	mx     sync.Mutex
+	relays map[peer.ID]pstore.PeerInfo
+	addrs  []ma.Multiaddr
+}
+
+func NewAutoRelayHost(ctx context.Context, bhost *basic.BasicHost, discover discovery.Discoverer) *AutoRelayHost {
+	autonat := autonat.NewAutoNAT(ctx, bhost)
+	h := &AutoRelayHost{
+		BasicHost:  bhost,
+		discover:   discover,
+		autonat:    autonat,
+		addrsF:     bhost.AddrsFactory,
+		relays:     make(map[peer.ID]pstore.PeerInfo),
+		disconnect: make(chan struct{}, 1),
+	}
+	bhost.AddrsFactory = h.hostAddrs
+	bhost.Network().Notify(h)
+	go h.background(ctx)
+	return h
+}
+
+func (h *AutoRelayHost) hostAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
+	h.mx.Lock()
+	defer h.mx.Unlock()
+	if h.addrs != nil && h.autonat.Status() == autonat.NATStatusPrivate {
+		return h.addrs
+	} else {
+		return h.addrsF(addrs)
+	}
+}
+
+func (h *AutoRelayHost) background(ctx context.Context) {
+	select {
+	case <-time.After(autonat.AutoNATBootDelay + 30*time.Second):
+	case <-ctx.Done():
+		return
+	}
+
+	for {
+		wait := autonat.AutoNATRefreshInterval
+		switch h.autonat.Status() {
+		case autonat.NATStatusUnknown:
+			wait = autonat.AutoNATRetryInterval
+		case autonat.NATStatusPublic:
+		case autonat.NATStatusPrivate:
+			h.findRelays(ctx)
+		}
+
+		select {
+		case <-h.disconnect:
+			// invalidate addrs
+			h.mx.Lock()
+			h.addrs = nil
+			h.mx.Unlock()
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *AutoRelayHost) findRelays(ctx context.Context) {
+	h.mx.Lock()
+	if len(h.relays) >= DesiredRelays {
+		h.mx.Unlock()
+		return
+	}
+	need := DesiredRelays - len(h.relays)
+	h.mx.Unlock()
+
+	limit := 20
+	for ; need > limit; limit *= 2 {
+	}
+
+	dctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	pis, err := discovery.FindPeers(dctx, h.discover, "/libp2p/relay", limit)
+	cancel()
+	if err != nil {
+		log.Debugf("error discovering relays: %s", err.Error())
+		return
+	}
+
+	// TODO better relay selection strategy; this just selects random relays
+	//      but we should probably use ping latency as the selection metric
+	shuffleRelays(pis)
+
+	update := 0
+
+	for _, pi := range pis {
+		h.mx.Lock()
+		if _, ok := h.relays[pi.ID]; ok {
+			h.mx.Unlock()
+			continue
+		}
+		h.mx.Unlock()
+
+		cctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		err = h.Connect(cctx, pi)
+		cancel()
+		if err != nil {
+			log.Debugf("error connecting to relay %s: %s", pi.ID, err.Error())
+			continue
+		}
+
+		log.Debugf("connected to relay %s", pi.ID)
+		h.mx.Lock()
+		h.relays[pi.ID] = pi
+		h.mx.Unlock()
+
+		update++
+		need--
+		if need == 0 {
+			break
+		}
+	}
+
+	if update > 0 || h.addrs == nil {
+		h.updateAddrs()
+	}
+}
+
+func (h *AutoRelayHost) updateAddrs() {
+	h.doUpdateAddrs()
+	h.PushIdentify()
+}
+
+func (h *AutoRelayHost) doUpdateAddrs() {
+	h.mx.Lock()
+	defer h.mx.Unlock()
+
+	addrs := h.addrsF(h.AllAddrs())
+	raddrs := make([]ma.Multiaddr, 0, len(addrs)+len(h.relays))
+
+	// remove our public addresses from the list and replace them by just the public IP
+	for _, addr := range addrs {
+		if manet.IsPublicAddr(addr) {
+			ip, err := addr.ValueForProtocol(ma.P_IP4)
+			if err == nil {
+				pub, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s", ip))
+				if err != nil {
+					panic(err)
+				}
+
+				if !containsAddr(raddrs, pub) {
+					raddrs = append(raddrs, pub)
+				}
+				continue
+			}
+
+			ip, err = addr.ValueForProtocol(ma.P_IP6)
+			if err == nil {
+				pub, err := ma.NewMultiaddr(fmt.Sprintf("/ip6/%s", ip))
+				if err != nil {
+					panic(err)
+				}
+				if !containsAddr(raddrs, pub) {
+					raddrs = append(raddrs, pub)
+				}
+				continue
+			}
+		} else {
+			raddrs = append(raddrs, addr)
+		}
+	}
+
+	circuit, err := ma.NewMultiaddr("/p2p-circuit")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, pi := range h.relays {
+		for _, addr := range pi.Addrs {
+			if !manet.IsPrivateAddr(addr) {
+				pub := addr.Encapsulate(circuit)
+				raddrs = append(raddrs, pub)
+			}
+		}
+	}
+
+	h.addrs = raddrs
+}
+
+func shuffleRelays(pis []pstore.PeerInfo) {
+	for i := range pis {
+		j := rand.Intn(i + 1)
+		pis[i], pis[j] = pis[j], pis[i]
+	}
+}
+
+func containsAddr(lst []ma.Multiaddr, addr ma.Multiaddr) bool {
+	for _, xaddr := range lst {
+		if xaddr.Equal(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// notify
+func (h *AutoRelayHost) Listen(inet.Network, ma.Multiaddr)      {}
+func (h *AutoRelayHost) ListenClose(inet.Network, ma.Multiaddr) {}
+func (h *AutoRelayHost) Connected(inet.Network, inet.Conn)      {}
+
+func (h *AutoRelayHost) Disconnected(_ inet.Network, c inet.Conn) {
+	p := c.RemotePeer()
+	h.mx.Lock()
+	defer h.mx.Unlock()
+	if _, ok := h.relays[p]; ok {
+		delete(h.relays, p)
+		select {
+		case h.disconnect <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (h *AutoRelayHost) OpenedStream(inet.Network, inet.Stream) {}
+func (h *AutoRelayHost) ClosedStream(inet.Network, inet.Stream) {}
+
+var _ host.Host = (*AutoRelayHost)(nil)

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -222,7 +222,7 @@ func (h *AutoRelayHost) doUpdateAddrs() {
 
 	// add relay specific addrs to the list
 	for _, pi := range h.relays {
-		circuit, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit", pi.ID.Pretty()))
+		circuit, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s/p2p-circuit", pi.ID.Pretty()))
 		if err != nil {
 			panic(err)
 		}

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -22,7 +22,7 @@ import (
 var (
 	DesiredRelays = 3
 
-	BootDelay = 90 * time.Second
+	BootDelay = 60 * time.Second
 )
 
 // AutoRelayHost is a Host that uses relays for connectivity when a NAT is detected.

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -40,7 +40,7 @@ type AutoRelayHost struct {
 }
 
 func NewAutoRelayHost(ctx context.Context, bhost *basic.BasicHost, discover discovery.Discoverer) *AutoRelayHost {
-	autonat := autonat.NewAutoNAT(ctx, bhost)
+	autonat := autonat.NewAutoNAT(ctx, bhost, bhost.AllAddrs)
 	h := &AutoRelayHost{
 		BasicHost:  bhost,
 		discover:   discover,

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -132,9 +132,7 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 		return
 	}
 
-	// TODO better relay selection strategy; this just selects random relays
-	//      but we should probably use ping latency as the selection metric
-	shuffleRelays(pis)
+	pis = h.selectRelays(pis)
 
 	update := 0
 
@@ -169,6 +167,13 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 	if update > 0 || h.addrs == nil {
 		h.updateAddrs()
 	}
+}
+
+func (h *AutoRelayHost) selectRelays(pis []pstore.PeerInfo) []pstore.PeerInfo {
+	// TODO better relay selection strategy; this just selects random relays
+	//      but we should probably use ping latency as the selection metric
+	shuffleRelays(pis)
+	return pis
 }
 
 func (h *AutoRelayHost) updateAddrs() {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -157,6 +157,9 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 		h.relays[pi.ID] = pi
 		h.mx.Unlock()
 
+		// tag the connection as very important
+		h.ConnManager().TagPeer(pi.ID, "relay", 42)
+
 		update++
 		need--
 		if need == 0 {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -199,12 +199,12 @@ func (h *AutoRelayHost) doUpdateAddrs() {
 		}
 	}
 
-	circuit, err := ma.NewMultiaddr("/p2p-circuit")
-	if err != nil {
-		panic(err)
-	}
-
 	for _, pi := range h.relays {
+		circuit, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit", pi.ID.Pretty()))
+		if err != nil {
+			panic(err)
+		}
+
 		for _, addr := range pi.Addrs {
 			if !manet.IsPrivateAddr(addr) {
 				pub := addr.Encapsulate(circuit)

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -20,6 +20,10 @@ import (
 	manet "github.com/multiformats/go-multiaddr-net"
 )
 
+const (
+	RelayRenezvous = "/libp2p/relay"
+)
+
 var (
 	DesiredRelays = 3
 
@@ -121,7 +125,7 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 	}
 
 	dctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	pis, err := discovery.FindPeers(dctx, h.discover, "/libp2p/relay", limit)
+	pis, err := discovery.FindPeers(dctx, h.discover, RelayRenezvous, limit)
 	cancel()
 	if err != nil {
 		log.Debugf("error discovering relays: %s", err.Error())

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -19,7 +19,11 @@ import (
 	manet "github.com/multiformats/go-multiaddr-net"
 )
 
-var DesiredRelays = 3
+var (
+	DesiredRelays = 3
+
+	BootDelay = 90 * time.Second
+)
 
 // AutoRelayHost is a Host that uses relays for connectivity when a NAT is detected.
 type AutoRelayHost struct {
@@ -63,7 +67,7 @@ func (h *AutoRelayHost) hostAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 
 func (h *AutoRelayHost) background(ctx context.Context) {
 	select {
-	case <-time.After(autonat.AutoNATBootDelay + 30*time.Second):
+	case <-time.After(autonat.AutoNATBootDelay + BootDelay):
 	case <-ctx.Done():
 		return
 	}

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -1,0 +1,169 @@
+package relay_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	libp2p "github.com/libp2p/go-libp2p"
+	config "github.com/libp2p/go-libp2p/config"
+	relay "github.com/libp2p/go-libp2p/p2p/host/relay"
+
+	ggio "github.com/gogo/protobuf/io"
+	cid "github.com/ipfs/go-cid"
+	autonat "github.com/libp2p/go-libp2p-autonat"
+	autonatpb "github.com/libp2p/go-libp2p-autonat/pb"
+	circuit "github.com/libp2p/go-libp2p-circuit"
+	host "github.com/libp2p/go-libp2p-host"
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	routing "github.com/libp2p/go-libp2p-routing"
+	manet "github.com/multiformats/go-multiaddr-net"
+)
+
+// test specific parameters
+func init() {
+	autonat.AutoNATIdentifyDelay = 10 * time.Millisecond
+	autonat.AutoNATBootDelay = 1 * time.Second
+	relay.BootDelay = 1 * time.Second
+	manet.Private4 = []*net.IPNet{}
+}
+
+// mock routing
+type mockRoutingTable struct {
+	mx        sync.Mutex
+	providers map[string]map[peer.ID]pstore.PeerInfo
+}
+
+type mockRouting struct {
+	h   host.Host
+	tab *mockRoutingTable
+}
+
+func newMockRoutingTable() *mockRoutingTable {
+	return &mockRoutingTable{providers: make(map[string]map[peer.ID]pstore.PeerInfo)}
+}
+
+func newMockRouting(h host.Host, tab *mockRoutingTable) *mockRouting {
+	return &mockRouting{h: h, tab: tab}
+}
+
+func (m *mockRouting) FindPeer(ctx context.Context, p peer.ID) (pstore.PeerInfo, error) {
+	return pstore.PeerInfo{}, routing.ErrNotFound
+}
+
+func (m *mockRouting) Provide(ctx context.Context, cid cid.Cid, bcast bool) error {
+	m.tab.mx.Lock()
+	defer m.tab.mx.Unlock()
+
+	pmap, ok := m.tab.providers[cid.String()]
+	if !ok {
+		pmap = make(map[peer.ID]pstore.PeerInfo)
+		m.tab.providers[cid.String()] = pmap
+	}
+
+	pmap[m.h.ID()] = pstore.PeerInfo{ID: m.h.ID(), Addrs: m.h.Addrs()}
+
+	return nil
+}
+
+func (m *mockRouting) FindProvidersAsync(ctx context.Context, cid cid.Cid, limit int) <-chan pstore.PeerInfo {
+	ch := make(chan pstore.PeerInfo)
+	go func() {
+		defer close(ch)
+		m.tab.mx.Lock()
+		defer m.tab.mx.Unlock()
+
+		pmap, ok := m.tab.providers[cid.String()]
+		if !ok {
+			return
+		}
+
+		for _, pi := range pmap {
+			select {
+			case ch <- pi:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch
+}
+
+// mock autonat
+func makeAutoNATServicePrivate(ctx context.Context, t *testing.T) host.Host {
+	h, err := libp2p.New(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.SetStreamHandler(autonat.AutoNATProto, sayAutoNATPrivate)
+	return h
+}
+
+func sayAutoNATPrivate(s inet.Stream) {
+	defer s.Close()
+	w := ggio.NewDelimitedWriter(s)
+	res := autonatpb.Message{
+		Type:         autonatpb.Message_DIAL_RESPONSE.Enum(),
+		DialResponse: newDialResponseError(autonatpb.Message_E_DIAL_ERROR, "no dialable addresses"),
+	}
+	w.WriteMsg(&res)
+}
+
+func newDialResponseError(status autonatpb.Message_ResponseStatus, text string) *autonatpb.Message_DialResponse {
+	dr := new(autonatpb.Message_DialResponse)
+	dr.Status = status.Enum()
+	dr.StatusText = &text
+	return dr
+}
+
+// connector
+func connect(t *testing.T, a, b host.Host) {
+	pinfo := pstore.PeerInfo{ID: a.ID(), Addrs: a.Addrs()}
+	err := b.Connect(context.Background(), pinfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// and the actual test!
+func TestAutoRelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mtab := newMockRoutingTable()
+	makeRouting := func(h host.Host) (config.Routing, error) {
+		mr := newMockRouting(h, mtab)
+		return mr, nil
+	}
+
+	h1 := makeAutoNATServicePrivate(ctx, t)
+	_, err := libp2p.New(ctx, libp2p.EnableRelay(circuit.OptHop), libp2p.Routing(makeRouting))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h3, err := libp2p.New(ctx, libp2p.EnableRelay(), libp2p.Routing(makeRouting))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connect(t, h1, h3)
+	time.Sleep(3 * time.Second)
+
+	haveRelay := false
+	for _, addr := range h3.Addrs() {
+		_, err := addr.ValueForProtocol(circuit.P_CIRCUIT)
+		if err != nil {
+			haveRelay = true
+			break
+		}
+	}
+
+	if !haveRelay {
+		t.Fatal("No relay addrs advertised")
+	}
+}

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -26,7 +26,7 @@ import (
 
 // test specific parameters
 func init() {
-	autonat.AutoNATIdentifyDelay = 10 * time.Millisecond
+	autonat.AutoNATIdentifyDelay = 100 * time.Millisecond
 	autonat.AutoNATBootDelay = 1 * time.Second
 	relay.BootDelay = 1 * time.Second
 	manet.Private4 = []*net.IPNet{}

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -136,7 +136,7 @@ func TestAutoRelay(t *testing.T) {
 	defer cancel()
 
 	mtab := newMockRoutingTable()
-	makeRouting := func(h host.Host) (libp2p.BasicRouting, error) {
+	makeRouting := func(h host.Host) (routing.PeerRouting, error) {
 		mr := newMockRouting(h, mtab)
 		return mr, nil
 	}

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -178,7 +178,7 @@ func TestAutoRelay(t *testing.T) {
 		}
 	}
 
-	err = h4.Connect(ctx, pstore.PeerInfo{h3.ID(), raddrs})
+	err = h4.Connect(ctx, pstore.PeerInfo{ID: h3.ID(), Addrs: raddrs})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -160,7 +160,7 @@ func TestAutoRelay(t *testing.T) {
 	haveRelay := false
 	for _, addr := range h3.Addrs() {
 		_, err := addr.ValueForProtocol(circuit.P_CIRCUIT)
-		if err != nil {
+		if err == nil {
 			haveRelay = true
 			break
 		}
@@ -174,7 +174,7 @@ func TestAutoRelay(t *testing.T) {
 	var raddrs []ma.Multiaddr
 	for _, addr := range h3.Addrs() {
 		_, err := addr.ValueForProtocol(circuit.P_CIRCUIT)
-		if err != nil {
+		if err == nil {
 			raddrs = append(raddrs, addr)
 		}
 	}

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	libp2p "github.com/libp2p/go-libp2p"
-	config "github.com/libp2p/go-libp2p/config"
 	relay "github.com/libp2p/go-libp2p/p2p/host/relay"
 
 	ggio "github.com/gogo/protobuf/io"
@@ -137,7 +136,7 @@ func TestAutoRelay(t *testing.T) {
 	defer cancel()
 
 	mtab := newMockRoutingTable()
-	makeRouting := func(h host.Host) (config.Routing, error) {
+	makeRouting := func(h host.Host) (libp2p.BasicRouting, error) {
 		mr := newMockRouting(h, mtab)
 		return mr, nil
 	}

--- a/p2p/host/relay/doc.go
+++ b/p2p/host/relay/doc.go
@@ -1,0 +1,28 @@
+/*
+The relay package contains host implementations that automatically
+advertise relay addresses when the presence of NAT is detected. This
+feature is dubbed `autorelay`.
+
+System Components:
+- AutoNATService instances -- see https://github.com/libp2p/go-libp2p-autonat-svc
+- One or more relays, instances of `RelayHost`
+- The autorelayed hosts, instances of `AutoRelayHost`.
+
+How it works:
+- `AutoNATService` instances are instantiated in the
+  bootstrappers (or other well known publicly reachable hosts)
+
+- `RelayHost`s are constructed with
+  `libp2p.New(libp2p.EnableRelay(circuit.OptHop), libp2p.Routing(makeDHT))`.
+  They provide Relay Hop services, and advertise through the DHT
+  in the `/libp2p/relay` namespace
+
+- `AutoRelayHost`s are constructed with `libp2p.New(libp2p.Routing(makeDHT))`
+  They passively discover autonat service instances and test dialability of
+  their listen address set through them.  When the presence of NAT is detected,
+  they discover relays through the DHT, connect to some of them and begin
+  advertising relay addresses.  The new set of addresses is propagated to
+  connected peers through the `identify/push` protocol.
+
+*/
+package relay

--- a/p2p/host/relay/doc.go
+++ b/p2p/host/relay/doc.go
@@ -3,6 +3,8 @@ The relay package contains host implementations that automatically
 advertise relay addresses when the presence of NAT is detected. This
 feature is dubbed `autorelay`.
 
+Warning: the internal interfaces are unstable.
+
 System Components:
 - AutoNATService instances -- see https://github.com/libp2p/go-libp2p-autonat-svc
 - One or more relays, instances of `RelayHost`

--- a/p2p/host/relay/log.go
+++ b/p2p/host/relay/log.go
@@ -1,0 +1,7 @@
+package relay
+
+import (
+	logging "github.com/ipfs/go-log"
+)
+
+var log = logging.Logger("relay")

--- a/p2p/host/relay/log.go
+++ b/p2p/host/relay/log.go
@@ -4,4 +4,4 @@ import (
 	logging "github.com/ipfs/go-log"
 )
 
-var log = logging.Logger("relay")
+var log = logging.Logger("autorelay")

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -1,0 +1,23 @@
+package relay
+
+import (
+	"context"
+
+	discovery "github.com/libp2p/go-libp2p-discovery"
+	host "github.com/libp2p/go-libp2p-host"
+)
+
+// RelayHost is a Host that provides Relay services.
+type RelayHost struct {
+	host.Host
+	advertise discovery.Advertiser
+}
+
+// New constructs a new RelayHost
+func NewRelayHost(ctx context.Context, host host.Host, advertise discovery.Advertiser) *RelayHost {
+	h := &RelayHost{Host: host, advertise: advertise}
+	discovery.Advertise(ctx, advertise, "/libp2p/relay")
+	return h
+}
+
+var _ host.Host = (*RelayHost)(nil)

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -3,21 +3,34 @@ package relay
 import (
 	"context"
 
+	basic "github.com/libp2p/go-libp2p/p2p/host/basic"
+
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	host "github.com/libp2p/go-libp2p-host"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 // RelayHost is a Host that provides Relay services.
 type RelayHost struct {
-	host.Host
+	*basic.BasicHost
 	advertise discovery.Advertiser
+	addrsF    basic.AddrsFactory
 }
 
 // New constructs a new RelayHost
-func NewRelayHost(ctx context.Context, host host.Host, advertise discovery.Advertiser) *RelayHost {
-	h := &RelayHost{Host: host, advertise: advertise}
+func NewRelayHost(ctx context.Context, bhost *basic.BasicHost, advertise discovery.Advertiser) *RelayHost {
+	h := &RelayHost{
+		BasicHost: bhost,
+		addrsF:    bhost.AddrsFactory,
+		advertise: advertise,
+	}
+	bhost.AddrsFactory = h.hostAddrs
 	discovery.Advertise(ctx, advertise, "/libp2p/relay")
 	return h
+}
+
+func (h *RelayHost) hostAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
+	return filterUnspecificRelay(h.addrsF(addrs))
 }
 
 var _ host.Host = (*RelayHost)(nil)

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -25,7 +25,7 @@ func NewRelayHost(ctx context.Context, bhost *basic.BasicHost, advertise discove
 		advertise: advertise,
 	}
 	bhost.AddrsFactory = h.hostAddrs
-	discovery.Advertise(ctx, advertise, RelayRenezvous)
+	discovery.Advertise(ctx, advertise, RelayRendezvous)
 	return h
 }
 

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -25,7 +25,7 @@ func NewRelayHost(ctx context.Context, bhost *basic.BasicHost, advertise discove
 		advertise: advertise,
 	}
 	bhost.AddrsFactory = h.hostAddrs
-	discovery.Advertise(ctx, advertise, "/libp2p/relay")
+	discovery.Advertise(ctx, advertise, RelayRenezvous)
 	return h
 }
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -3,6 +3,7 @@ package identify
 import (
 	"context"
 	"sync"
+	"time"
 
 	pb "github.com/libp2p/go-libp2p/p2p/protocol/identify/pb"
 
@@ -22,6 +23,9 @@ var log = logging.Logger("net/identify")
 
 // ID is the protocol.ID of the Identify Service.
 const ID = "/ipfs/id/1.0.0"
+
+// IDPush is the protocol.ID of the Identify push protocol
+const IDPush = "/ipfs/id/push/1.0.0"
 
 // LibP2PVersion holds the current protocol version for a client running this code
 // TODO(jbenet): fix the versioning mess.
@@ -60,6 +64,7 @@ func NewIDService(h host.Host) *IDService {
 		currid: make(map[inet.Conn]chan struct{}),
 	}
 	h.SetStreamHandler(ID, s.requestHandler)
+	h.SetStreamHandler(IDPush, s.pushHandler)
 	h.Network().Notify((*netNotifiee)(s))
 	return s
 }
@@ -136,6 +141,24 @@ func (ids *IDService) responseHandler(s inet.Stream) {
 		c.RemotePeer(), c.RemoteMultiaddr())
 
 	go inet.FullClose(s)
+}
+
+func (ids *IDService) pushHandler(s inet.Stream) {
+	ids.responseHandler(s)
+}
+
+func (ids *IDService) Push() {
+	for _, p := range ids.Host.Network().Peers() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		s, err := ids.Host.NewStream(ctx, p, IDPush)
+		cancel()
+		if err != nil {
+			log.Debugf("error opening push stream: %s", err.Error())
+			continue
+		}
+
+		ids.requestHandler(s)
+	}
 }
 
 func (ids *IDService) populateMessage(mes *pb.Identify, c inet.Conn) {

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -149,15 +149,17 @@ func (ids *IDService) pushHandler(s inet.Stream) {
 
 func (ids *IDService) Push() {
 	for _, p := range ids.Host.Network().Peers() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		s, err := ids.Host.NewStream(ctx, p, IDPush)
-		cancel()
-		if err != nil {
-			log.Debugf("error opening push stream: %s", err.Error())
-			continue
-		}
+		go func(p peer.ID) {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			s, err := ids.Host.NewStream(ctx, p, IDPush)
+			if err != nil {
+				log.Debugf("error opening push stream: %s", err.Error())
+				return
+			}
 
-		ids.requestHandler(s)
+			ids.requestHandler(s)
+		}(p)
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -229,15 +229,15 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmYwn471zWPm7dLaEtNWMUj9ytMDFwnpFy1uMQDK3BZ4xj",
+      "hash": "QmfWLPvbWEHjMbEsLwCzg3igdeijJHDWhLth3k9E3imdEL",
       "name": "go-libp2p-discovery",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "author": "vyzo",
-      "hash": "QmNtEW59XTrreF9U4NAjYUmixEJ56HnfiJCj1p97bFnah2",
+      "hash": "QmUn8mtaf4tTFwKnFRzkNYYLc8XEo3yz6qBfp5ShVB1HYZ",
       "name": "go-libp2p-autonat",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   ],
   "gxVersion": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -226,6 +226,18 @@
       "hash": "QmdxUuburamoF6zF9qjeQC4WYcWGbWuRmdLacMEsW8ioD8",
       "name": "gogo-protobuf",
       "version": "0.0.0"
+    },
+    {
+      "author": "vyzo",
+      "hash": "QmYwn471zWPm7dLaEtNWMUj9ytMDFwnpFy1uMQDK3BZ4xj",
+      "name": "go-libp2p-discovery",
+      "version": "1.0.0"
+    },
+    {
+      "author": "vyzo",
+      "hash": "QmNtEW59XTrreF9U4NAjYUmixEJ56HnfiJCj1p97bFnah2",
+      "name": "go-libp2p-autonat",
+      "version": "1.0.0"
     }
   ],
   "gxVersion": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -229,15 +229,15 @@
     },
     {
       "author": "vyzo",
-      "hash": "QmfWLPvbWEHjMbEsLwCzg3igdeijJHDWhLth3k9E3imdEL",
+      "hash": "QmT8eNT96scr6wcrARzyxrCcsBAPKn9GkEx2TeXZniHiMP",
       "name": "go-libp2p-discovery",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "author": "vyzo",
-      "hash": "QmUn8mtaf4tTFwKnFRzkNYYLc8XEo3yz6qBfp5ShVB1HYZ",
+      "hash": "QmU2XQcwPxikg1jZqDBMFgLQVan7zjT2HtQWrWui3vbUVS",
       "name": "go-libp2p-autonat",
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
Implements autorelay; Closes #444.

Depends on:
- [X] https://github.com/libp2p/go-libp2p-discovery/pull/1
- [X] https://github.com/libp2p/go-libp2p-autonat/pull/2
- [X] https://github.com/multiformats/go-multiaddr-net/pull/46

TBD:
- [X] gx import discovery
- [X] gx import autonat
- [X] gx update multiaddr-net
- [X] Update `New` constructor to automatically create relay/autorelay/routed hosts
- [X] tests!