### PR TITLE
Add ping service in basic host and libp2p constructor option (enabled by default)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,9 @@ type Config struct {
 	NATManager  NATManagerC
 	Peerstore   pstore.Peerstore
 	Reporter    metrics.Reporter
+
+	PingCustom bool
+	Ping       bool
 }
 
 // NewNode constructs a new libp2p Host from the Config.
@@ -102,6 +105,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		ConnManager:  cfg.ConnManager,
 		AddrsFactory: cfg.AddrsFactory,
 		NATManager:   cfg.NATManager,
+		EnablePing:   cfg.Ping,
 	})
 	if err != nil {
 		swrm.Close()

--- a/defaults.go
+++ b/defaults.go
@@ -75,6 +75,11 @@ var DefaultEnableRelay = func(cfg *Config) error {
 	return cfg.Apply(EnableRelay())
 }
 
+// DefaultEnablePing enables the ping service by default
+var DefaultEnablePing = func(cfg *Config) error {
+	return cfg.Apply(Ping(true))
+}
+
 // Complete list of default options and when to fallback on them.
 //
 // Please *DON'T* specify default options any other way. Putting this all here
@@ -110,6 +115,10 @@ var defaults = []struct {
 	{
 		fallback: func(cfg *Config) bool { return !cfg.RelayCustom },
 		opt:      DefaultEnableRelay,
+	},
+	{
+		fallback: func(cfg *Config) bool { return !cfg.PingCustom },
+		opt:      DefaultEnablePing,
 	},
 }
 

--- a/options.go
+++ b/options.go
@@ -252,6 +252,15 @@ func NATManager(nm config.NATManagerC) Option {
 	}
 }
 
+// Ping will configure libp2p to support the ping service; enable by default.
+func Ping(enable bool) Option {
+	return func(cfg *Config) error {
+		cfg.PingCustom = true
+		cfg.Ping = enable
+		return nil
+	}
+}
+
 // NoListenAddrs will configure libp2p to not listen by default.
 //
 // This will both clear any configured listen addrs and prevent libp2p from

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -14,6 +14,7 @@ import (
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	protocol "github.com/libp2p/go-libp2p-protocol"
 	identify "github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	ping "github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	ma "github.com/multiformats/go-multiaddr"
 	madns "github.com/multiformats/go-multiaddr-dns"
 	msmux "github.com/multiformats/go-multistream"
@@ -56,6 +57,7 @@ type BasicHost struct {
 	network    inet.Network
 	mux        *msmux.MultistreamMuxer
 	ids        *identify.IDService
+	pings      *ping.PingService
 	natmgr     NATManager
 	addrs      AddrsFactory
 	maResolver *madns.Resolver
@@ -96,6 +98,9 @@ type HostOpts struct {
 
 	// ConnManager is a libp2p connection manager
 	ConnManager ifconnmgr.ConnManager
+
+	// EnablePing indicates whether to instantiate the ping service
+	EnablePing bool
 }
 
 // NewHost constructs a new *BasicHost and activates it by attaching its stream and connection handlers to the given inet.Network.
@@ -147,6 +152,10 @@ func NewHost(ctx context.Context, net inet.Network, opts *HostOpts) (*BasicHost,
 	} else {
 		h.cmgr = opts.ConnManager
 		net.Notify(h.cmgr.Notifee())
+	}
+
+	if opts.EnablePing {
+		h.pings = ping.NewPingService(h)
 	}
 
 	net.SetConnHandler(h.newConnHandler)

--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -72,7 +72,11 @@ func (p *PingService) PingHandler(s inet.Stream) {
 }
 
 func (ps *PingService) Ping(ctx context.Context, p peer.ID) (<-chan time.Duration, error) {
-	s, err := ps.Host.NewStream(ctx, p, ID)
+	return Ping(ctx, ps.Host, p)
+}
+
+func Ping(ctx context.Context, h host.Host, p peer.ID) (<-chan time.Duration, error) {
+	s, err := h.NewStream(ctx, p, ID)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +96,7 @@ func (ps *PingService) Ping(ctx context.Context, p peer.ID) (<-chan time.Duratio
 					return
 				}
 
-				ps.Host.Peerstore().RecordLatency(p, t)
+				h.Peerstore().RecordLatency(p, t)
 				select {
 				case out <- t:
 				case <-ctx.Done():

--- a/p2p/protocol/ping/ping_test.go
+++ b/p2p/protocol/ping/ping_test.go
@@ -1,4 +1,4 @@
-package ping
+package ping_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	ping "github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
 func TestPing(t *testing.T) {
@@ -26,14 +27,14 @@ func TestPing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ps1 := NewPingService(h1)
-	ps2 := NewPingService(h2)
+	ps1 := ping.NewPingService(h1)
+	ps2 := ping.NewPingService(h2)
 
 	testPing(t, ps1, h2.ID())
 	testPing(t, ps2, h1.ID())
 }
 
-func testPing(t *testing.T, ps *PingService, p peer.ID) {
+func testPing(t *testing.T, ps *ping.PingService, p peer.ID) {
 	pctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts, err := ps.Ping(pctx, p)


### PR DESCRIPTION
Adds the ping service to basic_host, with a libp2p constructor option to control its instantiation; it's enabled by default.