### PR TITLE
don't disconnect on protocol version mismatch

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -2,12 +2,10 @@ package identify
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	pb "github.com/libp2p/go-libp2p/p2p/protocol/identify/pb"
 
-	semver "github.com/coreos/go-semver/semver"
 	ggio "github.com/gogo/protobuf/io"
 	logging "github.com/ipfs/go-log"
 	ic "github.com/libp2p/go-libp2p-crypto"
@@ -225,15 +223,6 @@ func (ids *IDService) consumeMessage(mes *pb.Identify, c inet.Conn) {
 	pv := mes.GetProtocolVersion()
 	av := mes.GetAgentVersion()
 
-	// version check. if we shouldn't talk, bail.
-	// TODO: at this point, we've already exchanged information.
-	// move this into a first handshake before the connection can open streams.
-	if !protocolVersionsAreCompatible(pv, LibP2PVersion) {
-		logProtocolMismatchDisconnect(c, pv, av)
-		c.Close()
-		return
-	}
-
 	ids.Host.Peerstore().Put(p, "ProtocolVersion", pv)
 	ids.Host.Peerstore().Put(p, "AgentVersion", av)
 
@@ -404,31 +393,6 @@ func addrInAddrs(a ma.Multiaddr, as []ma.Multiaddr) bool {
 		}
 	}
 	return false
-}
-
-// protocolVersionsAreCompatible checks that the two implementations
-// can talk to each other. It will use semver, but for now while
-// we're in tight development, we will return false for minor version
-// changes too.
-func protocolVersionsAreCompatible(v1, v2 string) bool {
-	if strings.HasPrefix(v1, "ipfs/") {
-		v1 = v1[5:]
-	}
-	if strings.HasPrefix(v2, "ipfs/") {
-		v2 = v2[5:]
-	}
-
-	v1s, err := semver.NewVersion(v1)
-	if err != nil {
-		return false
-	}
-
-	v2s, err := semver.NewVersion(v2)
-	if err != nil {
-		return false
-	}
-
-	return v1s.Major == v2s.Major && v1s.Minor == v2s.Minor
 }
 
 // netNotifiee defines methods to be used with the IpfsDHT

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
   },
   "gxDependencies": [
     {
-      "hash": "QmcrrEpx3VMUbrbgVroH3YiYyUS5c4YAykzyPJWKspUYLa",
-      "name": "go-semver",
-      "version": "0.0.0"
-    },
-    {
       "hash": "QmekaTKpWkYGcn4ZEC5PwJDRCQHapwugmmG86g2Xpz5GBH",
       "name": "mdns",
       "version": "0.2.0"


### PR DESCRIPTION
Sending a protocol version is nice. However, this "disconnect if our versions are different" logic makes the version entirely useless (because we can't change it).

Really, each indevidual protocol is versioned so let's just leave it at that. If we make a breaking change that requires a protocol bump, we can do that and then switch on the other side's version. However, we'll have to wait for the entire network to upgrade for that to work.