### PR TITLE
fix a data-race in the mock net

### DIFF
--- a/p2p/net/mock/mock_stream.go
+++ b/p2p/net/mock/mock_stream.go
@@ -56,6 +56,11 @@ func (s *stream) Write(p []byte) (n int, err error) {
 	l := s.conn.link
 	delay := l.GetLatency() + l.RateLimit(len(p))
 	t := time.Now().Add(delay)
+
+	// Copy it.
+	cpy := make([]byte, len(p))
+	copy(cpy, p)
+
 	select {
 	case <-s.closed: // bail out if we're closing.
 		return 0, s.writeErr


### PR DESCRIPTION
This was causing https://github.com/ipfs/go-ipfs/pull/5637#issuecomment-432792969