### PR TITLE
mocknet: use peer ID in peer address

### DIFF
--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -3,6 +3,7 @@ package mocknet
 import (
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"sync"
 
@@ -17,9 +18,12 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	pstoremem "github.com/libp2p/go-libp2p-peerstore/pstoremem"
-	testutil "github.com/libp2p/go-testutil"
 	ma "github.com/multiformats/go-multiaddr"
 )
+
+// IP6 range that gets blackholed (in case our traffic ever makes it out onto
+// the internet).
+var blackholeIP6 = net.ParseIP("100::")
 
 // mocknet implements mocknet.Mocknet
 type mocknet struct {
@@ -54,8 +58,20 @@ func (mn *mocknet) GenPeer() (host.Host, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	a := testutil.RandLocalTCPAddress()
+	id, err := peer.IDFromPrivateKey(sk)
+	if err != nil {
+		return nil, err
+	}
+	suffix := id
+	if len(id) > 8 {
+		suffix = id[len(id)-8:]
+	}
+	ip := append(net.IP{}, blackholeIP6...)
+	copy(ip[net.IPv6len-len(suffix):], suffix)
+	a, err := ma.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/4242", ip))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create test multiaddr: %s", err)
+	}
 
 	h, err := mn.AddPeer(sk, a)
 	if err != nil {

--- a/p2p/net/mock/mock_test.go
+++ b/p2p/net/mock/mock_test.go
@@ -582,6 +582,14 @@ func TestLimitedStreams(t *testing.T) {
 		t.Fatal("Expected 2ish seconds but got ", time.Since(before))
 	}
 }
+func TestFuzzManyPeers(t *testing.T) {
+	for i := 0; i < 50000; i++ {
+		_, err := FullMeshConnected(context.Background(), 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
 
 func TestStreamsWithLatency(t *testing.T) {
 	latency := time.Millisecond * 500


### PR DESCRIPTION
RandLocalTCPAddress is mostly useful when we *actually* want to listen on a real
address. Unfortunately, when running a bunch of tests, we can actually run
out.

With this change, a collision means we have a duplicate peer ID so yeah...

fixes #473