### PR TITLE
deflake identify test

### DIFF
--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -88,7 +88,7 @@ func subtestIDService(t *testing.T) {
 	// Forget the first one.
 	testKnowsAddrs(t, h2, h1p, addrs[:len(addrs)-1])
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	// Forget the rest.
 	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{})


### PR DESCRIPTION
This was probably failing (rarely) due to the fact that we're shrinking the
timeout asynchronously (I think?).

fixes #478