### PR TITLE
Add delay in initial relay advertisement to allow the dht time to bootstrap

### DIFF
--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -26,9 +26,10 @@ import (
 
 // test specific parameters
 func init() {
-	autonat.AutoNATIdentifyDelay = 100 * time.Millisecond
+	autonat.AutoNATIdentifyDelay = 500 * time.Millisecond
 	autonat.AutoNATBootDelay = 1 * time.Second
 	relay.BootDelay = 1 * time.Second
+	relay.AdvertiseBootDelay = 1 * time.Millisecond
 	manet.Private4 = []*net.IPNet{}
 }
 

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -31,8 +31,11 @@ func NewRelayHost(ctx context.Context, bhost *basic.BasicHost, advertise discove
 	}
 	bhost.AddrsFactory = h.hostAddrs
 	go func() {
-		time.Sleep(AdvertiseBootDelay)
-		discovery.Advertise(ctx, advertise, RelayRendezvous)
+		select {
+		case <-time.After(AdvertiseBootDelay):
+			discovery.Advertise(ctx, advertise, RelayRendezvous)
+		case <-ctx.Done():
+		}
 	}()
 	return h
 }

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -2,12 +2,17 @@ package relay
 
 import (
 	"context"
+	"time"
 
 	basic "github.com/libp2p/go-libp2p/p2p/host/basic"
 
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	host "github.com/libp2p/go-libp2p-host"
 	ma "github.com/multiformats/go-multiaddr"
+)
+
+var (
+	AdvertiseBootDelay = 5 * time.Second
 )
 
 // RelayHost is a Host that provides Relay services.
@@ -25,7 +30,10 @@ func NewRelayHost(ctx context.Context, bhost *basic.BasicHost, advertise discove
 		advertise: advertise,
 	}
 	bhost.AddrsFactory = h.hostAddrs
-	discovery.Advertise(ctx, advertise, RelayRendezvous)
+	go func() {
+		time.Sleep(AdvertiseBootDelay)
+		discovery.Advertise(ctx, advertise, RelayRendezvous)
+	}()
 	return h
 }
 


### PR DESCRIPTION
This came up in https://github.com/libp2p/go-libp2p-discovery/issues/5

Also increases the test autonat identify delay to 500ms to make it less flaky in macos.