### PR TITLE
mdns: Grab lock on service entry before reading it

### DIFF
--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -152,6 +152,8 @@ func (m *mdnsService) pollForEntries(ctx context.Context) {
 }
 
 func (m *mdnsService) handleEntry(e *mdns.ServiceEntry) {
+	e.ReadLock.Lock()
+	defer e.ReadLock.Unlock()
 	log.Debugf("Handling MDNS entry: %s:%d %s", e.AddrV4, e.Port, e.Info)
 	mpeer, err := peer.IDB58Decode(e.Info)
 	if err != nil {


### PR DESCRIPTION
Depends on: https://github.com/whyrusleeping/mdns/pull/4

We are seeing some data races downstream in https://github.com/prysmaticlabs/prysm

```
==================
WARNING: DATA RACE
Write at 0x00c00031a738 by goroutine 105:
  github.com/whyrusleeping/mdns.(*client).query()
      external/com_github_whyrusleeping_mdns/client.go:271 +0xbd9
  github.com/whyrusleeping/mdns.Query()
      external/com_github_whyrusleeping_mdns/client.go:87 +0xf4
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:137 +0x23d

Previous read at 0x00c00031a738 by goroutine 107:
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).handleEntry()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:156 +0x25b
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries.func1()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:125 +0x56

Goroutine 105 (running) created at:
  github.com/libp2p/go-libp2p/p2p/discovery.NewMdnsService()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:108 +0x6b5
  github.com/prysmaticlabs/prysm/shared/p2p.startmDNSDiscovery()
      shared/p2p/discovery.go:26 +0xc5
  github.com/prysmaticlabs/prysm/shared/p2p.(*Server).Start()
      shared/p2p/service.go:132 +0x1e3
  github.com/prysmaticlabs/prysm/shared/p2p.TestStartDialRelayNodeFails()
      shared/p2p/service_test.go:49 +0x11c
  testing.tRunner()
      GOROOT/src/testing/testing.go:827 +0x162

Goroutine 107 (running) created at:
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:123 +0xe3
==================
```

This PR (along with the dependent PR) resolve our downstream data race issue. 