### PR TITLE
Use PeerRouting in autorelay to find relay peer addresses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -208,7 +208,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		if hop {
 			h = relay.NewRelayHost(swrm.Context(), h.(*bhost.BasicHost), discovery)
 		} else {
-			h = relay.NewAutoRelayHost(swrm.Context(), h.(*bhost.BasicHost), discovery)
+			h = relay.NewAutoRelayHost(swrm.Context(), h.(*bhost.BasicHost), discovery, router)
 		}
 	}
 

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -16,6 +16,7 @@ import (
 	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	routing "github.com/libp2p/go-libp2p-routing"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 )
@@ -44,6 +45,7 @@ func init() {
 type AutoRelayHost struct {
 	*basic.BasicHost
 	discover discovery.Discoverer
+	router   routing.PeerRouting
 	autonat  autonat.AutoNAT
 	addrsF   basic.AddrsFactory
 
@@ -54,10 +56,11 @@ type AutoRelayHost struct {
 	addrs  []ma.Multiaddr
 }
 
-func NewAutoRelayHost(ctx context.Context, bhost *basic.BasicHost, discover discovery.Discoverer) *AutoRelayHost {
+func NewAutoRelayHost(ctx context.Context, bhost *basic.BasicHost, discover discovery.Discoverer, router routing.PeerRouting) *AutoRelayHost {
 	h := &AutoRelayHost{
 		BasicHost:  bhost,
 		discover:   discover,
+		router:     router,
 		addrsF:     bhost.AddrsFactory,
 		relays:     make(map[peer.ID]pstore.PeerInfo),
 		disconnect: make(chan struct{}, 1),
@@ -148,6 +151,16 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 		h.mx.Unlock()
 
 		cctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+
+		if len(pi.Addrs) == 0 {
+			pi, err = h.router.FindPeer(cctx, pi.ID)
+			if err != nil {
+				log.Debugf("error finding relay peer %s: %s", pi.ID, err.Error())
+				cancel()
+				continue
+			}
+		}
+
 		err = h.Connect(cctx, pi)
 		cancel()
 		if err != nil {


### PR DESCRIPTION
Fixes a subtle bug: if the discovery module returns no addresses for the relay peers, then we might not be able to connect to them because we only have a basic host.
