### PR TITLE
increase initial relay advertisement delay to 30s

### DIFF
--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	AdvertiseBootDelay = 5 * time.Second
+	AdvertiseBootDelay = 30 * time.Second
 )
 
 // RelayHost is a Host that provides Relay services.


### PR DESCRIPTION
5s is too short to initialize the DHT.