### PR TITLE
Fix typos in p2p/net/README.md

### DIFF
--- a/p2p/net/README.md
+++ b/p2p/net/README.md
@@ -4,9 +4,9 @@ The IPFS Network package handles all of the peer-to-peer networking. It connects
 
 - `Conn` - a connection to a single Peer
   - `MultiConn` - a set of connections to a single Peer
-  - `SecureConn` - an encrypted (tls-like) connection
+  - `SecureConn` - an encrypted (TLS-like) connection
 - `Swarm` - holds connections to Peers, multiplexes from/to each `MultiConn`
-- `Muxer` - multiplexes between `Services` and `Swarm`. Handles `Requet/Reply`.
+- `Muxer` - multiplexes between `Services` and `Swarm`. Handles `Request/Reply`.
   - `Service` - connects between an outside client service and Network.
   - `Handler` - the client service part that handles requests
 


### PR DESCRIPTION
"Requet" -> "Request", "tls" -> "TLS"