### PR TITLE
Fix UDP listen on a Unspecified Address and Dial from the Unspecified Address

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -413,7 +413,7 @@ func (ids *IDService) consumeObservedAddress(observed []byte, c inet.Conn) {
 	}
 
 	log.Debugf("identify identifying observed multiaddr: %s %s", c.LocalMultiaddr(), ifaceaddrs)
-	if !addrInAddrs(c.LocalMultiaddr(), ifaceaddrs) {
+	if !addrInAddrs(c.LocalMultiaddr(), ifaceaddrs) && !addrInAddrs(c.LocalMultiaddr(), ids.Host.Network().ListenAddresses()) {
 		// not in our list
 		return
 	}


### PR DESCRIPTION
LocalMultiaddr May return the Unspecified Address, if so, we need to
check if we listen on the Unspecified address and they were equal.