### PR TITLE
Reduce autorelay boot delay and correctly handle private->public transition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
 	github.com/libp2p/go-conn-security v0.0.1
 	github.com/libp2p/go-conn-security-multistream v0.0.1
-	github.com/libp2p/go-libp2p-autonat v0.0.2
+	github.com/libp2p/go-libp2p-autonat v0.0.3
 	github.com/libp2p/go-libp2p-blankhost v0.0.1
 	github.com/libp2p/go-libp2p-circuit v0.0.1
 	github.com/libp2p/go-libp2p-crypto v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/libp2p/go-libp2p-autonat v0.0.1 h1:d5eskFxeJ4ag1ekhMC3yLTK+z+6RTw9W1Y
 github.com/libp2p/go-libp2p-autonat v0.0.1/go.mod h1:fs71q5Xk+pdnKU014o2iq1RhMs9/PMaG5zXRFNnIIT4=
 github.com/libp2p/go-libp2p-autonat v0.0.2 h1:ilo9QPzNPf1hMkqaPG55yzvhILf5ZtijstJhcii+l3s=
 github.com/libp2p/go-libp2p-autonat v0.0.2/go.mod h1:fs71q5Xk+pdnKU014o2iq1RhMs9/PMaG5zXRFNnIIT4=
+github.com/libp2p/go-libp2p-autonat v0.0.3 h1:PUD+pAx8Qs9hh+Bowzxq8RCkg/Vwrz5oCFC4peixXQk=
+github.com/libp2p/go-libp2p-autonat v0.0.3/go.mod h1:fs71q5Xk+pdnKU014o2iq1RhMs9/PMaG5zXRFNnIIT4=
 github.com/libp2p/go-libp2p-blankhost v0.0.1 h1:/mZuuiwntNR8RywnCFlGHLKrKLYne+qciBpQXWqp5fk=
 github.com/libp2p/go-libp2p-blankhost v0.0.1/go.mod h1:Ibpbw/7cPPYwFb7PACIWdvxxv0t0XCCI10t7czjAjTc=
 github.com/libp2p/go-libp2p-circuit v0.0.1 h1:DYbjyQ5ZY3QVAVYZWG4uzBQ6Wmcd1C82Bk8Q/pJlM1I=

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -122,7 +122,7 @@ func (h *AutoRelayHost) findRelays(ctx context.Context) {
 		limit = 2 * need
 	}
 
-	dctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	pis, err := discovery.FindPeers(dctx, h.discover, RelayRendezvous, limit)
 	cancel()
 	if err != nil {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -28,7 +28,7 @@ const (
 var (
 	DesiredRelays = 3
 
-	BootDelay = 60 * time.Second
+	BootDelay = 30 * time.Second
 
 	unspecificRelay = ma.StringCast("/p2p-circuit")
 )

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -28,7 +28,7 @@ const (
 var (
 	DesiredRelays = 3
 
-	BootDelay = 30 * time.Second
+	BootDelay = 20 * time.Second
 
 	unspecificRelay = ma.StringCast("/p2p-circuit")
 )


### PR DESCRIPTION
Reduces the autorelay boot delay to take advantage of recent autonat optimizations and also correctly handles the private->public transition by scheduling an identify push in that case.

Depends on https://github.com/libp2p/go-libp2p-autonat/pull/20 [go mod update needed]
