### PR TITLE
identify: only store _reported_ multiaddrs

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -238,11 +238,8 @@ func (ids *IDService) consumeMessage(mes *pb.Identify, c inet.Conn) {
 		lmaddrs = append(lmaddrs, maddr)
 	}
 
-	// if the address reported by the connection roughly matches their annoucned
-	// listener addresses, its likely to be an external NAT address
-	if HasConsistentTransport(c.RemoteMultiaddr(), lmaddrs) {
-		lmaddrs = append(lmaddrs, c.RemoteMultiaddr())
-	}
+	// NOTE: Do not add `c.RemoteMultiaddr()` to the peerstore if the remote
+	// peer doesn't tell us to do so. Otherwise, we'll advertise it.
 
 	// Extend the TTLs on the known (probably) good addresses.
 	// Taking the lock ensures that we don't concurrently process a disconnect.

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -409,6 +409,11 @@ func (ids *IDService) consumeObservedAddress(observed []byte, c inet.Conn) {
 		return
 	}
 
+	if !HasConsistentTransport(c.RemoteMultiaddr(), ids.Host.Addrs()) {
+		log.Debugf("ignoring observed multiaddr that doesn't match the transports of any addresses we're announcing", c.RemoteMultiaddr())
+		return
+	}
+
 	log.Debugf("identify identifying observed multiaddr: %s %s", c.LocalMultiaddr(), ifaceaddrs)
 	if !addrInAddrs(c.LocalMultiaddr(), ifaceaddrs) && !addrInAddrs(c.LocalMultiaddr(), ids.Host.Network().ListenAddresses()) {
 		// not in our list


### PR DESCRIPTION
We still tell the remote host about the observed addr but we don't store it. That way, we give them a chance to decide if they want to actually use and advertise it.

Ideally, we'd distinguish between local information and signed routing information but we don't do that yet.

Hopefully this will prevent nodes behind relays from telling everyone else to connect to their peers through these relays.