### PR TITLE
identify: be more careful about the addresses we store

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -240,6 +240,11 @@ func (ids *IDService) consumeMessage(mes *pb.Identify, c inet.Conn) {
 
 	// NOTE: Do not add `c.RemoteMultiaddr()` to the peerstore if the remote
 	// peer doesn't tell us to do so. Otherwise, we'll advertise it.
+	//
+	// This can cause an "addr-splosion" issue where the network will slowly
+	// gossip and collect observed but unadvertised addresses. Given a NAT
+	// that picks random source ports, this can cause DHT nodes to collect
+	// many undialable addresses for other peers.
 
 	// Extend the TTLs on the known (probably) good addresses.
 	// Taking the lock ensures that we don't concurrently process a disconnect.
@@ -412,6 +417,11 @@ func (ids *IDService) consumeObservedAddress(observed []byte, c inet.Conn) {
 	log.Debugf("identify identifying observed multiaddr: %s %s", c.LocalMultiaddr(), ifaceaddrs)
 	if !addrInAddrs(c.LocalMultiaddr(), ifaceaddrs) && !addrInAddrs(c.LocalMultiaddr(), ids.Host.Network().ListenAddresses()) {
 		// not in our list
+		return
+	}
+
+	if !HasConsistentTransport(maddr, ids.Host.Addrs()) {
+		log.Debugf("ignoring observed multiaddr that doesn't match the transports of any addresses we're announcing", c.RemoteMultiaddr())
 		return
 	}
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -238,11 +238,8 @@ func (ids *IDService) consumeMessage(mes *pb.Identify, c inet.Conn) {
 		lmaddrs = append(lmaddrs, maddr)
 	}
 
-	// if the address reported by the connection roughly matches their annoucned
-	// listener addresses, its likely to be an external NAT address
-	if HasConsistentTransport(c.RemoteMultiaddr(), lmaddrs) {
-		lmaddrs = append(lmaddrs, c.RemoteMultiaddr())
-	}
+	// NOTE: Do not add `c.RemoteMultiaddr()` to the peerstore if the remote
+	// peer doesn't tell us to do so. Otherwise, we'll advertise it.
 
 	// Extend the TTLs on the known (probably) good addresses.
 	// Taking the lock ensures that we don't concurrently process a disconnect.


### PR DESCRIPTION
1. Never record addresses _we_ observe. Only store addresses if a peer tells us to. This could make dialing back a bit harder but should give nodes more control over the addresses they care to advertise.
2. Only record reported observed addresses if they match the transports of some address we're already advertising. For example, we should only advertise relay addresses if we're already advertising other relay addresses.

Note: I don't believe this is related to #575 but, IMO, it's still a good idea.