### PR TITLE
identify: avoid parsing/printing multiaddrs

### DIFF
--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -167,7 +167,8 @@ func (oas *ObservedAddrSet) Add(observed, local, observer ma.Multiaddr,
 // IP addresses. In practice, this is what we want.
 func observerGroup(m ma.Multiaddr) string {
 	//TODO: If IPv6 rolls out we should mark /64 routing zones as one group
-	return ma.Split(m)[0].String()
+	first, _ := ma.SplitFirst(m)
+	return string(first.Bytes())
 }
 
 func (oas *ObservedAddrSet) SetTTL(ttl time.Duration) {


### PR DESCRIPTION
1. Don't bother formatting the address as a _string_.
2. Use SplitFirst to avoid parsing the entire address.