### PR TITLE
Improve observed address handling

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -132,7 +132,7 @@ func NewHost(ctx context.Context, net inet.Network, opts *HostOpts) (*BasicHost,
 		h.ids = opts.IdentifyService
 	} else {
 		// we can't set this as a default above because it depends on the *BasicHost.
-		h.ids = identify.NewIDService(h)
+		h.ids = identify.NewIDService(ctx, h)
 	}
 
 	if uint64(opts.NegotiationTimeout) != 0 {

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -53,15 +53,16 @@ type IDService struct {
 
 	// our own observed addresses.
 	// TODO: instead of expiring, remove these when we disconnect
-	observedAddrs ObservedAddrSet
+	observedAddrs *ObservedAddrSet
 }
 
 // NewIDService constructs a new *IDService and activates it by
 // attaching its stream handler to the given host.Host.
-func NewIDService(h host.Host) *IDService {
+func NewIDService(ctx context.Context, h host.Host) *IDService {
 	s := &IDService{
-		Host:   h,
-		currid: make(map[inet.Conn]chan struct{}),
+		Host:          h,
+		currid:        make(map[inet.Conn]chan struct{}),
+		observedAddrs: NewObservedAddrSet(ctx),
 	}
 	h.SetStreamHandler(ID, s.requestHandler)
 	h.SetStreamHandler(IDPush, s.pushHandler)

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -26,8 +26,8 @@ func subtestIDService(t *testing.T) {
 	h1p := h1.ID()
 	h2p := h2.ID()
 
-	ids1 := identify.NewIDService(h1)
-	ids2 := identify.NewIDService(h2)
+	ids1 := identify.NewIDService(ctx, h1)
+	ids2 := identify.NewIDService(ctx, h2)
 
 	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{}) // nothing
 	testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{}) // nothing

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -160,7 +160,11 @@ func (oas *ObservedAddrSet) gc() {
 				filteredAddrs = append(filteredAddrs, a)
 			}
 		}
-		oas.addrs[local] = filteredAddrs
+		if len(filteredAddrs) > 0 {
+			oas.addrs[local] = filteredAddrs
+		} else {
+			delete(oas.addrs, local)
+		}
 	}
 }
 

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -66,6 +66,7 @@ type ObservedAddrSet struct {
 func NewObservedAddrSet(ctx context.Context) *ObservedAddrSet {
 	oas := &ObservedAddrSet{
 		addrs: make(map[string][]*ObservedAddr),
+		ttl:   pstore.OwnObservedAddrTTL,
 		wch:   make(chan newObservation, 1),
 	}
 	go oas.worker(ctx)
@@ -78,7 +79,6 @@ func (oas *ObservedAddrSet) AddrsFor(addr ma.Multiaddr) (addrs []ma.Multiaddr) {
 	oas.Lock()
 	defer oas.Unlock()
 
-	// for zero-value.
 	if len(oas.addrs) == 0 {
 		return nil
 	}
@@ -104,7 +104,6 @@ func (oas *ObservedAddrSet) Addrs() (addrs []ma.Multiaddr) {
 	oas.Lock()
 	defer oas.Unlock()
 
-	// for zero-value.
 	if len(oas.addrs) == 0 {
 		return nil
 	}
@@ -178,12 +177,6 @@ func (oas *ObservedAddrSet) doAdd(observed, local, observer ma.Multiaddr,
 
 	oas.Lock()
 	defer oas.Unlock()
-
-	// for zero-value.
-	if oas.addrs == nil {
-		oas.addrs = make(map[string][]*ObservedAddr)
-		oas.ttl = pstore.OwnObservedAddrTTL
-	}
 
 	observedAddrs := oas.addrs[localString]
 	// check if observed address seen yet, if so, update it

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -67,7 +67,7 @@ func NewObservedAddrSet(ctx context.Context) *ObservedAddrSet {
 	oas := &ObservedAddrSet{
 		addrs: make(map[string][]*ObservedAddr),
 		ttl:   pstore.OwnObservedAddrTTL,
-		wch:   make(chan newObservation, 1),
+		wch:   make(chan newObservation, 16),
 	}
 	go oas.worker(ctx)
 	return oas

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -53,7 +53,7 @@ type newObservation struct {
 // ObservedAddrSet keeps track of a set of ObservedAddrs
 // the zero-value is ready to be used.
 type ObservedAddrSet struct {
-	sync.Mutex // guards whole datastruct.
+	sync.RWMutex // guards whole datastruct.
 
 	// local(internal) address -> list of observed(external) addresses
 	addrs map[string][]*ObservedAddr
@@ -76,8 +76,8 @@ func NewObservedAddrSet(ctx context.Context) *ObservedAddrSet {
 // AddrsFor return all activated observed addresses associated with the given
 // (resolved) listen address.
 func (oas *ObservedAddrSet) AddrsFor(addr ma.Multiaddr) (addrs []ma.Multiaddr) {
-	oas.Lock()
-	defer oas.Unlock()
+	oas.RLock()
+	defer oas.RUnlock()
 
 	if len(oas.addrs) == 0 {
 		return nil
@@ -101,8 +101,8 @@ func (oas *ObservedAddrSet) AddrsFor(addr ma.Multiaddr) (addrs []ma.Multiaddr) {
 
 // Addrs return all activated observed addresses
 func (oas *ObservedAddrSet) Addrs() (addrs []ma.Multiaddr) {
-	oas.Lock()
-	defer oas.Unlock()
+	oas.RLock()
+	defer oas.RUnlock()
 
 	if len(oas.addrs) == 0 {
 		return nil
@@ -220,11 +220,7 @@ func (oas *ObservedAddrSet) SetTTL(ttl time.Duration) {
 }
 
 func (oas *ObservedAddrSet) TTL() time.Duration {
-	oas.Lock()
-	defer oas.Unlock()
-	// for zero-value.
-	if oas.addrs == nil {
-		oas.ttl = pstore.OwnObservedAddrTTL
-	}
+	oas.RLock()
+	defer oas.RUnlock()
 	return oas.ttl
 }

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -70,20 +70,10 @@ func (oas *ObservedAddrSet) AddrsFor(addr ma.Multiaddr) (addrs []ma.Multiaddr) {
 	}
 
 	now := time.Now()
-	filteredAddrs := make([]*ObservedAddr, 0, len(observedAddrs))
 	for _, a := range observedAddrs {
-		// leave only alive observed addresses
-		if now.Sub(a.LastSeen) <= oas.ttl {
-			filteredAddrs = append(filteredAddrs, a)
-			if a.activated(oas.ttl) {
-				addrs = append(addrs, a.Addr)
-			}
+		if now.Sub(a.LastSeen) <= oas.ttl && a.activated(oas.ttl) {
+			addrs = append(addrs, a.Addr)
 		}
-	}
-	if len(filteredAddrs) > 0 {
-		oas.addrs[key] = filteredAddrs
-	} else {
-		delete(oas.addrs, key)
 	}
 
 	return addrs
@@ -100,18 +90,12 @@ func (oas *ObservedAddrSet) Addrs() (addrs []ma.Multiaddr) {
 	}
 
 	now := time.Now()
-	for local, observedAddrs := range oas.addrs {
-		filteredAddrs := make([]*ObservedAddr, 0, len(observedAddrs))
+	for _, observedAddrs := range oas.addrs {
 		for _, a := range observedAddrs {
-			// leave only alive observed addresses
-			if now.Sub(a.LastSeen) <= oas.ttl {
-				filteredAddrs = append(filteredAddrs, a)
-				if a.activated(oas.ttl) {
-					addrs = append(addrs, a.Addr)
-				}
+			if now.Sub(a.LastSeen) <= oas.ttl && a.activated(oas.ttl) {
+				addrs = append(addrs, a.Addr)
 			}
 		}
-		oas.addrs[local] = filteredAddrs
 	}
 	return addrs
 }

--- a/p2p/protocol/identify/obsaddr_test.go
+++ b/p2p/protocol/identify/obsaddr_test.go
@@ -1,6 +1,7 @@
 package identify
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -52,7 +53,9 @@ func TestObsAddrSet(t *testing.T) {
 	b4 := m("/ip4/1.2.3.9/tcp/1237")
 	b5 := m("/ip4/1.2.3.10/tcp/1237")
 
-	oas := &ObservedAddrSet{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	oas := NewObservedAddrSet(ctx)
 
 	if !addrsMarch(oas.Addrs(), nil) {
 		t.Error("addrs should be empty")
@@ -63,6 +66,7 @@ func TestObsAddrSet(t *testing.T) {
 		dummyDirection := net.DirOutbound
 
 		oas.Add(observed, dummyLocal, observer, dummyDirection)
+		time.Sleep(1 * time.Millisecond) // let the worker run
 	}
 
 	add(oas, a1, a4)
@@ -131,13 +135,17 @@ func TestAddAddrsProfile(b *testing.T) {
 		}
 		return m
 	}
-	oas := &ObservedAddrSet{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	oas := NewObservedAddrSet(ctx)
 
 	add := func(oas *ObservedAddrSet, observed, observer ma.Multiaddr) {
 		dummyLocal := m("/ip4/127.0.0.1/tcp/10086")
 		dummyDirection := net.DirOutbound
 
 		oas.Add(observed, dummyLocal, observer, dummyDirection)
+		time.Sleep(1 * time.Millisecond) // let the worker run
 	}
 
 	a1 := m("/ip4/1.2.3.4/tcp/1231")


### PR DESCRIPTION
Overhauls the observed address set to be more friendly to relays:
- Optimizes the lock contention in Addrs, AddrsFor by stopping the eager clean up of expired entries
- Adds a background worker for adding and gc'ing observed address, with a very short buffer

Closes #584 