### PR TITLE
Deprecate gx in readme & link to workspace repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,29 +83,31 @@ Examples can be found in the [examples repo](https://github.com/libp2p/go-libp2p
 
 ## Development
 
-### Dependencies
+### Using the libp2p workspace
 
-While developing, you need to use [gx to install and link your dependencies](https://github.com/whyrusleeping/gx#dependencies), to do that, run:
+While developing, you may need to make changes to several modules at once, or you may want changes made locally in one module to be available for import by another.
 
-```sh
-> make deps
-```
+The [go libp2p workspace](https://github.com/libp2p/workspace-go-libp2p) provides a developer-oriented view of the modules that comprise go-libp2p. 
 
-Before commiting and pushing to Github, make sure to rewind the gx'ify of dependencies. You can do that with:
+Using the tooling in the workspace repository, you can checkout all of go-libp2p's module repos and enter "local mode", which adds [replace directives](https://github.com/golang/go/wiki/Modules#gomod) to the go.mod files in each local working copy. When you build locally, the libp2p depdendencies will be resolved from your local working copies.
 
-```sh
-> make publish
-```
+Once you've committed your changes, you can switch back to "remote mode", which removes the replace directives and pulls imports from the main go module cache.
+
+See the [workspace repo](https://github.com/libp2p/workspace-go-libp2p) for more information.
+
+### About gx
+
+Before adopting gomod, libp2p used [gx](https://github.com/whyrusleeping/gx) to manage dependencies using [IPFS](https://ipfs.io).
+
+Due to the difficulties in keeping both dependency management solutions up-to-date, gx support was ended in April 2019.
+
+Ending gx support does not mean that existing gx builds will break. Because gx references dependencies by their immutable IPFS hash, any currently working gx builds will continue to work for as long as the dependencies are resolvable in IPFS.
+
+However, new changes to go-libp2p will not be published via gx, and users are encouraged to adopt gomod to stay up-to-date.
 
 ### Tests
 
-Running of individual tests is done through `gx test <path to test>`
-
-```bash
-$ cd $GOPATH/src/github.com/libp2p/go-libp2p
-$ make deps
-$ gx test ./p2p/<path of module you want to run tests for>
-```
+`go test ./...` will run all tests in the repo. 
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,15 @@
 # Table of Contents
 
 - [Background](#background)
-- [Bundles](#bundles)
 - [Usage](#usage)
-  - [Install](#install)
   - [API](#api)
   - [Examples](#examples)
 - [Development](#development)
+  - [Using the libp2p Workspace](#using-the-libp2p-workspace)
+  - [About gx](#about-gx)
   - [Tests](#tests)
   - [Packages](#packages)
 - [Contribute](#contribute)
-- [License](#license)
 
 ## Background
 
@@ -83,7 +82,7 @@ Examples can be found in the [examples repo](https://github.com/libp2p/go-libp2p
 
 ## Development
 
-### Using the libp2p workspace
+### Using the libp2p Workspace
 
 While developing, you may need to make changes to several modules at once, or you may want changes made locally in one module to be available for import by another.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Ending gx support does not mean that existing gx builds will break. Because gx r
 
 However, new changes to go-libp2p will not be published via gx, and users are encouraged to adopt gomod to stay up-to-date.
 
+If you experience any issues migrating from gx to gomod, please [join the discussion at the libp2p forums](https://discuss.libp2p.io/t/gomod-and-go-libp2p/44).
+
 ### Tests
 
 `go test ./...` will run all tests in the repo. 


### PR DESCRIPTION
Following on with https://github.com/libp2p/go-libp2p/issues/589, we want to go all in on gomod.

This removes instructions for using `gx` and adds a link to the https://github.com/libp2p/workspace-go-libp2p repo, with some context on why you should use it.

I also added an "About gx" section for people that are or were using it to encourage them to make the switch.