### PR TITLE
Periodically schedule identify push if the address set has changed

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -228,6 +228,9 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		}
 	}
 
+	// start the host background tasks
+	h.Start()
+
 	if router != nil {
 		return routed.Wrap(h, router), nil
 	}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -289,6 +289,9 @@ func (h *BasicHost) PushIdentify() {
 }
 
 func (h *BasicHost) background(ctx context.Context) {
+	// wait a bit for the host to initialize (avoid race with libp2p constructor)
+	time.Sleep(1 * time.Second)
+
 	// periodically schedules an IdentifyPush to update our peers for changes
 	// in our address set (if needed)
 	ticker := time.NewTicker(1 * time.Minute)

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -323,7 +323,7 @@ func sameAddrs(a, b []ma.Multiaddr) bool {
 		return false
 	}
 
-	bmap := make(map[string]struct{})
+	bmap := make(map[string]struct{}, len(b))
 	for _, addr := range b {
 		bmap[string(addr.Bytes())] = struct{}{}
 	}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -323,23 +323,19 @@ func sameAddrs(a, b []ma.Multiaddr) bool {
 		return false
 	}
 
-	// this is O(n*m), might be worth using a map to turn into O(n+m)
+	bmap := make(map[string]struct{})
+	for _, addr := range b {
+		bmap[string(addr.Bytes())] = struct{}{}
+	}
+
 	for _, addr := range a {
-		if !findAddr(addr, b) {
+		_, ok := bmap[string(addr.Bytes())]
+		if !ok {
 			return false
 		}
 	}
 
 	return true
-}
-
-func findAddr(addr ma.Multiaddr, addrs []ma.Multiaddr) bool {
-	for _, xaddr := range addrs {
-		if addr.Equal(xaddr) {
-			return true
-		}
-	}
-	return false
 }
 
 // ID returns the (local) peer.ID associated with this Host

--- a/p2p/net/mock/mock_test.go
+++ b/p2p/net/mock/mock_test.go
@@ -588,7 +588,7 @@ func TestLimitedStreams(t *testing.T) {
 func TestFuzzManyPeers(t *testing.T) {
 	peerCount := 50000
 	if detectrace.WithRace() {
-		peerCount = 1000
+		peerCount = 100
 	}
 	for i := 0; i < peerCount; i++ {
 		_, err := FullMeshConnected(context.Background(), 2)

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -47,6 +47,8 @@ const transientTTL = 10 * time.Second
 type IDService struct {
 	Host host.Host
 
+	ctx context.Context
+
 	// connections undergoing identification
 	// for wait purposes
 	currid map[inet.Conn]chan struct{}
@@ -64,6 +66,7 @@ type IDService struct {
 func NewIDService(ctx context.Context, h host.Host) *IDService {
 	s := &IDService{
 		Host:          h,
+		ctx:           ctx,
 		currid:        make(map[inet.Conn]chan struct{}),
 		observedAddrs: NewObservedAddrSet(ctx),
 	}
@@ -162,7 +165,7 @@ func (ids *IDService) Push() {
 	// stream over an existing connection. This would avoid the need for the
 	// supervisory goroutine below, but timeout-less contexts in network operations
 	// make me nervous.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(ids.ctx, 15*time.Second)
 	ctx = inet.WithNoDial(ctx, "identify push")
 
 	for _, p := range ids.Host.Network().Peers() {


### PR DESCRIPTION
Adds a background task to basic host, that periodically schedules an identify push if the address set has changed.