### PR TITLE
autorelay: curtail addrsplosion

### DIFF
--- a/p2p/host/relay/addrsplosion.go
+++ b/p2p/host/relay/addrsplosion.go
@@ -118,16 +118,30 @@ func sanitizeAddrsplodedSet(public, private []ma.Multiaddr) []ma.Multiaddr {
 	var result []ma.Multiaddr
 	for _, pas := range pubaddrs {
 		if len(pas) == 1 {
+			// it's not addrsploded
 			result = append(result, pas[0].addr)
 			continue
 		}
 
+		haveAddr := false
 		for _, pa := range pas {
 			if pa.port == 4001 || pa.port == 4002 {
+				// it's a default port, use it
 				result = append(result, pa.addr)
+				haveAddr = true
 				continue
 			}
+
 			if _, ok := privports[pa.port]; ok {
+				// it matches a privately bound port, use it
+				result = append(result, pa.addr)
+				haveAddr = true
+			}
+		}
+
+		if !haveAddr {
+			// we weren't able to select a port; bite the bullet and use them all
+			for _, pa := range pas {
 				result = append(result, pa.addr)
 			}
 		}

--- a/p2p/host/relay/addrsplosion.go
+++ b/p2p/host/relay/addrsplosion.go
@@ -1,0 +1,137 @@
+package relay
+
+import (
+	"encoding/binary"
+
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr-net"
+)
+
+// This function cleans up a relay's address set to remove private addresses and curtail
+// addrsplosion.
+func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
+	var public, private []ma.Multiaddr
+
+	for _, a := range pi.Addrs {
+		if manet.IsPublicAddr(a) || isDNSAddr(a) {
+			public = append(public, a)
+			continue
+		}
+
+		// discard unroutable addrs
+		if manet.IsPrivateAddr(a) {
+			private = append(private, a)
+		}
+	}
+
+	if !hasAddrsplosion(public) {
+		return pstore.PeerInfo{ID: pi.ID, Addrs: public}
+	}
+
+	addrs := sanitizeAddrsplodedSet(public, private)
+	return pstore.PeerInfo{ID: pi.ID, Addrs: addrs}
+}
+
+func isDNSAddr(a ma.Multiaddr) bool {
+	dnsaddr := false
+	ma.ForEach(a, func(c ma.Component) bool {
+		switch c.Protocol().Code {
+		case 54, 55, 56:
+			dnsaddr = true
+		}
+
+		return false
+	})
+
+	return dnsaddr
+}
+
+// we have addrsplosion if for some protocol we advertise multiple ports on
+// the same base address.
+func hasAddrsplosion(addrs []ma.Multiaddr) bool {
+	aset := make(map[string]int)
+
+	for _, a := range addrs {
+		key, port := addrKeyAndPort(a)
+		xport, ok := aset[key]
+		if ok && port != xport {
+			return true
+		}
+		aset[key] = port
+	}
+
+	return false
+}
+
+func addrKeyAndPort(a ma.Multiaddr) (string, int) {
+	var (
+		key  string
+		port int
+	)
+
+	ma.ForEach(a, func(c ma.Component) bool {
+		switch c.Protocol().Code {
+		case ma.P_TCP, ma.P_UDP:
+			port = int(binary.BigEndian.Uint16(c.RawValue()))
+			key += "/" + c.Protocol().Name
+		default:
+			val := c.Value()
+			if val == "" {
+				val = c.Protocol().Name
+			}
+			key += "/" + val
+		}
+		return true
+	})
+
+	return key, port
+}
+
+// clean up addrsplosion
+// the following heuristic is used:
+// - for each base address/protocol combination, if there are multiple ports advertised then
+//   only accept the default port if present.
+//   - If the default port is not present, we check for non-standard ports by tracking
+//     private port bindings if present.
+//   - If there is no default or private port binding, then we can't infer the correct
+//     port and give up and return all addrs (for that base address)
+func sanitizeAddrsplodedSet(public, private []ma.Multiaddr) []ma.Multiaddr {
+	type portAndAddr struct {
+		addr ma.Multiaddr
+		port int
+	}
+
+	privports := make(map[int]struct{})
+	pubaddrs := make(map[string][]portAndAddr)
+
+	for _, a := range private {
+		_, port := addrKeyAndPort(a)
+		privports[port] = struct{}{}
+	}
+
+	for _, a := range public {
+		key, port := addrKeyAndPort(a)
+		pubaddrs[key] = append(pubaddrs[key], portAndAddr{addr: a, port: port})
+	}
+
+	var result []ma.Multiaddr
+	for _, pas := range pubaddrs {
+		if len(pas) == 1 {
+			result = append(result, pas[0].addr)
+			continue
+		}
+
+		for _, pa := range pas {
+			if pa.port == 4001 || pa.port == 4002 {
+				result = append(result, pa.addr)
+				continue
+			}
+			if _, ok := privports[pa.port]; ok {
+				result = append(result, pa.addr)
+			}
+		}
+	}
+
+	return result
+}

--- a/p2p/host/relay/addrsplosion.go
+++ b/p2p/host/relay/addrsplosion.go
@@ -6,6 +6,7 @@ import (
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
+	dns "github.com/multiformats/go-multiaddr-dns"
 	manet "github.com/multiformats/go-multiaddr-net"
 )
 
@@ -57,7 +58,7 @@ func isRelayAddr(a ma.Multiaddr) bool {
 func isDNSAddr(a ma.Multiaddr) bool {
 	if first, _ := ma.SplitFirst(a); first != nil {
 		switch first.Protocol().Code {
-		case 54, 55, 56:
+		case dns.P_DNS4, dns.P_DNS6, dns.P_DNSADDR:
 			return true
 		}
 	}

--- a/p2p/host/relay/addrsplosion.go
+++ b/p2p/host/relay/addrsplosion.go
@@ -142,15 +142,15 @@ func sanitizeAddrsplodedSet(public, private []ma.Multiaddr) []ma.Multiaddr {
 
 		haveAddr := false
 		for _, pa := range pas {
-			if pa.port == 4001 || pa.port == 4002 {
-				// it's a default port, use it
+			if _, ok := privports[pa.port]; ok {
+				// it matches a privately bound port, use it
 				result = append(result, pa.addr)
 				haveAddr = true
 				continue
 			}
 
-			if _, ok := privports[pa.port]; ok {
-				// it matches a privately bound port, use it
+			if pa.port == 4001 || pa.port == 4002 {
+				// it's a default port, use it
 				result = append(result, pa.addr)
 				haveAddr = true
 			}

--- a/p2p/host/relay/addrsplosion.go
+++ b/p2p/host/relay/addrsplosion.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 
 	circuit "github.com/libp2p/go-libp2p-circuit"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 	dns "github.com/multiformats/go-multiaddr-dns"
 	manet "github.com/multiformats/go-multiaddr-net"
@@ -12,10 +11,10 @@ import (
 
 // This function cleans up a relay's address set to remove private addresses and curtail
 // addrsplosion.
-func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
+func cleanupAddressSet(addrs []ma.Multiaddr) []ma.Multiaddr {
 	var public, private []ma.Multiaddr
 
-	for _, a := range pi.Addrs {
+	for _, a := range addrs {
 		if isRelayAddr(a) {
 			continue
 		}
@@ -32,11 +31,10 @@ func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
 	}
 
 	if !hasAddrsplosion(public) {
-		return pstore.PeerInfo{ID: pi.ID, Addrs: public}
+		return public
 	}
 
-	addrs := sanitizeAddrsplodedSet(public, private)
-	return pstore.PeerInfo{ID: pi.ID, Addrs: addrs}
+	return sanitizeAddrsplodedSet(public, private)
 }
 
 func isRelayAddr(a ma.Multiaddr) bool {

--- a/p2p/host/relay/addrsplosion.go
+++ b/p2p/host/relay/addrsplosion.go
@@ -34,17 +34,13 @@ func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
 }
 
 func isDNSAddr(a ma.Multiaddr) bool {
-	dnsaddr := false
-	ma.ForEach(a, func(c ma.Component) bool {
-		switch c.Protocol().Code {
+	if first, _ := ma.SplitFirst(a); first != nil {
+		switch first.Protocol().Code {
 		case 54, 55, 56:
-			dnsaddr = true
+			return true
 		}
-
-		return false
-	})
-
-	return dnsaddr
+	}
+	return false
 }
 
 // we have addrsplosion if for some protocol we advertise multiple ports on

--- a/p2p/host/relay/addrsplosion_test.go
+++ b/p2p/host/relay/addrsplosion_test.go
@@ -1,10 +1,8 @@
 package relay
 
 import (
-	"fmt"
 	"testing"
 
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 	_ "github.com/multiformats/go-multiaddr-dns"
 )
@@ -24,9 +22,8 @@ func TestCleanupAddrs(t *testing.T) {
 		"/dnsaddr/somedomain.com/tcp/4002/ws",
 	)
 
-	pi := cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
-	if !sameAddrs(clean, pi.Addrs) {
-		fmt.Println(pi.Addrs)
+	r := cleanupAddressSet(addrs)
+	if !sameAddrs(clean, r) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 
@@ -43,8 +40,8 @@ func TestCleanupAddrs(t *testing.T) {
 		"/ip4/1.2.3.4/tcp/4001",
 		"/ip4/1.2.3.4/udp/4002/quic",
 	)
-	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
-	if !sameAddrs(clean, pi.Addrs) {
+	r = cleanupAddressSet(addrs)
+	if !sameAddrs(clean, r) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 
@@ -60,8 +57,8 @@ func TestCleanupAddrs(t *testing.T) {
 		"/ip4/1.2.3.4/tcp/4001",
 		"/ip4/1.2.3.4/udp/4002/quic",
 	)
-	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
-	if !sameAddrs(clean, pi.Addrs) {
+	r = cleanupAddressSet(addrs)
+	if !sameAddrs(clean, r) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 
@@ -76,8 +73,8 @@ func TestCleanupAddrs(t *testing.T) {
 	clean = makeAddrList(
 		"/ip4/1.2.3.4/tcp/12345",
 	)
-	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
-	if !sameAddrs(clean, pi.Addrs) {
+	r = cleanupAddressSet(addrs)
+	if !sameAddrs(clean, r) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 
@@ -87,8 +84,8 @@ func TestCleanupAddrs(t *testing.T) {
 		"/ip4/1.2.3.4/udp/4001/quic",
 	)
 	clean = addrs
-	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
-	if !sameAddrs(clean, pi.Addrs) {
+	r = cleanupAddressSet(addrs)
+	if !sameAddrs(clean, r) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 }

--- a/p2p/host/relay/addrsplosion_test.go
+++ b/p2p/host/relay/addrsplosion_test.go
@@ -48,6 +48,23 @@ func TestCleanupAddrs(t *testing.T) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 
+	// test with default port addrsplosion but no private addrs
+	addrs = makeAddrList(
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/tcp/33333",
+		"/ip4/1.2.3.4/tcp/33334",
+		"/ip4/1.2.3.4/tcp/33335",
+		"/ip4/1.2.3.4/udp/4002/quic",
+	)
+	clean = makeAddrList(
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/udp/4002/quic",
+	)
+	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
+	if !sameAddrs(clean, pi.Addrs) {
+		t.Fatal("cleaned up set doesn't match expected")
+	}
+
 	// test with non-standard port addrsplosion
 	addrs = makeAddrList(
 		"/ip4/127.0.0.1/tcp/12345",
@@ -64,6 +81,16 @@ func TestCleanupAddrs(t *testing.T) {
 		t.Fatal("cleaned up set doesn't match expected")
 	}
 
+	// test with a squeaky clean address set
+	addrs = makeAddrList(
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/udp/4001/quic",
+	)
+	clean = addrs
+	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
+	if !sameAddrs(clean, pi.Addrs) {
+		t.Fatal("cleaned up set doesn't match expected")
+	}
 }
 
 func makeAddrList(strs ...string) []ma.Multiaddr {

--- a/p2p/host/relay/addrsplosion_test.go
+++ b/p2p/host/relay/addrsplosion_test.go
@@ -1,0 +1,98 @@
+package relay
+
+import (
+	"fmt"
+	"testing"
+
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
+	_ "github.com/multiformats/go-multiaddr-dns"
+)
+
+func TestCleanupAddrs(t *testing.T) {
+	// test with no addrsplosion
+	addrs := makeAddrList(
+		"/ip4/127.0.0.1/tcp/4001",
+		"/ip4/127.0.0.1/udp/4002/quic",
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/udp/4002/quic",
+		"/dnsaddr/somedomain.com/tcp/4002/ws",
+	)
+	clean := makeAddrList(
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/udp/4002/quic",
+		"/dnsaddr/somedomain.com/tcp/4002/ws",
+	)
+
+	pi := cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
+	if !sameAddrs(clean, pi.Addrs) {
+		fmt.Println(pi.Addrs)
+		t.Fatal("cleaned up set doesn't match expected")
+	}
+
+	// test with default port addrspolosion
+	addrs = makeAddrList(
+		"/ip4/127.0.0.1/tcp/4001",
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/tcp/33333",
+		"/ip4/1.2.3.4/tcp/33334",
+		"/ip4/1.2.3.4/tcp/33335",
+		"/ip4/1.2.3.4/udp/4002/quic",
+	)
+	clean = makeAddrList(
+		"/ip4/1.2.3.4/tcp/4001",
+		"/ip4/1.2.3.4/udp/4002/quic",
+	)
+	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
+	if !sameAddrs(clean, pi.Addrs) {
+		t.Fatal("cleaned up set doesn't match expected")
+	}
+
+	// test with non-standard port addrsplosion
+	addrs = makeAddrList(
+		"/ip4/127.0.0.1/tcp/12345",
+		"/ip4/1.2.3.4/tcp/12345",
+		"/ip4/1.2.3.4/tcp/33333",
+		"/ip4/1.2.3.4/tcp/33334",
+		"/ip4/1.2.3.4/tcp/33335",
+	)
+	clean = makeAddrList(
+		"/ip4/1.2.3.4/tcp/12345",
+	)
+	pi = cleanupAddressSet(pstore.PeerInfo{Addrs: addrs})
+	if !sameAddrs(clean, pi.Addrs) {
+		t.Fatal("cleaned up set doesn't match expected")
+	}
+
+}
+
+func makeAddrList(strs ...string) []ma.Multiaddr {
+	result := make([]ma.Multiaddr, 0, len(strs))
+	for _, s := range strs {
+		a := ma.StringCast(s)
+		result = append(result, a)
+	}
+	return result
+}
+
+func sameAddrs(as, bs []ma.Multiaddr) bool {
+	if len(as) != len(bs) {
+		return false
+	}
+
+	for _, a := range as {
+		if !findAddr(a, bs) {
+			return false
+		}
+	}
+	return true
+}
+
+func findAddr(a ma.Multiaddr, bs []ma.Multiaddr) bool {
+	for _, b := range bs {
+		if a.Equal(b) {
+			return true
+		}
+	}
+	return false
+}

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -286,7 +286,6 @@ func (ar *AutoRelay) doUpdateAddrs() {
 // addrsplosion. For the latter, we use the following heuristic:
 // - if the address set includes a (tcp) address with the default port 4001,
 //   we remove all tcp addrs with a different port
-// - Otherwise we remove all addrs with ephemeral ports (>= 32768)
 func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
 	// pass-1: find default port
 	has4001 := false
@@ -313,9 +312,9 @@ func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
 			continue
 		}
 
-		port, err := tcpPort(addr)
-		if err == nil {
-			if (has4001 && port != 4001) || port >= 32768 {
+		if has4001 {
+			port, err := tcpPort(addr)
+			if err == nil && port != 4001 {
 				continue
 			}
 		}

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -282,7 +282,7 @@ func (ar *AutoRelay) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 		return addrs
 	}
 
-	raddrs := make([]ma.Multiaddr, 0, len(addrs)+len(ar.relays))
+	var raddrs []ma.Multiaddr
 
 	// only keep private addrs from the original addr set
 	for _, addr := range addrs {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -133,12 +133,11 @@ again:
 	ar.mx.Lock()
 	haveRelays := len(ar.relays)
 	if haveRelays >= DesiredRelays {
+		ar.mx.Unlock()
 		// this dance is necessary to cover the Private->Public->Private transition
 		// where we were already connected to enough relays while private and dropped
 		// the addrs while public
-		needUpdate := ar.addrs == nil
-		ar.mx.Unlock()
-		if needUpdate {
+		if ar.addrs == nil {
 			ar.updateAddrs()
 		}
 		return

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -290,10 +290,6 @@ func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
 	// pass-1: find default port
 	has4001 := false
 	for _, addr := range pi.Addrs {
-		if manet.IsPrivateAddr(addr) {
-			continue
-		}
-
 		port, err := tcpPort(addr)
 		if err != nil {
 			continue

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -147,7 +147,7 @@ func (ar *AutoRelay) findRelays(ctx context.Context) {
 		return
 	}
 
-	pis = ar.selectRelays(ctx, pis, 20)
+	pis = ar.selectRelays(ctx, pis, 50)
 	update := 0
 
 	for _, pi := range pis {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -315,10 +315,8 @@ func (ar *AutoRelay) doUpdateAddrs() {
 		}
 
 		for _, addr := range pi.Addrs {
-			if !manet.IsPrivateAddr(addr) {
-				pub := addr.Encapsulate(circuit)
-				raddrs = append(raddrs, pub)
-			}
+			pub := addr.Encapsulate(circuit)
+			raddrs = append(raddrs, pub)
 		}
 	}
 

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
 	"time"
 
@@ -169,6 +170,14 @@ func (ar *AutoRelay) findRelays(ctx context.Context) {
 			}
 		}
 
+		cleanupAddressSet(&pi)
+
+		if len(pi.Addrs) == 0 {
+			log.Debugf("no usable addresses for relay peer %s", pi.ID)
+			cancel()
+			continue
+		}
+
 		err = ar.host.Connect(cctx, pi)
 		cancel()
 		if err != nil {
@@ -248,6 +257,55 @@ func (ar *AutoRelay) doUpdateAddrs() {
 	}
 
 	ar.addrs = raddrs
+}
+
+// This function cleans up a relay's address set to remove private addresses and curtail
+// addrsplosion. For the latter, we use the following heuristic:
+// - if the address set includes a (tcp) address with the default port 4001,
+//   we remove all tcp addrs with a different port
+// - Otherwise we remove all addrs with ephemeral ports (>= 32768)
+func cleanupAddressSet(pi *pstore.PeerInfo) {
+	// pass-1: find default port
+	has4001 := false
+	for _, addr := range pi.Addrs {
+		port, err := tcpPort(addr)
+		if err != nil {
+			continue
+		}
+		if port == 4001 {
+			has4001 = true
+			break
+		}
+	}
+
+	// pass-2: cleanup
+	var newAddrs []ma.Multiaddr
+
+	for _, addr := range pi.Addrs {
+		if manet.IsPrivateAddr(addr) {
+			continue
+		}
+
+		port, err := tcpPort(addr)
+		if err == nil {
+			if (has4001 && port != 4001) || port >= 32768 {
+				continue
+			}
+		}
+
+		newAddrs = append(newAddrs, addr)
+	}
+
+	pi.Addrs = newAddrs
+}
+
+func tcpPort(addr ma.Multiaddr) (int, error) {
+	val, err := addr.ValueForProtocol(ma.P_TCP)
+	if err != nil {
+		// not tcp
+		return 0, err
+	}
+	return strconv.Atoi(val)
 }
 
 func shuffleRelays(pis []pstore.PeerInfo) {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -158,7 +158,7 @@ func (ar *AutoRelay) findRelays(ctx context.Context) {
 		}
 		ar.mx.Unlock()
 
-		cctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 
 		if len(pi.Addrs) == 0 {
 			pi, err = ar.router.FindPeer(cctx, pi.ID)

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -240,6 +240,12 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 	// shuffle to randomize the order of queries
 	shuffleRelays(pis)
 	for _, pi := range pis[:maxq] {
+		// first check to see if we already know this peer from a previous query
+		addrs := ar.host.Peerstore().Addrs(pi.ID)
+		if len(addrs) > 0 {
+			resultCh <- queryResult{pi: pstore.PeerInfo{ID: pi.ID, Addrs: addrs}, err: nil}
+			continue
+		}
 		go func(p peer.ID) {
 			pi, err := ar.router.FindPeer(qctx, p)
 			if err != nil {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -205,6 +205,8 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 	qctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
+	// shuffle to randomize the order of queries
+	shuffleRelays(pis)
 	for _, pi := range pis {
 		go func(p peer.ID) {
 			pi, err := ar.router.FindPeer(qctx, p)

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -155,6 +155,8 @@ again:
 		return
 	}
 
+	log.Debugf("discovered %d relays", len(pis))
+
 	pis = ar.selectRelays(ctx, pis, 20, 50)
 	update := 0
 
@@ -193,6 +195,7 @@ again:
 	if haveRelays == 0 {
 		// we failed to find any relays and we are not connected to any!
 		// wait a little and try again, the discovery query might have returned only dead peers
+		log.Debug("no relays connected; retrying in 30s")
 		select {
 		case <-time.After(30 * time.Second):
 			goto again
@@ -211,7 +214,6 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 	//      but we should probably use ping latency as the selection metric
 
 	if len(pis) == 0 {
-		log.Debugf("no relays discovered")
 		return pis
 	}
 

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -202,7 +202,7 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 	result := make([]pstore.PeerInfo, 0, count)
 	resultCh := make(chan queryResult, len(pis))
 
-	qctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	qctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	// shuffle to randomize the order of queries

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -136,7 +136,9 @@ again:
 		ar.mx.Unlock()
 		// this dance is necessary to cover the Private->Public->Private transition
 		// where we were already connected to enough relays while private and dropped
-		// the addrs while public
+		// the addrs while public.
+		// Note tht we don't need the lock for reading addrs, as the only writer is
+		// the current goroutine.
 		if ar.addrs == nil {
 			ar.updateAddrs()
 		}

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -211,7 +211,7 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 		go func(p peer.ID) {
 			pi, err := ar.router.FindPeer(qctx, p)
 			if err != nil {
-				log.Debugf("Error finding relay peer %s: %s", p, err.Error())
+				log.Debugf("error finding relay peer %s: %s", p, err.Error())
 			}
 			resultCh <- queryResult{pi: pi, err: err}
 		}(pi.ID)
@@ -223,7 +223,12 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 		case qr := <-resultCh:
 			rcount++
 			if qr.err == nil {
-				result = append(result, cleanupAddressSet(qr.pi))
+				pi := cleanupAddressSet(qr.pi)
+				if len(pi.Addrs) > 0 {
+					result = append(result, pi)
+				} else {
+					log.Debugf("ignoring relay peer %s: cleaned up address set is empty", pi.ID)
+				}
 			}
 
 		case <-qctx.Done():

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -162,7 +162,7 @@ again:
 
 	log.Debugf("discovered %d relays", len(pis))
 
-	pis = ar.selectRelays(ctx, pis, 20, 50)
+	pis = ar.selectRelays(ctx, pis, 25, 50)
 	update := 0
 
 	for _, pi := range pis {
@@ -173,7 +173,7 @@ again:
 		}
 		ar.mx.Unlock()
 
-		cctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		err = ar.host.Connect(cctx, pi)
 		cancel()
 		if err != nil {
@@ -254,6 +254,8 @@ func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo, co
 			resultCh <- queryResult{pi: pstore.PeerInfo{ID: pi.ID, Addrs: addrs}, err: nil}
 			continue
 		}
+
+		// no known addrs, do a query
 		go func(p peer.ID) {
 			pi, err := ar.router.FindPeer(qctx, p)
 			if err != nil {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -149,7 +149,7 @@ again:
 		return
 	}
 
-	pis = ar.selectRelays(ctx, pis, 50)
+	pis = ar.selectRelays(ctx, pis, 20)
 	update := 0
 
 	for _, pi := range pis {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -136,10 +136,7 @@ func (ar *AutoRelay) findRelays(ctx context.Context) {
 	need := DesiredRelays - len(ar.relays)
 	ar.mx.Unlock()
 
-	limit := 50
-	if need > limit/2 {
-		limit = 2 * need
-	}
+	limit := 1000
 
 	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	pis, err := discovery.FindPeers(dctx, ar.discover, RelayRendezvous, limit)

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -187,8 +187,12 @@ again:
 	if haveRelays == 0 {
 		// we failed to find any relays and we are not connected to any!
 		// wait a little and try again, the discovery query might have returned only dead peers
-		time.Sleep(30 * time.Second)
-		goto again
+		select {
+		case <-time.After(30 * time.Second):
+			goto again
+		case <-ctx.Done():
+			return
+		}
 	}
 
 	if update > 0 || ar.addrs == nil {

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -291,6 +291,10 @@ func cleanupAddressSet(pi pstore.PeerInfo) pstore.PeerInfo {
 	// pass-1: find default port
 	has4001 := false
 	for _, addr := range pi.Addrs {
+		if manet.IsPrivateAddr(addr) {
+			continue
+		}
+
 		port, err := tcpPort(addr)
 		if err != nil {
 			continue

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -133,7 +133,14 @@ again:
 	ar.mx.Lock()
 	haveRelays := len(ar.relays)
 	if haveRelays >= DesiredRelays {
+		// this dance is necessary to cover the Private->Public->Private transition
+		// where we were already connected to enough relays while private and dropped
+		// the addrs while public
+		needUpdate := ar.addrs == nil
 		ar.mx.Unlock()
+		if needUpdate {
+			ar.updateAddrs()
+		}
 		return
 	}
 	need := DesiredRelays - len(ar.relays)

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -26,8 +26,8 @@ import (
 
 // test specific parameters
 func init() {
-	autonat.AutoNATIdentifyDelay = 500 * time.Millisecond
-	autonat.AutoNATBootDelay = 1 * time.Second
+	autonat.AutoNATIdentifyDelay = 1 * time.Second
+	autonat.AutoNATBootDelay = 2 * time.Second
 	relay.BootDelay = 1 * time.Second
 	relay.AdvertiseBootDelay = 1 * time.Millisecond
 	manet.Private4 = []*net.IPNet{}
@@ -37,6 +37,7 @@ func init() {
 type mockRoutingTable struct {
 	mx        sync.Mutex
 	providers map[string]map[peer.ID]pstore.PeerInfo
+	peers     map[peer.ID]pstore.PeerInfo
 }
 
 type mockRouting struct {
@@ -53,7 +54,13 @@ func newMockRouting(h host.Host, tab *mockRoutingTable) *mockRouting {
 }
 
 func (m *mockRouting) FindPeer(ctx context.Context, p peer.ID) (pstore.PeerInfo, error) {
-	return pstore.PeerInfo{}, routing.ErrNotFound
+	m.tab.mx.Lock()
+	defer m.tab.mx.Unlock()
+	pi, ok := m.tab.peers[p]
+	if !ok {
+		return pstore.PeerInfo{}, routing.ErrNotFound
+	}
+	return pi, nil
 }
 
 func (m *mockRouting) Provide(ctx context.Context, cid cid.Cid, bcast bool) error {
@@ -66,7 +73,12 @@ func (m *mockRouting) Provide(ctx context.Context, cid cid.Cid, bcast bool) erro
 		m.tab.providers[cid.String()] = pmap
 	}
 
-	pmap[m.h.ID()] = pstore.PeerInfo{ID: m.h.ID(), Addrs: m.h.Addrs()}
+	pi := pstore.PeerInfo{ID: m.h.ID(), Addrs: m.h.Addrs()}
+	pmap[m.h.ID()] = pi
+	if m.tab.peers == nil {
+		m.tab.peers = make(map[peer.ID]pstore.PeerInfo)
+	}
+	m.tab.peers[m.h.ID()] = pi
 
 	return nil
 }
@@ -133,7 +145,7 @@ func connect(t *testing.T, a, b host.Host) {
 
 // and the actual test!
 func TestAutoRelay(t *testing.T) {
-	t.Skip("fails 99% of the time")
+	//t.Skip("fails 99% of the time")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -165,7 +177,7 @@ func TestAutoRelay(t *testing.T) {
 
 	// connect to AutoNAT and let detection/discovery work its magic
 	connect(t, h1, h3)
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// verify that we now advertise relay addrs (but not unspecific relay addrs)
 	unspecificRelay, err := ma.NewMultiaddr("/p2p-circuit")

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -30,7 +30,6 @@ func init() {
 	autonat.AutoNATBootDelay = 2 * time.Second
 	relay.BootDelay = 1 * time.Second
 	relay.AdvertiseBootDelay = 100 * time.Millisecond
-	manet.Private4 = []*net.IPNet{}
 }
 
 // mock routing
@@ -146,6 +145,10 @@ func connect(t *testing.T, a, b host.Host) {
 // and the actual test!
 func TestAutoRelay(t *testing.T) {
 	//t.Skip("fails 99% of the time")
+
+	save := manet.Private4
+	manet.Private4 = []*net.IPNet{}
+	defer func() { manet.Private4 = save }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -146,9 +146,7 @@ func connect(t *testing.T, a, b host.Host) {
 func TestAutoRelay(t *testing.T) {
 	//t.Skip("fails 99% of the time")
 
-	save := manet.Private4
 	manet.Private4 = []*net.IPNet{}
-	defer func() { manet.Private4 = save }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -29,7 +29,7 @@ func init() {
 	autonat.AutoNATIdentifyDelay = 1 * time.Second
 	autonat.AutoNATBootDelay = 2 * time.Second
 	relay.BootDelay = 1 * time.Second
-	relay.AdvertiseBootDelay = 1 * time.Millisecond
+	relay.AdvertiseBootDelay = 100 * time.Millisecond
 	manet.Private4 = []*net.IPNet{}
 }
 

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	circuit "github.com/libp2p/go-libp2p-circuit"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -29,8 +28,7 @@ func Advertise(ctx context.Context, advertise discovery.Advertiser) {
 func Filter(addrs []ma.Multiaddr) []ma.Multiaddr {
 	raddrs := make([]ma.Multiaddr, 0, len(addrs))
 	for _, addr := range addrs {
-		_, err := addr.ValueForProtocol(circuit.P_CIRCUIT)
-		if err == nil {
+		if isRelayAddr(addr) {
 			continue
 		}
 		raddrs = append(raddrs, addr)

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	AdvertiseBootDelay = 30 * time.Second
+	// this is purposefully long to require some node stability before advertising as a relay
+	AdvertiseBootDelay = 15 * time.Minute
 )
 
 // Advertise advertises this node as a libp2p relay.


### PR DESCRIPTION
Relays, as discovered in the DHT, are _addrsploded_. The current (pre-)computation of advertised relay addrs fails to account for this fact, resulting in the advertisement of many dead addresses. In addition, many relays discovered in the DHT are actually dead.

This patch adds logic to deal with the situation
- relay addrs are dynamically recomputed by the address factory using the relay addrs present in the peerstore instead of pre-computing based on what was advertised.
- a special clean up pass is done on the relay address set to remove addrsploded addrs.
- a retry pass is added to `findRelays` that deals with the case of no live relays in the discovered set.
- we also increase the relay advertisement boot delay to 15 min so that some minimum node stability is ensured.

Note: the patch was originally much more extensive, adding a complex relay selection logic that tried to parallelize to deal with dead relays. That proved to be contentious, and biased against dedicated relays, so it has been reverted.