### PR TITLE
constructor: allow nil options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,6 +242,9 @@ type Option func(cfg *Config) error
 // encountered (if any).
 func (cfg *Config) Apply(opts ...Option) error {
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		if err := opt(cfg); err != nil {
 			return err
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestNilOption(t *testing.T) {
+	var cfg Config
+	optsRun := 0
+	opt := func(c *Config) error {
+		optsRun++
+		return nil
+	}
+	if err := cfg.Apply(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Apply(opt, nil, nil, opt, opt, nil); err != nil {
+		t.Fatal(err)
+	}
+	if optsRun != 3 {
+		t.Fatalf("expected to have handled 3 options, handled %d", optsRun)
+	}
+}

--- a/libp2p.go
+++ b/libp2p.go
@@ -19,6 +19,9 @@ type Option = config.Option
 func ChainOptions(opts ...Option) Option {
 	return func(cfg *Config) error {
 		for _, opt := range opts {
+			if opt == nil {
+				continue
+			}
 			if err := opt(cfg); err != nil {
 				return err
 			}

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -133,3 +133,28 @@ func makeRandomHost(t *testing.T, port int) (host.Host, error) {
 
 	return New(ctx, opts...)
 }
+
+func TestChainOptions(t *testing.T) {
+	var cfg Config
+	var optsRun []int
+	optcount := 0
+	newOpt := func() Option {
+		index := optcount
+		optcount++
+		return func(c *Config) error {
+			optsRun = append(optsRun, index)
+			return nil
+		}
+	}
+	if err := cfg.Apply(newOpt(), nil, ChainOptions(newOpt(), newOpt(), ChainOptions(), ChainOptions(nil, newOpt()))); err != nil {
+		t.Fatal(err)
+	}
+	if optcount != len(optsRun) {
+		t.Errorf("expected to have handled %d options, handled %d", optcount, len(optsRun))
+	}
+	for i, x := range optsRun {
+		if i != x {
+			t.Errorf("expected opt %d, got opt %d", i, x)
+		}
+	}
+}


### PR DESCRIPTION
This can make it significantly easier to configure libp2p with optional options.