### PR TITLE
autorelay: break findRelays into multiple functions and avoid the goto

### DIFF
--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -159,6 +159,9 @@ func (ar *AutoRelay) findRelaysOnce(ctx context.Context) bool {
 	update := false
 	for _, pi := range pis {
 		update = ar.tryRelay(ctx, pi) || update
+		if ar.numRelays() >= DesiredRelays {
+			break
+		}
 	}
 	return update
 }


### PR DESCRIPTION
(@stebalien is picky and opinionated...)

* No goto.
* No counters (except the "retry" counter).
* Dedup retry-wait logic.
* Smaller functions.