### PR TITLE
avoid intermediate allocation in relayAddrs

### DIFF
--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -266,12 +266,7 @@ func (ar *AutoRelay) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 		return ar.cachedAddrs
 	}
 
-	relays := make([]peer.ID, 0, len(ar.relays))
-	for p := range ar.relays {
-		relays = append(relays, p)
-	}
-
-	raddrs := make([]ma.Multiaddr, 0, 4*len(relays)+2)
+	raddrs := make([]ma.Multiaddr, 0, 4*len(ar.relays)+4)
 
 	// only keep private addrs from the original addr set
 	for _, addr := range addrs {
@@ -281,7 +276,7 @@ func (ar *AutoRelay) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	}
 
 	// add relay specific addrs to the list
-	for _, p := range relays {
+	for p := range ar.relays {
 		addrs := cleanupAddressSet(ar.host.Peerstore().Addrs(p))
 
 		circuit, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s/p2p-circuit", p.Pretty()))


### PR DESCRIPTION
now that we have the lock for the duration of the method, we don't need the intermediate
relays array. This removes it, and also extends the pre-allocation of the result array
by 2 so that it can cover two localhost and two private address bindings.