### PR TITLE
Frequent Relay Advertisements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/libp2p/go-libp2p-blankhost v0.0.1
 	github.com/libp2p/go-libp2p-circuit v0.0.6
 	github.com/libp2p/go-libp2p-crypto v0.0.2
-	github.com/libp2p/go-libp2p-discovery v0.0.2
+	github.com/libp2p/go-libp2p-discovery v0.0.3
 	github.com/libp2p/go-libp2p-host v0.0.3
 	github.com/libp2p/go-libp2p-interface-connmgr v0.0.4
 	github.com/libp2p/go-libp2p-interface-pnet v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/libp2p/go-libp2p-crypto v0.0.1 h1:JNQd8CmoGTohO/akqrH16ewsqZpci2CbgYH
 github.com/libp2p/go-libp2p-crypto v0.0.1/go.mod h1:yJkNyDmO341d5wwXxDUGO0LykUVT72ImHNUqh5D/dBE=
 github.com/libp2p/go-libp2p-crypto v0.0.2 h1:TTdJ4y6Uoa6NxQcuEaVkQfFRcQeCE2ReDk8Ok4I0Fyw=
 github.com/libp2p/go-libp2p-crypto v0.0.2/go.mod h1:eETI5OUfBnvARGOHrJz2eWNyTUxEGZnBxMcbUjfIj4I=
-github.com/libp2p/go-libp2p-discovery v0.0.2 h1:Rf+20nsFcCnHo4Kxvf8ofAft75+fW+cXy9FonNVyU/g=
-github.com/libp2p/go-libp2p-discovery v0.0.2/go.mod h1:ZkkF9xIFRLA1xCc7bstYFkd80gBGK8Fc1JqGoU2i+zI=
+github.com/libp2p/go-libp2p-discovery v0.0.3 h1:/41EY87ErU1yQLoPoTfJXV3xomDwx7Ti1Ae66DuDk9U=
+github.com/libp2p/go-libp2p-discovery v0.0.3/go.mod h1:ZkkF9xIFRLA1xCc7bstYFkd80gBGK8Fc1JqGoU2i+zI=
 github.com/libp2p/go-libp2p-host v0.0.1 h1:dnqusU+DheGcdxrE718kG4XgHNuL2n9eEv8Rg5zy8hQ=
 github.com/libp2p/go-libp2p-host v0.0.1/go.mod h1:qWd+H1yuU0m5CwzAkvbSjqKairayEHdR5MMl7Cwa7Go=
 github.com/libp2p/go-libp2p-host v0.0.3 h1:BB/1Z+4X0rjKP5lbQTmjEjLbDVbrcmLOlA6QDsN5/j4=

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -236,7 +236,7 @@ func (ar *AutoRelay) connect(ctx context.Context, pi pstore.PeerInfo) bool {
 func (ar *AutoRelay) discoverRelays(ctx context.Context) ([]pstore.PeerInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	return discovery.FindPeers(ctx, ar.discover, RelayRendezvous, 1000)
+	return discovery.FindPeers(ctx, ar.discover, RelayRendezvous, discovery.Limit(1000))
 }
 
 func (ar *AutoRelay) selectRelays(ctx context.Context, pis []pstore.PeerInfo) []pstore.PeerInfo {

--- a/p2p/host/relay/relay.go
+++ b/p2p/host/relay/relay.go
@@ -11,6 +11,7 @@ import (
 var (
 	// this is purposefully long to require some node stability before advertising as a relay
 	AdvertiseBootDelay = 15 * time.Minute
+	AdvertiseTTL       = 30 * time.Minute
 )
 
 // Advertise advertises this node as a libp2p relay.
@@ -18,7 +19,7 @@ func Advertise(ctx context.Context, advertise discovery.Advertiser) {
 	go func() {
 		select {
 		case <-time.After(AdvertiseBootDelay):
-			discovery.Advertise(ctx, advertise, RelayRendezvous)
+			discovery.Advertise(ctx, advertise, RelayRendezvous, discovery.TTL(AdvertiseTTL))
 		case <-ctx.Done():
 		}
 	}()


### PR DESCRIPTION
It has been observed that relays are not always discoverable, presumably because of DHT churn.
This cuts down the relay advertisement TTL to 30min (from 3hrs).