### PR TITLE
if we already have a peers key, don't bother checking identify for it

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -317,6 +317,10 @@ func (ids *IDService) consumeReceivedPubKey(c network.Conn, kb []byte) {
 		return
 	}
 
+	if ids.Host.Peerstore().PubKey(rp) != nil {
+		return
+	}
+
 	newKey, err := ic.UnmarshalPublicKey(kb)
 	if err != nil {
 		log.Warningf("%s cannot unmarshal key from remote peer: %s, %s", lp, rp, err)


### PR DESCRIPTION
Obviously this change requires more change than this, but I want to discuss it a little bit first.