### PR TITLE
identify: cache the encoded public key

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -157,7 +157,10 @@ func NewHost(ctx context.Context, net network.Network, opts *HostOpts) (*BasicHo
 		h.ids = opts.IdentifyService
 	} else {
 		// we can't set this as a default above because it depends on the *BasicHost.
-		h.ids = identify.NewIDService(goprocessctx.WithProcessClosing(ctx, h.proc), h)
+		h.ids, err = identify.NewIDService(goprocessctx.WithProcessClosing(ctx, h.proc), h)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if uint64(opts.NegotiationTimeout) != 0 {

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -34,8 +34,8 @@ func subtestIDService(t *testing.T) {
 	h1p := h1.ID()
 	h2p := h2.ID()
 
-	ids1 := identify.NewIDService(ctx, h1)
-	ids2 := identify.NewIDService(ctx, h2)
+	ids1, _ := identify.NewIDService(ctx, h1)
+	ids2, _ := identify.NewIDService(ctx, h2)
 
 	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{}) // nothing
 	testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{}) // nothing
@@ -201,8 +201,8 @@ func TestIdentifyDeltaOnProtocolChange(t *testing.T) {
 
 	h2.SetStreamHandler(protocol.TestingID, func(_ network.Stream) {})
 
-	ids1 := identify.NewIDService(ctx, h1)
-	_ = identify.NewIDService(ctx, h2)
+	ids1, _ := identify.NewIDService(ctx, h1)
+	_, _ = identify.NewIDService(ctx, h2)
 
 	if err := h1.Connect(ctx, peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()}); err != nil {
 		t.Fatal(err)
@@ -314,8 +314,8 @@ func TestIdentifyDeltaWhileIdentifyingConn(t *testing.T) {
 	defer h2.Close()
 	defer h1.Close()
 
-	_ = identify.NewIDService(ctx, h1)
-	ids2 := identify.NewIDService(ctx, h2)
+	_, _ = identify.NewIDService(ctx, h1)
+	ids2, _ := identify.NewIDService(ctx, h2)
 
 	// replace the original identify handler by one that blocks until we close the block channel.
 	// this allows us to control how long identify runs.


### PR DESCRIPTION
Saves some work and quite a bit of allocation each time a new peer connects.

BREAKING: The identify service can now return an error on construction. It no longer logs and drops critical errors.