### PR TITLE
mdns: always use interface addresses

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/libp2p/go-libp2p-circuit v0.1.0 h1:eniLL3Y9aq/sryfyV1IAHj5rlvuyj3b7iz
 github.com/libp2p/go-libp2p-circuit v0.1.0/go.mod h1:Ahq4cY3V9VJcHcn1SBXjr78AbFkZeIRmfunbA7pmFh8=
 github.com/libp2p/go-libp2p-core v0.0.1/go.mod h1:g/VxnTZ/1ygHxH3dKok7Vno1VfpvGcGip57wjTU4fco=
 github.com/libp2p/go-libp2p-core v0.0.4/go.mod h1:jyuCQP356gzfCFtRKyvAbNkyeuxb7OlyhWZ3nls5d2I=
+github.com/libp2p/go-libp2p-core v0.0.6 h1:SsYhfWJ47vLP1Rd9/0hqEm/W/PlFbC/3YLZyLCcvo1w=
 github.com/libp2p/go-libp2p-core v0.0.6/go.mod h1:0d9xmaYAVY5qmbp/fcgxHT3ZJsLjYeYPMJAUKpaCHrE=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0 h1:j+R6cokKcGbnZLf4kcNwpx6mDEUPF3N6SrqMymQhmvs=

--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -49,7 +49,11 @@ type mdnsService struct {
 
 func getDialableListenAddrs(ph host.Host) ([]*net.TCPAddr, error) {
 	var out []*net.TCPAddr
-	for _, addr := range ph.Addrs() {
+	addrs, err := ph.Network().InterfaceListenAddresses()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
 		na, err := manet.ToNetAddr(addr)
 		if err != nil {
 			continue


### PR DESCRIPTION
We don't want to use the transformed/munged host addresses for local announcements. Ideally, we'd take a more scientific approach to this (i.e., "host, please give me addresses relative to X") but we can't do that yet.

Note: this is causing mdns to break when used with autorelay