### PR TITLE
WIP - Provide private key to insecure.New()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -142,7 +142,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 	upgrader.Protector = cfg.Protector
 	upgrader.Filters = swrm.Filters
 	if cfg.Insecure {
-		upgrader.Secure = makeInsecureTransport(pid)
+		upgrader.Secure = makeInsecureTransport(pid, cfg.PeerKey)
 	} else {
 		upgrader.Secure, err = makeSecurityTransport(h, cfg.SecurityTransports)
 		if err != nil {

--- a/config/security.go
+++ b/config/security.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/sec/insecure"
 
 	csms "github.com/libp2p/go-conn-security-multistream"
+	ci "github.com/libp2p/go-libp2p-core/crypto"
 )
 
 // SecC is a security transport constructor
@@ -49,9 +50,9 @@ func SecurityConstructor(security interface{}) (SecC, error) {
 	}, nil
 }
 
-func makeInsecureTransport(id peer.ID) sec.SecureTransport {
+func makeInsecureTransport(id peer.ID, key ci.PrivKey) sec.SecureTransport {
 	secMuxer := new(csms.SSMuxer)
-	secMuxer.AddTransport(insecure.ID, insecure.New(id))
+	secMuxer.AddTransport(insecure.ID, insecure.New(id, key))
 	return secMuxer
 }
 

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/libp2p/go-libp2p-circuit v0.1.0 h1:eniLL3Y9aq/sryfyV1IAHj5rlvuyj3b7iz
 github.com/libp2p/go-libp2p-circuit v0.1.0/go.mod h1:Ahq4cY3V9VJcHcn1SBXjr78AbFkZeIRmfunbA7pmFh8=
 github.com/libp2p/go-libp2p-core v0.0.1/go.mod h1:g/VxnTZ/1ygHxH3dKok7Vno1VfpvGcGip57wjTU4fco=
 github.com/libp2p/go-libp2p-core v0.0.4/go.mod h1:jyuCQP356gzfCFtRKyvAbNkyeuxb7OlyhWZ3nls5d2I=
+github.com/libp2p/go-libp2p-core v0.0.6 h1:SsYhfWJ47vLP1Rd9/0hqEm/W/PlFbC/3YLZyLCcvo1w=
 github.com/libp2p/go-libp2p-core v0.0.6/go.mod h1:0d9xmaYAVY5qmbp/fcgxHT3ZJsLjYeYPMJAUKpaCHrE=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0 h1:j+R6cokKcGbnZLf4kcNwpx6mDEUPF3N6SrqMymQhmvs=


### PR DESCRIPTION
insecure.New() requires a private key argument.  The key is used only for identity generation.  (See [this line in github.com/libp2p/go-libp2p-core/sec/insecure/insecure.go](https://github.com/libp2p/go-libp2p-core/blob/1d45af25d96204b2f5fd6ea13a6ebe573ae25a49/sec/insecure/insecure.go#L35))  This PR passes the host's private key through to the chain of functions that lead to a call to insecure.New() to correct a compile-time error in `go-libp2p/config/config.go` on the line `upgrader.Secure = makeInsecureTransport(pid)`.  

When the insecure transport is not being used, the compiler seems to optimize that line away before it can emit an error, which may be why this error hasn't been noticed previously.