### PR TITLE
Added missing error check in test

### DIFF
--- a/p2p/host/relay/autorelay_test.go
+++ b/p2p/host/relay/autorelay_test.go
@@ -169,6 +169,9 @@ func TestAutoRelay(t *testing.T) {
 		t.Fatal(err)
 	}
 	h4, err := libp2p.New(ctx, libp2p.EnableRelay())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// verify that we don't advertise relay addrs initially
 	for _, addr := range h3.Addrs() {


### PR DESCRIPTION
Since err gets assigned, I assume we also want to check for it being nil.