### PR TITLE
Pass peer private key to insecure transport

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -142,7 +142,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 	upgrader.Protector = cfg.Protector
 	upgrader.Filters = swrm.Filters
 	if cfg.Insecure {
-		upgrader.Secure = makeInsecureTransport(pid)
+		upgrader.Secure = makeInsecureTransport(pid, cfg.PeerKey)
 	} else {
 		upgrader.Secure, err = makeSecurityTransport(h, cfg.SecurityTransports)
 		if err != nil {

--- a/config/security.go
+++ b/config/security.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"
@@ -49,9 +50,9 @@ func SecurityConstructor(security interface{}) (SecC, error) {
 	}, nil
 }
 
-func makeInsecureTransport(id peer.ID) sec.SecureTransport {
+func makeInsecureTransport(id peer.ID, privKey crypto.PrivKey) sec.SecureTransport {
 	secMuxer := new(csms.SSMuxer)
-	secMuxer.AddTransport(insecure.ID, insecure.New(id))
+	secMuxer.AddTransport(insecure.ID, insecure.NewWithIdentity(id, privKey))
 	return secMuxer
 }
 


### PR DESCRIPTION
I was attempting to analyze the libp2p protocol by sniffing the communications in the [example programs]( https://github.com/libp2p/go-libp2p-examples). They instruct you to use the `-insecure` flag to replace the actually secure transports with a plaintext transport, however doing this results in an error. 
```panic: runtime error: index out of range

goroutine 30 [running]:
github.com/libp2p/go-libp2p-peerstore/pstoremem.(*protoSegments).get(...)
	/home/gabe/code/go/src/github.com/libp2p/go-libp2p-peerstore/pstoremem/protobook.go:19
github.com/libp2p/go-libp2p-peerstore/pstoremem.(*memoryProtoBook).SetProtocols(0xc0000e1b00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/gabe/code/go/src/github.com/libp2p/go-libp2p-peerstore/pstoremem/protobook.go:70 +0x1d4
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newConnHandler(0xc0000a8370, 0xc1ac40, 0xc0000fa540)
	/home/gabe/code/go/src/github.com/libp2p/go-libp2p/p2p/host/basic/basic_host.go:243 +0x8c
created by github.com/libp2p/go-libp2p-swarm.(*Swarm).addConn
	/home/gabe/code/go/src/github.com/libp2p/go-libp2p-swarm/swarm.go:243 +0x384
```
I think I found the issue. The issue was that the insecure transport was not recieving the client private key and it was being left empty which lead to a segfault in later code which required the private key.

#### Caveat!!
As I said, I am very new to libp2p and this solution is purely mechanical. I don't know if it is really correct. All I know is that it seemed to solve my problem in the examples.

I am sorry if I have gone about anything incorrectly. Please feel free to correct me.