### PR TITLE
options to configure static relays for autorelay

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	Routing RoutingC
 
 	EnableAutoRelay bool
+	StaticRelays    []peer.AddrInfo
 }
 
 // NewNode constructs a new libp2p Host from the Config.
@@ -226,7 +227,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 			// advertise ourselves
 			relay.Advertise(ctx, discovery)
 		} else {
-			_ = relay.NewAutoRelay(swrm.Context(), h, discovery, router)
+			_ = relay.NewAutoRelay(swrm.Context(), h, discovery, router, cfg.StaticRelays)
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ import (
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	config "github.com/libp2p/go-libp2p/config"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	autorelay "github.com/libp2p/go-libp2p/p2p/host/relay"
 
 	filter "github.com/libp2p/go-maddr-filter"
 	ma "github.com/multiformats/go-multiaddr"
@@ -251,19 +252,15 @@ func EnableAutoRelay() Option {
 // discover relays
 func StaticRelays(relays []peer.AddrInfo) Option {
 	return func(cfg *Config) error {
-		cfg.StaticRelays = relays
+		cfg.StaticRelays = append(cfg.StaticRelays, relays...)
 		return nil
 	}
 }
 
-// DefaultRelays configures the static relays to use the known PL-operated relays
-func DefaultRelays() Option {
+// DefaultStaticRelays configures the static relays to use the known PL-operated relays
+func DefaultStaticRelays() Option {
 	return func(cfg *Config) error {
-		for _, addr := range []string{
-			"/ip4/147.75.80.110/tcp/4001/p2p/QmbFgm5zan8P6eWWmeyfncR5feYEMPbht5b1FW1C37aQ7y",
-			"/ip4/147.75.195.153/tcp/4001/p2p/QmW9m57aiBDHAkKj9nmFSEn7ZqrcF1fZS4bipsTCHburei",
-			"/ip4/147.75.70.221/tcp/4001/p2p/Qme8g49gm3q4Acp7xWBKg3nAa9fxZ1YmyDJdyGgoG6LsXh",
-		} {
+		for _, addr := range autorelay.DefaultRelays {
 			a, err := ma.NewMultiaddr(addr)
 			if err != nil {
 				return err

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/metrics"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-core/pnet"
 
@@ -241,6 +242,39 @@ func DisableRelay() Option {
 func EnableAutoRelay() Option {
 	return func(cfg *Config) error {
 		cfg.EnableAutoRelay = true
+		return nil
+	}
+}
+
+// StaticRelays configures known relays for autorelay; when this option is enabled
+// then the system will use the configured relays instead of querying the DHT to
+// discover relays
+func StaticRelays(relays []peer.AddrInfo) Option {
+	return func(cfg *Config) error {
+		cfg.StaticRelays = relays
+		return nil
+	}
+}
+
+// DefaultRelays configures the static relays to use the known PL-operated relays
+func DefaultRelays() Option {
+	return func(cfg *Config) error {
+		for _, addr := range []string{
+			"/ip4/147.75.80.110/tcp/4001/p2p/QmbFgm5zan8P6eWWmeyfncR5feYEMPbht5b1FW1C37aQ7y",
+			"/ip4/147.75.195.153/tcp/4001/p2p/QmW9m57aiBDHAkKj9nmFSEn7ZqrcF1fZS4bipsTCHburei",
+			"/ip4/147.75.70.221/tcp/4001/p2p/Qme8g49gm3q4Acp7xWBKg3nAa9fxZ1YmyDJdyGgoG6LsXh",
+		} {
+			a, err := ma.NewMultiaddr(addr)
+			if err != nil {
+				return err
+			}
+			pi, err := peer.AddrInfoFromP2pAddr(a)
+			if err != nil {
+				return err
+			}
+			cfg.StaticRelays = append(cfg.StaticRelays, *pi)
+		}
+
 		return nil
 	}
 }

--- a/p2p/host/relay/autorelay.go
+++ b/p2p/host/relay/autorelay.go
@@ -30,6 +30,13 @@ var (
 	BootDelay = 20 * time.Second
 )
 
+// These are the known PL-operated relays
+var DefaultRelays = []string{
+	"/ip4/147.75.80.110/tcp/4001/p2p/QmbFgm5zan8P6eWWmeyfncR5feYEMPbht5b1FW1C37aQ7y",
+	"/ip4/147.75.195.153/tcp/4001/p2p/QmW9m57aiBDHAkKj9nmFSEn7ZqrcF1fZS4bipsTCHburei",
+	"/ip4/147.75.70.221/tcp/4001/p2p/Qme8g49gm3q4Acp7xWBKg3nAa9fxZ1YmyDJdyGgoG6LsXh",
+}
+
 // AutoRelay is a Host that uses relays for connectivity when a NAT is detected.
 type AutoRelay struct {
 	host     *basic.BasicHost


### PR DESCRIPTION
So that we can avoid hitting the DHT; also changes the desired relays parameter to 1 (from 3).
See #694 