### PR TITLE
use new constructor for insecure transport

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,13 +100,11 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		return nil, fmt.Errorf("no peerstore specified")
 	}
 
-	if !cfg.Insecure {
-		if err := cfg.Peerstore.AddPrivKey(pid, cfg.PeerKey); err != nil {
-			return nil, err
-		}
-		if err := cfg.Peerstore.AddPubKey(pid, cfg.PeerKey.GetPublic()); err != nil {
-			return nil, err
-		}
+	if err := cfg.Peerstore.AddPrivKey(pid, cfg.PeerKey); err != nil {
+		return nil, err
+	}
+	if err := cfg.Peerstore.AddPubKey(pid, cfg.PeerKey.GetPublic()); err != nil {
+		return nil, err
 	}
 
 	// TODO: Make the swarm implementation configurable.
@@ -142,7 +140,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 	upgrader.Protector = cfg.Protector
 	upgrader.Filters = swrm.Filters
 	if cfg.Insecure {
-		upgrader.Secure = makeInsecureTransport(pid)
+		upgrader.Secure = makeInsecureTransport(pid, cfg.PeerKey)
 	} else {
 		upgrader.Secure, err = makeSecurityTransport(h, cfg.SecurityTransports)
 		if err != nil {

--- a/config/security.go
+++ b/config/security.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/libp2p/go-libp2p-core/crypto"
 
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -49,9 +50,9 @@ func SecurityConstructor(security interface{}) (SecC, error) {
 	}, nil
 }
 
-func makeInsecureTransport(id peer.ID) sec.SecureTransport {
+func makeInsecureTransport(id peer.ID, privKey crypto.PrivKey) sec.SecureTransport {
 	secMuxer := new(csms.SSMuxer)
-	secMuxer.AddTransport(insecure.ID, insecure.New(id))
+	secMuxer.AddTransport(insecure.ID, insecure.NewWithIdentity(id, privKey))
 	return secMuxer
 }
 

--- a/config/security.go
+++ b/config/security.go
@@ -2,8 +2,8 @@ package config
 
 import (
 	"fmt"
-	"github.com/libp2p/go-libp2p-core/crypto"
 
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"


### PR DESCRIPTION
Hey @bigs & @raulk, I realized that I never closed the loop on this and pushed the go-libp2p branch that uses the new plaintext constructor. Sorry about that!