### PR TITLE
Added utp transport

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -11,6 +11,7 @@ import (
 	secio "github.com/libp2p/go-libp2p-secio"
 	yamux "github.com/libp2p/go-libp2p-yamux"
 	tcp "github.com/libp2p/go-tcp-transport"
+	utp "github.com/libp2p/go-utp-transport"
 	ws "github.com/libp2p/go-ws-transport"
 	multiaddr "github.com/multiformats/go-multiaddr"
 )
@@ -36,6 +37,7 @@ var DefaultMuxers = ChainOptions(
 // libp2p instead of replacing them.
 var DefaultTransports = ChainOptions(
 	Transport(tcp.NewTCPTransport),
+	Transport(tcp.NewUtpTransport),
 	Transport(ws.New),
 )
 


### PR DESCRIPTION
Blocked: libp2p/go-utp-transport#5

Still need to be rebased with the correct go.mod when libp2p/go-utp-transport newer version is released.
I added in default and not in ipfs/go-ipfs because it was here in the past (see c441a14b693d7316700caae2ead204d7de770dd3).