### PR TITLE
fix(identify): announce localhost as long as one side of the connection is local

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -333,7 +333,8 @@ func (ids *IDService) populateMessage(mes *pb.Identify, c network.Conn) {
 
 	// set listen addrs, get our latest addrs from Host.
 	laddrs := ids.Host.Addrs()
-	viaLoopback := manet.IsIPLoopback(c.LocalMultiaddr())
+	// Note: LocalMultiaddr is sometimes 0.0.0.0
+	viaLoopback := manet.IsIPLoopback(c.LocalMultiaddr()) || manet.IsIPLoopback(c.RemoteMultiaddr())
 	mes.ListenAddrs = make([][]byte, 0, len(laddrs))
 	for _, addr := range laddrs {
 		if !viaLoopback && manet.IsIPLoopback(addr) {


### PR DESCRIPTION
Some transports return 0.0.0.0 for the local address. Really, if one side is local, both we're on the same machine.

fixes https://github.com/libp2p/go-libp2p-quic-transport/pull/66