### PR TITLE
fix: remove an unnecessary goroutine

### DIFF
--- a/p2p/protocol/identify/id_delta.go
+++ b/p2p/protocol/identify/id_delta.go
@@ -25,7 +25,8 @@ func (ids *IDService) deltaHandler(s network.Stream) {
 		return
 	}
 
-	defer func() { go helpers.FullClose(s) }()
+	defer helpers.FullClose(s)
+
 	log.Debugf("%s received message from %s %s", s.Protocol(), c.RemotePeer(), c.RemoteMultiaddr())
 
 	delta := mes.GetDelta()


### PR DESCRIPTION
The stream handler runs in a goroutine anyways. We might as well block it.