### PR TITLE
docs: uniform comment sentences

### DIFF
--- a/config/muxer.go
+++ b/config/muxer.go
@@ -8,7 +8,7 @@ import (
 	msmux "github.com/libp2p/go-stream-muxer-multistream"
 )
 
-// MuxC is a stream multiplex transport constructor
+// MuxC is a stream multiplex transport constructor.
 type MuxC func(h host.Host) (mux.Multiplexer, error)
 
 // MsMuxC is a tuple containing a multiplex transport constructor and a protocol

--- a/config/security.go
+++ b/config/security.go
@@ -12,7 +12,7 @@ import (
 	csms "github.com/libp2p/go-conn-security-multistream"
 )
 
-// SecC is a security transport constructor
+// SecC is a security transport constructor.
 type SecC func(h host.Host) (sec.SecureTransport, error)
 
 // MsSecC is a tuple containing a security transport constructor and a protocol

--- a/defaults.go
+++ b/defaults.go
@@ -44,7 +44,7 @@ var DefaultPeerstore Option = func(cfg *Config) error {
 	return cfg.Apply(Peerstore(pstoremem.NewPeerstore()))
 }
 
-// RandomIdentity generates a random identity (default behaviour)
+// RandomIdentity generates a random identity. (default behaviour)
 var RandomIdentity = func(cfg *Config) error {
 	priv, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
 	if err != nil {
@@ -53,7 +53,7 @@ var RandomIdentity = func(cfg *Config) error {
 	return cfg.Apply(Identity(priv))
 }
 
-// DefaultListenAddrs configures libp2p to use default listen address
+// DefaultListenAddrs configures libp2p to use default listen address.
 var DefaultListenAddrs = func(cfg *Config) error {
 	defaultIP4ListenAddr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
 	if err != nil {
@@ -70,7 +70,7 @@ var DefaultListenAddrs = func(cfg *Config) error {
 	))
 }
 
-// DefaultEnableRelay enables relay dialing and listening by default
+// DefaultEnableRelay enables relay dialing and listening by default.
 var DefaultEnableRelay = func(cfg *Config) error {
 	return cfg.Apply(EnableRelay())
 }

--- a/libp2p.go
+++ b/libp2p.go
@@ -8,7 +8,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 )
 
-// Config describes a set of settings for a libp2p node
+// Config describes a set of settings for a libp2p node.
 type Config = config.Config
 
 // Option is a libp2p config option that can be given to the libp2p constructor

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 package libp2p
 
 // This file contains all libp2p configuration options (except the defaults,
-// those are in defaults.go)
+// those are in defaults.go).
 
 import (
 	"fmt"
@@ -249,7 +249,7 @@ func EnableAutoRelay() Option {
 
 // StaticRelays configures known relays for autorelay; when this option is enabled
 // then the system will use the configured relays instead of querying the DHT to
-// discover relays
+// discover relays.
 func StaticRelays(relays []peer.AddrInfo) Option {
 	return func(cfg *Config) error {
 		cfg.StaticRelays = append(cfg.StaticRelays, relays...)
@@ -257,7 +257,7 @@ func StaticRelays(relays []peer.AddrInfo) Option {
 	}
 }
 
-// DefaultStaticRelays configures the static relays to use the known PL-operated relays
+// DefaultStaticRelays configures the static relays to use the known PL-operated relays.
 func DefaultStaticRelays() Option {
 	return func(cfg *Config) error {
 		for _, addr := range autorelay.DefaultRelays {
@@ -292,7 +292,7 @@ func FilterAddresses(addrs ...*net.IPNet) Option {
 }
 
 // Filters configures libp2p to use the given filters for accepting/denying
-// certain addresses. Filters offers more control and should be use when the
+// certain addresses. Filters offers more control and should be used when the
 // addresses you want to accept/deny are not known ahead of time and can
 // dynamically change.
 func Filters(filters *filter.Filters) Option {


### PR DESCRIPTION
After going through the code I found a few inconsistencies on comment sentences.

Some comment sentences did not end in a period, which causes inconsistent docs with the majority of libp2p docs and broader go ecosystem. [golang/go/wiki/CodeReviewComments#comment-sentences](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) recommends that we end with this period, which we mostly do in the codebase.

Also fixed a minor typo.