### PR TITLE
feat(mock): reliable notifications

### DIFF
--- a/p2p/net/mock/complement.go
+++ b/p2p/net/mock/complement.go
@@ -1,0 +1,17 @@
+package mocknet
+
+import (
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+// StreamComplement returns the other end of the given stream. This function
+// panics when passed a non-mocknet stream.
+func StreamComplement(s network.Stream) network.Stream {
+	return s.(*stream).rstream
+}
+
+// ConnComplement returns the other end of the given connection. This function
+// panics when passed a non-mocknet connection.
+func ConnComplement(c network.Conn) network.Conn {
+	return c.(*conn).rconn
+}

--- a/p2p/net/mock/mock_conn.go
+++ b/p2p/net/mock/mock_conn.go
@@ -15,6 +15,8 @@ import (
 // live connection between two peers.
 // it goes over a particular link.
 type conn struct {
+	notifLk sync.Mutex
+
 	local  peer.ID
 	remote peer.ID
 
@@ -34,8 +36,8 @@ type conn struct {
 	sync.RWMutex
 }
 
-func newConn(ln, rn *peernet, l *link, dir network.Direction) *conn {
-	c := &conn{net: ln, link: l}
+func newConn(p process.Process, ln, rn *peernet, l *link, dir network.Direction) *conn {
+	c := &conn{net: ln, link: l, proc: p}
 	c.local = ln.peer
 	c.remote = rn.peer
 	c.stat = network.Stat{Direction: dir}
@@ -46,7 +48,7 @@ func newConn(ln, rn *peernet, l *link, dir network.Direction) *conn {
 	c.localPrivKey = ln.ps.PrivKey(ln.peer)
 	c.remotePubKey = rn.ps.PubKey(rn.peer)
 
-	c.proc = process.WithTeardown(c.teardown)
+	c.proc.AddChild(process.WithTeardown(c.teardown))
 	return c
 }
 
@@ -59,6 +61,9 @@ func (c *conn) teardown() error {
 		s.Reset()
 	}
 	c.net.removeConn(c)
+
+	c.notifLk.Lock()
+	defer c.notifLk.Unlock()
 	c.net.notifyAll(func(n network.Notifiee) {
 		n.Disconnected(c.net, c)
 	})
@@ -69,18 +74,29 @@ func (c *conn) addStream(s *stream) {
 	c.Lock()
 	s.conn = c
 	c.streams.PushBack(s)
+	s.notifLk.Lock()
+	defer s.notifLk.Unlock()
 	c.Unlock()
+	c.net.notifyAll(func(n network.Notifiee) {
+		n.OpenedStream(c.net, s)
+	})
 }
 
 func (c *conn) removeStream(s *stream) {
 	c.Lock()
-	defer c.Unlock()
 	for e := c.streams.Front(); e != nil; e = e.Next() {
 		if s == e.Value {
 			c.streams.Remove(e)
-			return
+			break
 		}
 	}
+	c.Unlock()
+
+	s.notifLk.Lock()
+	defer s.notifLk.Unlock()
+	s.conn.net.notifyAll(func(n network.Notifiee) {
+		n.ClosedStream(s.conn.net, s)
+	})
 }
 
 func (c *conn) allStreams() []network.Stream {
@@ -98,18 +114,12 @@ func (c *conn) allStreams() []network.Stream {
 func (c *conn) remoteOpenedStream(s *stream) {
 	c.addStream(s)
 	c.net.handleNewStream(s)
-	c.net.notifyAll(func(n network.Notifiee) {
-		n.OpenedStream(c.net, s)
-	})
 }
 
 func (c *conn) openStream() *stream {
-	sl, sr := c.link.newStreamPair()
+	sl, sr := newStreamPair()
+	go c.rconn.remoteOpenedStream(sr)
 	c.addStream(sl)
-	c.net.notifyAll(func(n network.Notifiee) {
-		n.OpenedStream(c.net, sl)
-	})
-	c.rconn.remoteOpenedStream(sr)
 	return sl
 }
 

--- a/p2p/net/mock/mock_stream.go
+++ b/p2p/net/mock/mock_stream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,9 +16,13 @@ import (
 
 // stream implements network.Stream
 type stream struct {
+	notifLk sync.Mutex
+
+	rstream *stream
+	conn    *conn
+
 	write     *io.PipeWriter
 	read      *io.PipeReader
-	conn      *conn
 	toDeliver chan *transportObject
 
 	reset  chan struct{}
@@ -37,7 +42,18 @@ type transportObject struct {
 	arrivalTime time.Time
 }
 
-func NewStream(w *io.PipeWriter, r *io.PipeReader, dir network.Direction) *stream {
+func newStreamPair() (*stream, *stream) {
+	ra, wb := io.Pipe()
+	rb, wa := io.Pipe()
+
+	sa := newStream(wa, ra, network.DirOutbound)
+	sb := newStream(wb, rb, network.DirInbound)
+	sa.rstream = sb
+	sb.rstream = sa
+	return sa, sb
+}
+
+func newStream(w *io.PipeWriter, r *io.PipeReader, dir network.Direction) *stream {
 	s := &stream{
 		read:      r,
 		write:     w,
@@ -117,10 +133,6 @@ func (s *stream) teardown() {
 
 	// Mark as closed.
 	close(s.closed)
-
-	s.conn.net.notifyAll(func(n network.Notifiee) {
-		n.ClosedStream(s.conn.net, s)
-	})
 }
 
 func (s *stream) Conn() network.Conn {


### PR DESCRIPTION
* Export StreamComplement/ConnComplement convenience functions.
* Make the TestNotifications test pass reliably, even when we have a bunch of streams (identify, etc.).
* Make the mock net order disconnect events after connect events.
* Make closing one side of a connection actually close both sides.
* Make it possible to extract a mock stream's complement.
* Fire remote events at the same time as the local events.

I'm hoping this will put an end to spurious test failures due to mocknet issues.
Just kidding, that'll never happen.