### PR TITLE
Update id.go

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -204,7 +204,7 @@ func (ids *IDService) handleProtosChanged(evt event.EvtLocalProtocolsUpdated) {
 func (ids *IDService) handleLocalAddrsUpdated(evt event.EvtLocalAddressesUpdated) {
 	ids.peerrecMu.Lock()
 	rec := evt.SignedPeerRecord
-	ids.peerrec = &rec
+	ids.peerrec = rec
 	ids.peerrecMu.Unlock()
 
 	log.Debug("triggering push based on updated local PeerRecord")


### PR DESCRIPTION
IDService.peerrec and evt.SignedPeerRecord both are `*record.Envelope` type , cannot compile with pointer assignment

```go
func (ids *IDService) handleLocalAddrsUpdated(evt event.EvtLocalAddressesUpdated) {
	ids.peerrecMu.Lock()
	rec := evt.SignedPeerRecord
	ids.peerrec = &rec // ???
	ids.peerrecMu.Unlock()

	log.Debug("triggering push based on updated local PeerRecord")
	ids.Push()
}
```