### PR TITLE
fix: SignedPeerRecord now expects pointer to envelope

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -376,7 +376,8 @@ func (h *BasicHost) background() {
 			log.Errorf("error creating a signed peer record from the set of current addresses, err=%s", err)
 			return
 		}
-		changeEvt.SignedPeerRecord = *sr
+
+		changeEvt.SignedPeerRecord = sr
 
 		// persist the signed record to the peerstore
 		if _, err := h.caBook.ConsumePeerRecord(sr, peerstore.PermanentAddrTTL); err != nil {

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -463,7 +463,7 @@ func TestAddrResolution(t *testing.T) {
 	p2paddr3 := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p2.Pretty())
 
 	backend := &madns.MockBackend{
-		TXT: map[string][]string{"_dnsaddr.example.com": []string{
+		TXT: map[string][]string{"_dnsaddr.example.com": {
 			"dnsaddr=" + p2paddr2.String(), "dnsaddr=" + p2paddr3.String(),
 		}},
 	}
@@ -509,14 +509,14 @@ func TestAddrResolutionRecursive(t *testing.T) {
 
 	backend := &madns.MockBackend{
 		TXT: map[string][]string{
-			"_dnsaddr.example.com": []string{
+			"_dnsaddr.example.com": {
 				"dnsaddr=" + p2paddr1i.String(),
 				"dnsaddr=" + p2paddr2i.String(),
 			},
-			"_dnsaddr.foo.example.com": []string{
+			"_dnsaddr.foo.example.com": {
 				"dnsaddr=" + p2paddr1f.String(),
 			},
-			"_dnsaddr.bar.example.com": []string{
+			"_dnsaddr.bar.example.com": {
 				"dnsaddr=" + p2paddr2i.String(),
 			},
 		},
@@ -589,7 +589,7 @@ func TestAddrChangeImmediatelyIfAddressNonEmpty(t *testing.T) {
 	// assert it's in the peerstore
 	ev := h.Peerstore().(peerstore.CertifiedAddrBook).GetPeerRecord(h.ID())
 	require.NotNil(t, ev)
-	rc = peerRecordFromEnvelope(t, *ev)
+	rc = peerRecordFromEnvelope(t, ev)
 	require.Equal(t, taddrs, rc.Addrs)
 }
 
@@ -678,7 +678,7 @@ func TestHostAddrChangeDetection(t *testing.T) {
 		// assert it's in the peerstore
 		ev := h.Peerstore().(peerstore.CertifiedAddrBook).GetPeerRecord(h.ID())
 		require.NotNil(t, ev)
-		rc = peerRecordFromEnvelope(t, *ev)
+		rc = peerRecordFromEnvelope(t, ev)
 		require.Equal(t, addrSets[i], rc.Addrs)
 	}
 }
@@ -738,7 +738,7 @@ func updatedAddrEventsEqual(a, b event.EvtLocalAddressesUpdated) bool {
 		updatedAddrsEqual(a.Removed, b.Removed)
 }
 
-func peerRecordFromEnvelope(t *testing.T, ev record.Envelope) *peer.PeerRecord {
+func peerRecordFromEnvelope(t *testing.T, ev *record.Envelope) *peer.PeerRecord {
 	t.Helper()
 	rec, err := ev.Record()
 	if err != nil {

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -204,7 +204,7 @@ func (ids *IDService) handleProtosChanged(evt event.EvtLocalProtocolsUpdated) {
 func (ids *IDService) handleLocalAddrsUpdated(evt event.EvtLocalAddressesUpdated) {
 	ids.peerrecMu.Lock()
 	rec := evt.SignedPeerRecord
-	ids.peerrec = &rec
+	ids.peerrec = rec
 	ids.peerrecMu.Unlock()
 
 	log.Debug("triggering push based on updated local PeerRecord")

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -236,7 +236,8 @@ func generatePeerRecord(t *testing.T, h host.Host) {
 	if err != nil {
 		t.Fatalf("error generating peer record: %s", err)
 	}
-	evt := event.EvtLocalAddressesUpdated{SignedPeerRecord: *signed}
+
+	evt := event.EvtLocalAddressesUpdated{SignedPeerRecord: signed}
 	emitter, err := h.EventBus().Emitter(new(event.EvtLocalAddressesUpdated), eventbus.Stateful)
 	if err != nil {
 		t.Fatal(err)
@@ -625,6 +626,10 @@ func TestCompatibilityWithPeersThatDoNotSupportSignedAddrs(t *testing.T) {
 
 	// if we re-identify, h1 should now have certified addrs for h2
 	ids.IdentifyConn(h1t2c[0])
+
+	// Slight pause to allow peerstore to be updated
+	<-time.After(100 * time.Millisecond)
+
 	t.Log("test peer1 has peer2 certified addrs correctly")
 	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p))
 }


### PR DESCRIPTION
go-libp2p-core changed EvtLocalAddressesUpdated.SignedPeerRecord into
a pointer to record.Envelope to avoid copying a mutex. This broke
the build of go-libp2p.

Fixed by not dereferencing pointers when assigning.

Also fix TestCompatibilityWithPeersThatDoNotSupportSignedAddrs test
which was failing due to a race between update and test.