### PR TITLE
Disable generation of Signed peer record for Mockenets

### DIFF
--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -107,7 +107,8 @@ func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps peerstore.Peerstore) (host
 	}
 
 	opts := &bhost.HostOpts{
-		NegotiationTimeout: -1,
+		NegotiationTimeout:      -1,
+		DisableSignedPeerRecord: true,
 	}
 
 	h, err := bhost.NewHost(mn.ctx, n, opts)

--- a/p2p/protocol/identify/opts.go
+++ b/p2p/protocol/identify/opts.go
@@ -1,7 +1,8 @@
 package identify
 
 type config struct {
-	userAgent string
+	userAgent               string
+	disableSignedPeerRecord bool
 }
 
 // Option is an option function for identify.
@@ -11,5 +12,13 @@ type Option func(*config)
 func UserAgent(ua string) Option {
 	return func(cfg *config) {
 		cfg.userAgent = ua
+	}
+}
+
+// DisableSignedPeerRecord disables populating signed peer records on the outgoing Identify response
+// and ONLY sends the unsigned addresses.
+func DisableSignedPeerRecord() Option {
+	return func(cfg *config) {
+		cfg.disableSignedPeerRecord = true
 	}
 }


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p/issues/929.

Mocknets use Bogus private keys which shouldn't be used for signing records. However, this leads to the peer sending malformed signed peer records which floods up our test logs. 

This PR exposes an Option on the Host to disable generation of signed peer records. It also ensures that Identify responses we send ONLY have unsigned addresses. 
ONLY Mocknets uses this Option.