### PR TITLE
add test to demo missing peer records after listen

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -232,6 +232,16 @@ func NewHost(ctx context.Context, net network.Network, opts *HostOpts) (*BasicHo
 
 	net.SetStreamHandler(h.newStreamHandler)
 
+	// register to be notified when the network's listen addrs change,
+	// so we can update our address set and push events if needed
+	listenHandler := func(network.Network, ma.Multiaddr) {
+		h.SignalAddressChange()
+	}
+	net.Notify(&network.NotifyBundle{
+		ListenF:      listenHandler,
+		ListenCloseF: listenHandler,
+	})
+
 	return h, nil
 }
 

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -94,6 +94,44 @@ func TestMultipleClose(t *testing.T) {
 
 }
 
+func TestSignedPeerRecordWithNoListenAddrs(t *testing.T) {
+	ctx := context.Background()
+
+	h := New(swarmt.GenSwarm(t, ctx, swarmt.OptDialOnly))
+
+	if len(h.Addrs()) != 0 {
+		t.Errorf("expected no listen addrs, got %d", len(h.Addrs()))
+	}
+
+	// now add a listen addr
+	err := h.Network().Listen(ma.StringCast("/ip4/0.0.0.0/tcp/0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(h.Addrs()) < 1 {
+		t.Errorf("expected at least 1 listen addr, got %d", len(h.Addrs()))
+	}
+
+	// sadly, we still don't have a signed peer record, since the addr change ticker hasn't ticked yet
+	cab, ok := peerstore.GetCertifiedAddrBook(h.Peerstore())
+	if !ok {
+		t.Fatalf("peerstore doesn't support certified addrs")
+	}
+	rec := cab.GetPeerRecord(h.ID())
+	if rec != nil {
+		t.Fatalf("no signed peer record in peerstore for new host %s", h.ID())
+	}
+
+	// after sleeping we should have the record
+	time.Sleep(5100 * time.Millisecond)
+
+	// assert that the hosts' peerstore has a signed record for itself
+	rec = cab.GetPeerRecord(h.ID())
+	if rec == nil {
+		t.Fatalf("no signed peer record in peerstore for new host %s", h.ID())
+	}
+}
+
 func TestProtocolHandlerEvents(t *testing.T) {
 	ctx := context.Background()
 	h := New(swarmt.GenSwarm(t, ctx))

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -114,7 +114,7 @@ func TestSignedPeerRecordWithNoListenAddrs(t *testing.T) {
 
 	// we need to sleep for a moment, since the signed record with the new addr is
 	// added async
-	time.Sleep(time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	cab, ok := peerstore.GetCertifiedAddrBook(h.Peerstore())
 	if !ok {

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -113,20 +113,14 @@ func TestSignedPeerRecordWithNoListenAddrs(t *testing.T) {
 	}
 
 	// sadly, we still don't have a signed peer record, since the addr change ticker hasn't ticked yet
+	// uncommenting this causes the test to pass:
+	// time.Sleep(5100 * time.Millisecond)
+
 	cab, ok := peerstore.GetCertifiedAddrBook(h.Peerstore())
 	if !ok {
 		t.Fatalf("peerstore doesn't support certified addrs")
 	}
 	rec := cab.GetPeerRecord(h.ID())
-	if rec != nil {
-		t.Fatalf("no signed peer record in peerstore for new host %s", h.ID())
-	}
-
-	// after sleeping we should have the record
-	time.Sleep(5100 * time.Millisecond)
-
-	// assert that the hosts' peerstore has a signed record for itself
-	rec = cab.GetPeerRecord(h.ID())
 	if rec == nil {
 		t.Fatalf("no signed peer record in peerstore for new host %s", h.ID())
 	}

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -112,9 +112,9 @@ func TestSignedPeerRecordWithNoListenAddrs(t *testing.T) {
 		t.Errorf("expected at least 1 listen addr, got %d", len(h.Addrs()))
 	}
 
-	// sadly, we still don't have a signed peer record, since the addr change ticker hasn't ticked yet
-	// uncommenting this causes the test to pass:
-	// time.Sleep(5100 * time.Millisecond)
+	// we need to sleep for a moment, since the signed record with the new addr is
+	// added async
+	time.Sleep(time.Millisecond)
 
 	cab, ok := peerstore.GetCertifiedAddrBook(h.Peerstore())
 	if !ok {


### PR DESCRIPTION
This shows off what I think is causing https://github.com/libp2p/go-libp2p/issues/939

The problem is that we're starting our hosts without listen addrs, and apparently the peerstore isn't keeping our signed records since they don't have any addrs. Then, when we call `.Listen`, it takes ~ 5 seconds for the change to be detected and the new record to be generated.

cc @aarshkshah1992 @raulk @vyzo 