### PR TITLE
make the {F=>f}iltersConnectionGater private.

### DIFF
--- a/options.go
+++ b/options.go
@@ -333,20 +333,20 @@ func AutoNATServiceRateLimit(global, perPeer int, interval time.Duration) Option
 // Deprecated: Please use ConnectionGater() instead.
 func FilterAddresses(addrs ...*net.IPNet) Option {
 	return func(cfg *Config) error {
-		var f *FiltersConnectionGater
+		var f *filtersConnectionGater
 
 		// preserve backwards compatibility.
-		// if we have a connection gater, try to cast it to a *FiltersConnectionGater.
+		// if we have a connection gater, try to cast it to a *filtersConnectionGater.
 		if cfg.ConnectionGater != nil {
 			var ok bool
-			if f, ok = cfg.ConnectionGater.(*FiltersConnectionGater); !ok {
+			if f, ok = cfg.ConnectionGater.(*filtersConnectionGater); !ok {
 				return errors.New("cannot configure both Filters and Connection Gater. " +
 					"\n Please consider configuring just a ConnectionGater instead.")
 			}
 		}
 
 		if f == nil {
-			f = (*FiltersConnectionGater)(ma.NewFilters())
+			f = (*filtersConnectionGater)(ma.NewFilters())
 			cfg.ConnectionGater = f
 		}
 
@@ -374,7 +374,7 @@ func Filters(filters *ma.Filters) Option {
 				"\n Please consider configuring just a ConnectionGater instead.")
 
 		}
-		cfg.ConnectionGater = (*FiltersConnectionGater)(filters)
+		cfg.ConnectionGater = (*filtersConnectionGater)(filters)
 		return nil
 	}
 }

--- a/options_filter.go
+++ b/options_filter.go
@@ -9,29 +9,28 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// FiltersConnectionGater is an adapter that turns multiaddr.Filter into a
-// connmgr.ConnectionGater. It's not intended to be used directly by the user,
-// but it can.
-type FiltersConnectionGater ma.Filters
+// filtersConnectionGater is an adapter that turns multiaddr.Filter into a
+// connmgr.ConnectionGater.
+type filtersConnectionGater ma.Filters
 
-var _ connmgr.ConnectionGater = (*FiltersConnectionGater)(nil)
+var _ connmgr.ConnectionGater = (*filtersConnectionGater)(nil)
 
-func (f *FiltersConnectionGater) InterceptAddrDial(_ peer.ID, addr ma.Multiaddr) (allow bool) {
+func (f *filtersConnectionGater) InterceptAddrDial(_ peer.ID, addr ma.Multiaddr) (allow bool) {
 	return !(*ma.Filters)(f).AddrBlocked(addr)
 }
 
-func (f *FiltersConnectionGater) InterceptPeerDial(p peer.ID) (allow bool) {
+func (f *filtersConnectionGater) InterceptPeerDial(p peer.ID) (allow bool) {
 	return true
 }
 
-func (f *FiltersConnectionGater) InterceptAccept(_ network.ConnMultiaddrs) (allow bool) {
+func (f *filtersConnectionGater) InterceptAccept(_ network.ConnMultiaddrs) (allow bool) {
 	return true
 }
 
-func (f *FiltersConnectionGater) InterceptSecured(_ network.Direction, _ peer.ID, _ network.ConnMultiaddrs) (allow bool) {
+func (f *filtersConnectionGater) InterceptSecured(_ network.Direction, _ peer.ID, _ network.ConnMultiaddrs) (allow bool) {
 	return true
 }
 
-func (f *FiltersConnectionGater) InterceptUpgraded(_ network.Conn) (allow bool, reason control.DisconnectReason) {
+func (f *filtersConnectionGater) InterceptUpgraded(_ network.Conn) (allow bool, reason control.DisconnectReason) {
 	return true, 0
 }


### PR DESCRIPTION
There's no reason for this adapter to be public and muddy the public namespace:

* The user can only set `Filters` via the constructor.
* In no other place would a user need to convert an existing `Filters` to a `ConnectionGater`. `ConnectionGaters` are also set via the constructor.