### PR TITLE
Fixed compilation error due to net.Notify

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -245,7 +245,7 @@ func NewHost(ctx context.Context, n network.Network, opts *HostOpts) (*BasicHost
 	listenHandler := func(network.Network, ma.Multiaddr) {
 		h.SignalAddressChange()
 	}
-	net.Notify(&network.NotifyBundle{
+	n.Notify(&network.NotifyBundle{
 		ListenF:      listenHandler,
 		ListenCloseF: listenHandler,
 	})


### PR DESCRIPTION
See https://github.com/libp2p/go-libp2p/pull/936.