### PR TITLE
optimize numInbound count

### DIFF
--- a/p2p/net/mock/mock_link.go
+++ b/p2p/net/mock/mock_link.go
@@ -34,15 +34,15 @@ func (l *link) newConnPair(dialer *peernet) (*conn, *conn) {
 	defer l.RUnlock()
 
 	parent := process.WithTeardown(func() error { return nil })
-	c1 := newConn(parent, l.nets[0], l.nets[1], l, network.DirOutbound)
-	c2 := newConn(parent, l.nets[1], l.nets[0], l, network.DirInbound)
-	c1.rconn = c2
-	c2.rconn = c1
-
-	if dialer == c1.net {
-		return c1, c2
+	target := l.nets[0]
+	if target == dialer {
+		target = l.nets[1]
 	}
-	return c2, c1
+	dc := newConn(parent, dialer, target, l, network.DirOutbound)
+	tc := newConn(parent, target, dialer, l, network.DirInbound)
+	dc.rconn = tc
+	tc.rconn = dc
+	return dc, tc
 }
 
 func (l *link) Networks() []network.Network {

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -40,29 +40,29 @@ type observation struct {
 	connDirection network.Direction
 }
 
-// ObservedAddr is an entry for an address reported by our peers.
+// observedAddr is an entry for an address reported by our peers.
 // We only use addresses that:
 // - have been observed at least 4 times in last 40 minutes. (counter symmetric nats)
 // - have been observed at least once recently (10 minutes), because our position in the
 //   network, or network port mapppings, may have changed.
-type ObservedAddr struct {
-	Addr     ma.Multiaddr
-	SeenBy   map[string]observation // peer(observer) address -> observation info
-	LastSeen time.Time
+type observedAddr struct {
+	addr     ma.Multiaddr
+	seenBy   map[string]observation // peer(observer) address -> observation info
+	lastSeen time.Time
 }
 
-func (oa *ObservedAddr) activated() bool {
+func (oa *observedAddr) activated() bool {
 
 	// We only activate if other peers observed the same address
 	// of ours at least 4 times. SeenBy peers are removed by GC if
 	// they say the address more than ttl*ActivationThresh
-	return len(oa.SeenBy) >= ActivationThresh
+	return len(oa.seenBy) >= ActivationThresh
 }
 
-func (oa *ObservedAddr) numInbound() int {
+func (oa *observedAddr) numInbound() int {
 	count := 0
-	for obs := range oa.SeenBy {
-		if oa.SeenBy[obs].connDirection == network.DirInbound {
+	for obs := range oa.seenBy {
+		if oa.seenBy[obs].connDirection == network.DirInbound {
 			count++
 		}
 	}
@@ -74,9 +74,9 @@ func (oa *ObservedAddr) numInbound() int {
 // observed address's group is just the address with all ports set to 0. This
 // means we can advertise the most commonly observed external ports without
 // advertising _every_ observed port.
-func (oa *ObservedAddr) GroupKey() string {
-	key := make([]byte, 0, len(oa.Addr.Bytes()))
-	ma.ForEach(oa.Addr, func(c ma.Component) bool {
+func (oa *observedAddr) groupKey() string {
+	key := make([]byte, 0, len(oa.addr.Bytes()))
+	ma.ForEach(oa.addr, func(c ma.Component) bool {
 		switch proto := c.Protocol(); proto.Code {
 		case ma.P_TCP, ma.P_UDP:
 			key = append(key, proto.VCode...)
@@ -107,7 +107,7 @@ type ObservedAddrManager struct {
 
 	mu sync.RWMutex
 	// local(internal) address -> list of observed(external) addresses
-	addrs        map[string][]*ObservedAddr
+	addrs        map[string][]*observedAddr
 	ttl          time.Duration
 	refreshTimer *time.Timer
 
@@ -119,7 +119,7 @@ type ObservedAddrManager struct {
 // peerstore.OwnObservedAddressTTL as the TTL.
 func NewObservedAddrManager(ctx context.Context, host host.Host) *ObservedAddrManager {
 	oas := &ObservedAddrManager{
-		addrs:       make(map[string][]*ObservedAddr),
+		addrs:       make(map[string][]*observedAddr),
 		ttl:         peerstore.OwnObservedAddrTTL,
 		wch:         make(chan newObservation, observedAddrManagerWorkerChannelSize),
 		host:        host,
@@ -160,22 +160,22 @@ func (oas *ObservedAddrManager) Addrs() []ma.Multiaddr {
 		return nil
 	}
 
-	var allObserved []*ObservedAddr
+	var allObserved []*observedAddr
 	for k := range oas.addrs {
 		allObserved = append(allObserved, oas.addrs[k]...)
 	}
 	return oas.filter(allObserved)
 }
 
-func (oas *ObservedAddrManager) filter(observedAddrs []*ObservedAddr) []ma.Multiaddr {
-	pmap := make(map[string][]*ObservedAddr)
+func (oas *ObservedAddrManager) filter(observedAddrs []*observedAddr) []ma.Multiaddr {
+	pmap := make(map[string][]*observedAddr)
 	now := time.Now()
 
 	for i := range observedAddrs {
 		a := observedAddrs[i]
-		if now.Sub(a.LastSeen) <= oas.ttl && a.activated() {
+		if now.Sub(a.lastSeen) <= oas.ttl && a.activated() {
 			// group addresses by their IPX/Transport Protocol(TCP or UDP) pattern.
-			pat := a.GroupKey()
+			pat := a.groupKey()
 			pmap[pat] = append(pmap[pat], a)
 
 		}
@@ -195,11 +195,11 @@ func (oas *ObservedAddrManager) filter(observedAddrs []*ObservedAddr) []ma.Multi
 				return true
 			}
 
-			return len(first.SeenBy) > len(second.SeenBy)
+			return len(first.seenBy) > len(second.seenBy)
 		})
 
 		for i := 0; i < maxObservedAddrsPerIPAndTransport && i < len(s); i++ {
-			addrs = append(addrs, s[i].Addr)
+			addrs = append(addrs, s[i].addr)
 		}
 	}
 
@@ -281,14 +281,14 @@ func (oas *ObservedAddrManager) gc() {
 		filteredAddrs := observedAddrs[:0]
 		for _, a := range observedAddrs {
 			// clean up SeenBy set
-			for k, ob := range a.SeenBy {
+			for k, ob := range a.seenBy {
 				if now.Sub(ob.seenTime) > oas.ttl*time.Duration(ActivationThresh) {
-					delete(a.SeenBy, k)
+					delete(a.seenBy, k)
 				}
 			}
 
 			// leave only alive observed addresses
-			if now.Sub(a.LastSeen) <= oas.ttl {
+			if now.Sub(a.lastSeen) <= oas.ttl {
 				filteredAddrs = append(filteredAddrs, a)
 			}
 		}
@@ -389,19 +389,19 @@ func (oas *ObservedAddrManager) recordObservationUnlocked(conn network.Conn, obs
 	observedAddrs := oas.addrs[localString]
 	// check if observed address seen yet, if so, update it
 	for i, previousObserved := range observedAddrs {
-		if previousObserved.Addr.Equal(observed) {
-			observedAddrs[i].SeenBy[observerString] = ob
-			observedAddrs[i].LastSeen = now
+		if previousObserved.addr.Equal(observed) {
+			observedAddrs[i].seenBy[observerString] = ob
+			observedAddrs[i].lastSeen = now
 			return
 		}
 	}
 	// observed address not seen yet, append it
-	oas.addrs[localString] = append(oas.addrs[localString], &ObservedAddr{
-		Addr: observed,
-		SeenBy: map[string]observation{
+	oas.addrs[localString] = append(oas.addrs[localString], &observedAddr{
+		addr: observed,
+		seenBy: map[string]observation{
 			observerString: ob,
 		},
-		LastSeen: now,
+		lastSeen: now,
 	})
 }
 

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -35,9 +35,15 @@ var observedAddrManagerWorkerChannelSize = 16
 // we will return for each (IPx/TCP or UDP) group.
 var maxObservedAddrsPerIPAndTransport = 2
 
+// observation records an address observation from an "observer" (where every IP
+// address is a unique observer).
 type observation struct {
+	// seenTime is the last time this observation was made.
 	seenTime time.Time
-	inbound  bool
+	// inbound indicates whether or not this observation has been made from
+	// an inbound connection. This remains true even if we an observation
+	// from a subsequent outbound connection.
+	inbound bool
 }
 
 // observedAddr is an entry for an address reported by our peers.

--- a/p2p/protocol/identify/obsaddr_glass_test.go
+++ b/p2p/protocol/identify/obsaddr_glass_test.go
@@ -1,0 +1,38 @@
+package identify
+
+// This test lives in the identify package, not the identify_test package, so it
+// can access internal types.
+
+import (
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObservedAddrGroupKey(t *testing.T) {
+	oa1 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/tcp/2345")}
+	oa2 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/tcp/1231")}
+	oa3 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.5/tcp/1231")}
+	oa4 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1231")}
+	oa5 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1531")}
+	oa6 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1531/quic")}
+	oa7 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1111/quic")}
+	oa8 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.5/udp/1111/quic")}
+
+	// different ports, same IP => same key
+	require.Equal(t, oa1.groupKey(), oa2.groupKey())
+	// different IPs => different key
+	require.NotEqual(t, oa2.groupKey(), oa3.groupKey())
+	// same port, different protos => different keys
+	require.NotEqual(t, oa3.groupKey(), oa4.groupKey())
+	// same port, same address, different protos => different keys
+	require.NotEqual(t, oa2.groupKey(), oa4.groupKey())
+	// udp works as well
+	require.Equal(t, oa4.groupKey(), oa5.groupKey())
+	// udp and quic are different
+	require.NotEqual(t, oa5.groupKey(), oa6.groupKey())
+	// quic works as well
+	require.Equal(t, oa6.groupKey(), oa7.groupKey())
+	require.NotEqual(t, oa7.groupKey(), oa8.groupKey())
+}

--- a/p2p/protocol/identify/obsaddr_test.go
+++ b/p2p/protocol/identify/obsaddr_test.go
@@ -312,30 +312,3 @@ func TestObservedAddrFiltering(t *testing.T) {
 	require.Contains(t, addrs, it7)
 
 }
-
-func TestObservedAddrGroupKey(t *testing.T) {
-	oa1 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.4/tcp/2345")}
-	oa2 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.4/tcp/1231")}
-	oa3 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.5/tcp/1231")}
-	oa4 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.4/udp/1231")}
-	oa5 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.4/udp/1531")}
-	oa6 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.4/udp/1531/quic")}
-	oa7 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.4/udp/1111/quic")}
-	oa8 := &identify.ObservedAddr{Addr: ma.StringCast("/ip4/1.2.3.5/udp/1111/quic")}
-
-	// different ports, same IP => same key
-	require.Equal(t, oa1.GroupKey(), oa2.GroupKey())
-	// different IPs => different key
-	require.NotEqual(t, oa2.GroupKey(), oa3.GroupKey())
-	// same port, different protos => different keys
-	require.NotEqual(t, oa3.GroupKey(), oa4.GroupKey())
-	// same port, same address, different protos => different keys
-	require.NotEqual(t, oa2.GroupKey(), oa4.GroupKey())
-	// udp works as well
-	require.Equal(t, oa4.GroupKey(), oa5.GroupKey())
-	// udp and quic are different
-	require.NotEqual(t, oa5.GroupKey(), oa6.GroupKey())
-	// quic works as well
-	require.Equal(t, oa6.GroupKey(), oa7.GroupKey())
-	require.NotEqual(t, oa7.GroupKey(), oa8.GroupKey())
-}

--- a/p2p/protocol/identify/obsaddr_test.go
+++ b/p2p/protocol/identify/obsaddr_test.go
@@ -112,7 +112,7 @@ func TestObsAddrSet(t *testing.T) {
 		return m
 	}
 
-	addrsMarch := func(a, b []ma.Multiaddr) bool {
+	addrsMatch := func(a, b []ma.Multiaddr) bool {
 		if len(a) != len(b) {
 			return false
 		}
@@ -149,7 +149,7 @@ func TestObsAddrSet(t *testing.T) {
 
 	harness := newHarness(ctx, t)
 
-	if !addrsMarch(harness.oas.Addrs(), nil) {
+	if !addrsMatch(harness.oas.Addrs(), nil) {
 		t.Error("addrs should be empty")
 	}
 
@@ -167,7 +167,7 @@ func TestObsAddrSet(t *testing.T) {
 	harness.observe(a3, pa4)
 
 	// these are all different so we should not yet get them.
-	if !addrsMarch(harness.oas.Addrs(), nil) {
+	if !addrsMatch(harness.oas.Addrs(), nil) {
 		t.Error("addrs should _still_ be empty (once)")
 	}
 
@@ -175,7 +175,7 @@ func TestObsAddrSet(t *testing.T) {
 	harness.observe(a1, pa4)
 	harness.observe(a2, pa4)
 	harness.observe(a3, pa4)
-	if !addrsMarch(harness.oas.Addrs(), nil) {
+	if !addrsMatch(harness.oas.Addrs(), nil) {
 		t.Error("addrs should _still_ be empty (same obs)")
 	}
 
@@ -183,14 +183,14 @@ func TestObsAddrSet(t *testing.T) {
 	harness.observe(a1, pa5)
 	harness.observe(a2, pa5)
 	harness.observe(a3, pa5)
-	if !addrsMarch(harness.oas.Addrs(), nil) {
+	if !addrsMatch(harness.oas.Addrs(), nil) {
 		t.Error("addrs should _still_ be empty (same obs group)")
 	}
 
 	harness.observe(a1, pb1)
 	harness.observe(a1, pb2)
 	harness.observe(a1, pb3)
-	if !addrsMarch(harness.oas.Addrs(), []ma.Multiaddr{a1}) {
+	if !addrsMatch(harness.oas.Addrs(), []ma.Multiaddr{a1}) {
 		t.Error("addrs should only have a1")
 	}
 
@@ -205,14 +205,14 @@ func TestObsAddrSet(t *testing.T) {
 	harness.observe(a1, pb2)
 	harness.observe(a2, pb4)
 	harness.observe(a2, pb5)
-	if !addrsMarch(harness.oas.Addrs(), []ma.Multiaddr{a1, a2}) {
+	if !addrsMatch(harness.oas.Addrs(), []ma.Multiaddr{a1, a2}) {
 		t.Error("addrs should only have a1, a2")
 	}
 
 	// force a refresh.
 	harness.oas.SetTTL(time.Millisecond * 200)
 	<-time.After(time.Millisecond * 210)
-	if !addrsMarch(harness.oas.Addrs(), []ma.Multiaddr{a1, a2}) {
+	if !addrsMatch(harness.oas.Addrs(), []ma.Multiaddr{a1, a2}) {
 		t.Error("addrs should only have a1, a2")
 	}
 
@@ -228,7 +228,7 @@ func TestObsAddrSet(t *testing.T) {
 	<-time.After(time.Millisecond * 210)
 
 	// Should still have a2
-	if !addrsMarch(harness.oas.Addrs(), []ma.Multiaddr{a2}) {
+	if !addrsMatch(harness.oas.Addrs(), []ma.Multiaddr{a2}) {
 		t.Error("should only have a2, have: ", harness.oas.Addrs())
 	}
 
@@ -238,7 +238,7 @@ func TestObsAddrSet(t *testing.T) {
 	<-time.After(time.Millisecond * 400)
 
 	// Should still have a2
-	if !addrsMarch(harness.oas.Addrs(), nil) {
+	if !addrsMatch(harness.oas.Addrs(), nil) {
 		t.Error("addrs should have timed out")
 	}
 }
@@ -273,32 +273,10 @@ func TestAddAddrsProfile(t *testing.T) {
 }
 
 func TestObservedAddrFiltering(t *testing.T) {
-	addrsMarch := func(a, b []ma.Multiaddr) bool {
-		if len(a) != len(b) {
-			return false
-		}
-
-		for _, aa := range a {
-			found := false
-			for _, bb := range b {
-				if aa.Equal(bb) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return false
-			}
-		}
-		return true
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	harness := newHarness(ctx, t)
-	if !addrsMarch(harness.oas.Addrs(), nil) {
-		t.Error("addrs should be empty")
-	}
+	require.Empty(t, harness.oas.Addrs())
 
 	// IP4/TCP
 	it1 := ma.StringCast("/ip4/1.2.3.4/tcp/1231")


### PR DESCRIPTION
We call this _very_ frequently when computing our local addresses.

This PR also:

* Unexports some exported types to reduce confusion.
* Fixes a bug in the mock net.
* Ensures we don't clobber an _inbound_ observation with an outbound observation.

Review commit by commit.