### PR TITLE
Fix peer handler panic bug caused by connection races

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/multiformats/go-multistream v0.1.1
 	github.com/stretchr/testify v1.5.1
+	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5
 	github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9
 	golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476 // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect

--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5 h1:hNna6Fi0eP1f2sMBe/rJicDmaHmoXGe1Ta84FPYHLuE=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5/go.mod h1:f1SCnEOt6sc3fOJfPQDRDzHOtSXuTtnz0ImG9kPRDV0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -231,7 +231,7 @@ func (ids *IDService) loop() {
 			// before we could finish removing it's handler on the previous disconnection.
 			// If we delete the handler, we wont be able to push updates to it
 			// till we see a new connection. So, we should restart the handler.
-			// The fact that we got the handler on this channel means that it's context and handler
+			// The fact that we got the handler on this channel means that it's context and looping go-routine
 			// have completed because we write the handler to this chanel only after it closed.
 			if ph != nil && ids.Host.Network().Connectedness(rp) == network.Connected {
 				ph.start()

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -233,7 +233,7 @@ func (ids *IDService) loop() {
 			// till we see a new connection. So, we should restart the handler.
 			// The fact that we got the handler on this channel means that it's context and handler
 			// have completed because we write the handler to this chanel only after it closed.
-			if ids.Host.Network().Connectedness(rp) == network.Connected {
+			if ph != nil && ids.Host.Network().Connectedness(rp) == network.Connected {
 				ph.start()
 			} else {
 				delete(phs, rp)

--- a/p2p/protocol/identify/peer_loop.go
+++ b/p2p/protocol/identify/peer_loop.go
@@ -42,7 +42,7 @@ type peerHandler struct {
 	pushCh  chan struct{}
 	deltaCh chan struct{}
 
-	isClosed bool
+	isRunning bool
 }
 
 func newPeerHandler(pid peer.ID, ids *IDService) *peerHandler {
@@ -54,6 +54,8 @@ func newPeerHandler(pid peer.ID, ids *IDService) *peerHandler {
 
 		pushCh:  make(chan struct{}, 1),
 		deltaCh: make(chan struct{}, 1),
+
+		isRunning: false,
 	}
 
 	return ph
@@ -61,8 +63,8 @@ func newPeerHandler(pid peer.ID, ids *IDService) *peerHandler {
 
 // should be idempotent.
 func (ph *peerHandler) start() {
-	if ph.isClosed {
-		ph.isClosed = false
+	if !ph.isRunning {
+		ph.isRunning = true
 
 		ctx, cancel := context.WithCancel(context.Background())
 		ph.ctx = ctx
@@ -76,7 +78,7 @@ func (ph *peerHandler) start() {
 func (ph *peerHandler) close() error {
 	ph.cancel()
 	ph.wg.Wait()
-	ph.isClosed = true
+	ph.isRunning = false
 	return nil
 }
 


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p/issues/961.

@Stebalien  Let me know if this makes sense or if I'm missing something:

**a.** p1 has two connections to p2.
**b.** p1 sees both disconnections "simultaneously".
   **c.** Peerhandler removal requests for both get written to `rmPeerHandlerCh` and we start two go-routines to close the same handler, one for each request.
   **d.** When we process the request of the first go-routine written to `phClosedCh`, we are not connected to the peer and so delete the handler.
      **e**. However, when we process the request of the second go-routine in `phClosedCh`, we are connected to the peer(we got a new third connection, but there's handler for it _yet_) and so we call `start` on a nil handler.

The correct solution here is to NOT create/start the handler if it's nil. When the Identify request for that third connection is eventually "processed", we will have a new handler for it.

Using the same logic, `peerhandler.start()` should be idempotent as we could end up calling `start` on the same handler twice without closing it in between the `start()` calls.