### PR TITLE
Fix address advertisement bugs

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -915,7 +915,7 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 			}
 
 			// No.
-			// in case router give us a wrong address or we're behind a double-NAT.
+			// in case the router gives us a wrong address or we're behind a double-NAT.
 			// also add observed addresses
 			resolved, err := addrutil.ResolveUnspecifiedAddress(listen, allIfaceAddrs)
 			if err != nil {

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -917,7 +917,7 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 			// also add observed addresses
 			resolved, err := addrutil.ResolveUnspecifiedAddress(listen, allIfaceAddrs)
 			if err != nil {
-				// This an happen we try to resolve /ip6/::/...
+				// This can happen if we try to resolve /ip6/::/...
 				// without any IPv6 interface addresses.
 				continue
 			}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -267,17 +267,17 @@ func (h *BasicHost) updateLocalIpAddr() {
 	} else {
 		if _, _, localIPv4, err := r.Route(net.IPv4zero); err != nil {
 			log.Debugw("failed to fetch local IPv4 address", "error", err)
-		} else {
+		} else if localIPv4.IsGlobalUnicast() {
 			maddr, err := manet.FromIP(localIPv4)
 			if err == nil {
 				h.filteredInterfaceAddrs = append(h.filteredInterfaceAddrs, maddr)
 			}
 		}
 
-		if _, _, localIpv6, err := r.Route(net.IPv6unspecified); err != nil {
+		if _, _, localIPv6, err := r.Route(net.IPv6unspecified); err != nil {
 			log.Debugw("failed to fetch local IPv6 address", "error", err)
-		} else {
-			maddr, err := manet.FromIP(localIpv6)
+		} else if localIPv6.IsGlobalUnicast() {
+			maddr, err := manet.FromIP(localIPv6)
 			if err == nil {
 				h.filteredInterfaceAddrs = append(h.filteredInterfaceAddrs, maddr)
 			}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -888,8 +888,11 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 				extMaddr = ma.Join(extMaddr, rest)
 			}
 
-			// Add in the mapped addr.
-			finalAddrs = append(finalAddrs, extMaddr)
+			// if the router reported a sane address
+			if !manet.IsIPUnspecified(extMaddr) {
+				// Add in the mapped addr.
+				finalAddrs = append(finalAddrs, extMaddr)
+			}
 
 			// Did the router give us a routable public addr?
 			if manet.IsPublicAddr(mappedMaddr) {


### PR DESCRIPTION
This patch fixes several address advertisements bugs that slipped through into go-ipfs 0.6.0.

* Fallback on advertising all interface addresses if looking up the default route fails (#973).
* Don't ever advertise unspecified addresses, even if our NAT lies to us.
* Resolve addresses before trying to lookup observed addresses.

We _really_ need tests for this code, but that will likely require some mocking.