### PR TITLE
fix host can be dialed by autonat public addr, but lost the public addr to announce

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -335,7 +335,7 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		autonatOpts = append(autonatOpts, autonat.WithReachability(*cfg.AutoNATConfig.ForceReachability))
 	}
 
-	if _, err = autonat.New(ctx, h, autonatOpts...); err != nil {
+	if h.AutoNat, err = autonat.New(ctx, h, autonatOpts...); err != nil {
 		h.Close()
 		return nil, fmt.Errorf("cannot enable autorelay; autonat failed to start: %v", err)
 	}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -815,12 +815,9 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 	// so net.InterfaceAddrs() not has the public ip
 	// The host can indeed be dialed ！！！
 	if h.AutoNat != nil {
-		ambientAutoNat, ok := h.AutoNat.(*autonat.AmbientAutoNAT)
-		if ok && ambientAutoNat != nil {
-			publicAddr, _ := ambientAutoNat.PublicAddr()
-			if publicAddr != nil {
-				finalAddrs = append(finalAddrs, publicAddr)
-			}
+		publicAddr, _ := h.AutoNat.PublicAddr()
+		if publicAddr != nil {
+			finalAddrs = append(finalAddrs, publicAddr)
 		}
 	}
 


### PR DESCRIPTION
Consider the following scenario:

peers deployed on a cloud server, which may **provides an elastic ip** accessible to the public network, but **not have an external network card**, so net.InterfaceAddrs() can't get the public ip [(call by InterfaceMultiaddrs for get addresses associated with host)](https://github.com/multiformats/go-multiaddr-net/blob/f512d0e050a043c10980e1a6c9a9ffd726572184/net.go#L382)

**The host can indeed be dialed by autonat public addr, but lost the public addr to announce!**