### PR TITLE
fix: use the correct external address when NAT port-mapping

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -925,7 +925,7 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 			}
 
 			// Did the router give us a routable public addr?
-			if manet.IsPublicAddr(mappedMaddr) {
+			if manet.IsPublicAddr(extMaddr) {
 				//well done
 				continue
 			}
@@ -951,7 +951,7 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 				}
 
 				// Drop the IP from the external maddr
-				_, extMaddrNoIP := ma.SplitFirst(mappedMaddr)
+				_, extMaddrNoIP := ma.SplitFirst(extMaddr)
 
 				for _, obsMaddr := range observed {
 					// Extract a public observed addr.


### PR DESCRIPTION
Previously, we'd construct addresses like `/ip4/.../udp/...` instead of `/ip4/.../udp/.../quic` because we'd use mapped addr (ip + transport + port) instead of the full external address (ip + transport + port + other transports...).