### PR TITLE
fix tests

### DIFF
--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -788,7 +788,7 @@ func TestLargeIdentifyMessage(t *testing.T) {
 	// add protocol strings to make the message larger
 	// about 2K of protocol strings
 	for i := 0; i < 500; i++ {
-		r := "rand" + string(i)
+		r := fmt.Sprintf("rand%d", i)
 		h1.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
 		h2.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
 	}
@@ -898,7 +898,7 @@ func TestLargePushMessage(t *testing.T) {
 	// add protocol strings to make the message larger
 	// about 2K of protocol strings
 	for i := 0; i < 500; i++ {
-		r := "rand" + string(i)
+		r := fmt.Sprintf("rand%d", i)
 		h1.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
 		h2.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
 	}


### PR DESCRIPTION
1. Fix tests on go 1.15 by avoiding `string(i)`.
2. Fix the autorelay test by making relays announce fake "public" addresses. I'm not sure how this worked before.