### PR TITLE
fix autonat race

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -335,10 +335,12 @@ func (cfg *Config) NewNode(ctx context.Context) (host.Host, error) {
 		autonatOpts = append(autonatOpts, autonat.WithReachability(*cfg.AutoNATConfig.ForceReachability))
 	}
 
-	if h.AutoNat, err = autonat.New(ctx, h, autonatOpts...); err != nil {
+	autonat, err := autonat.New(ctx, h, autonatOpts...)
+	if err != nil {
 		h.Close()
 		return nil, fmt.Errorf("cannot enable autorelay; autonat failed to start: %v", err)
 	}
+	h.SetAutoNat(autonat)
 
 	// start the host background tasks
 	h.Start()

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -203,7 +203,7 @@ func TestHostAddrsFactory(t *testing.T) {
 	}
 
 	var err error
-	h.AutoNat, err = autonat.New(ctx, h, autonat.WithReachability(network.ReachabilityPublic))
+	h.autoNat, err = autonat.New(ctx, h, autonat.WithReachability(network.ReachabilityPublic))
 	if err != nil {
 		t.Fatalf("should be able to attach autonat: %v", err)
 	}


### PR DESCRIPTION
fix https://github.com/ipfs/go-ipfs/issues/7947

move `BasicHost.AutoNat` to a private field (it has no public method and shouldn't be accessed afaik.
Instead add a setter for config that sets it while holding the address mutex to prevent reads of the
field at the same time.