### PR TITLE
feat: add upstream & interop tests

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,9 +1,10 @@
 on: [push, pull_request]
+name: Interop Tests
 
 jobs:
   unit:
     runs-on: ubuntu-latest
-    name: Js/Go Interop tests
+    name: Js/Go
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,40 @@
+on: [push, pull_request]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    name: Js/Go Interop tests
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16.x"
+      - name: Go information
+        run: |
+          go version
+          go env
+      - uses: actions/checkout@v2
+        with:
+          path: 'libp2p'
+      - uses: actions/checkout@v2
+        with:
+          repository: 'libp2p/go-libp2p-daemon'
+          path: 'daemon'
+      - uses: actions/checkout@v2
+        with:
+          repository: 'libp2p/interop'
+          path: 'interop'
+      - name: Mod replace go-libp2p in go-libp2p-daemon
+        working-directory: daemon
+        run: |
+          go mod edit -replace "github.com/libp2p/go-libp2p=../libp2p"
+          go mod tidy
+      - name: Build libp2p daemon
+        working-directory: daemon
+        run: |
+          go build -o daemon ./p2pd
+      - name: Setup interop tests
+        working-directory: interop
+        run: npm install
+      - name: Run interop tests
+        working-directory: interop
+        run: LIBP2P_GO_BIN="$(pwd)/../daemon/daemon" npm run test

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 name: Interop Tests
 
 jobs:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,5 @@
 on: [push, pull_request]
+name: Upstream Test
 
 jobs:
   unit:
@@ -16,7 +17,7 @@ jobs:
           - 'libp2p/go-libp2p-kad-dht'
           - 'ipfs/go-bitswap'
     runs-on: ${{ matrix.os }}-latest
-    name: Upstream ${{ matrix.upstream }} unit tests (${{ matrix.os }}, Go ${{ matrix.go }})
+    name: ${{ matrix.upstream }} unit tests (${{ matrix.os }}, Go ${{ matrix.go }})
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 name: Upstream Test
 
 jobs:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,52 @@
+on: [push, pull_request]
+
+jobs:
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'ubuntu'
+        go:
+          # - '1.15.x'
+          - '1.16.x'
+        upstream:
+          - 'libp2p/go-libp2p-pubsub'
+          - 'libp2p/go-libp2p-daemon'
+          - 'libp2p/go-libp2p-kad-dht'
+          - 'ipfs/go-bitswap'
+    runs-on: ${{ matrix.os }}-latest
+    name: Upstream ${{ matrix.upstream }} unit tests (${{ matrix.os }}, Go ${{ matrix.go }})
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Go information
+        run: |
+          go version
+          go env
+      - uses: actions/checkout@v2
+        with:
+          path: 'libp2p'
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.upstream }}
+          path: upstream
+      - name: Patch in new go-libp2p
+        working-directory: upstream
+        run: |
+          go mod edit -replace "github.com/libp2p/go-libp2p=../libp2p"
+          go mod tidy
+      - name: Run tests
+        working-directory: upstream
+        run: go test -v ./...
+      - name: Run tests (32 bit)
+        working-directory: upstream
+        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
+        env:
+          GOARCH: 386
+        run: go test -v ./...
+      - name: Run tests with race detector
+        working-directory: upstream
+        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
+        run: go test -v -race ./...

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -18,10 +18,10 @@ jobs:
           # - '1.15.x'
           - '1.16.x'
         upstream:
-          - 'libp2p/go-libp2p-pubsub'
+          # - 'libp2p/go-libp2p-pubsub' flaky
+          # - 'ipfs/go-bitswap' flaky
+          # - 'libp2p/go-libp2p-kad-dht'
           - 'libp2p/go-libp2p-daemon'
-          - 'libp2p/go-libp2p-kad-dht'
-          - 'ipfs/go-bitswap'
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.upstream }} unit tests (${{ matrix.os }}, Go ${{ matrix.go }})
     steps:


### PR DESCRIPTION
Add tests to link in new libp2p release in upstream repos and interop tests. This way, we'll very quickly know if something is broken.

Known issues:
- [ ] https://github.com/ipfs/go-bitswap/issues/442
- [ ] https://github.com/ipfs/go-bitswap/issues/481
- [x] https://github.com/libp2p/interop/pull/44
- [ ] https://github.com/libp2p/go-libp2p-pubsub/issues/420