### PR TITLE
fix: re-expose AutoNAT service on BasicHost

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -1007,6 +1007,13 @@ func (h *BasicHost) SetAutoNat(a autonat.AutoNAT) {
 	}
 }
 
+// Return the host's AutoNAT service, if AutoNAT is enabled.
+func (h *BasicHost) GetAutoNat() autonat.AutoNAT {
+	h.addrMu.Lock()
+	defer h.addrMu.Unlock()
+	return h.autoNat
+}
+
 // Close shuts down the Host's services (network, etc).
 func (h *BasicHost) Close() error {
 	h.closeSync.Do(func() {


### PR DESCRIPTION
Unfortunately, lotus relies on this and we don't have a good alternative at the moment.

1. The "correct" way to get the status is to subscribe to the "discoverability" events and read the first event (you're guaranteed to see a "current status" event). However, this is a bit annoying.
2. Ideally, you'd call host.Addrs() to get the list of "good" addresses. Unfortunately, we don't feed enough information back into the Host from AutoNAT for this to be truly useful (yet).