### PR TITLE
remove Codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,0 @@
-coverage:
-  range: "50...100"
-comment: off


### PR DESCRIPTION
No need for a special config here. Our default config should be sufficient.