### PR TITLE
perf/basic_host: Don't handle address change if we hasn't anyone

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -520,8 +520,11 @@ func (h *BasicHost) background() {
 	defer ticker.Stop()
 
 	for {
-		h.updateLocalIpAddr()
-		curr := h.Addrs()
+		var curr []ma.Multiaddr
+		if len(h.network.ListenAddresses()) > 0 {
+			h.updateLocalIpAddr()
+			curr = h.Addrs()
+		}
 		emitAddrChange(curr, lastAddrs)
 		lastAddrs = curr
 


### PR DESCRIPTION
`basic_host.background` is used for handling address changed events, but the `node` may be created with `libp2p.NoListenerAddrs`.

the `h.updateLocalIpAddr` is cost a little CPU time.

But I use `NoListenerAddrs` with many (one thousand) tiny test nodes, and all these test nodes communicate with other peers by a  full feature node (by pubsub or relay) in the same process. 

The basic_host.background would use many CPU time and add 1000 useless goroutine in this situatuion.

-------------------------------------------------------------
I'm not sure whether the `network` could do `listen` after `host.background` started.  
So I just keep the background goroutine and skip one round if there hasn't any listener address.