### PR TITLE
test: fix flaky example test

### DIFF
--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -49,7 +49,9 @@ func main() {
 	}
 
 	if *targetF == "" {
-		runListener(ctx, ha, *listenF, *insecureF)
+		startListener(ctx, ha, *listenF, *insecureF)
+		// Run until canceled.
+		<-ctx.Done()
 	} else {
 		runSender(ctx, ha, *targetF)
 	}
@@ -95,7 +97,7 @@ func getHostAddress(ha host.Host) string {
 	return addr.Encapsulate(hostAddr).String()
 }
 
-func runListener(ctx context.Context, ha host.Host, listenPort int, insecure bool) {
+func startListener(ctx context.Context, ha host.Host, listenPort int, insecure bool) {
 	fullAddr := getHostAddress(ha)
 	log.Printf("I am %s\n", fullAddr)
 
@@ -118,9 +120,6 @@ func runListener(ctx context.Context, ha host.Host, listenPort int, insecure boo
 	} else {
 		log.Printf("Now run \"./echo -l %d -d %s\" on a different terminal\n", listenPort+1, fullAddr)
 	}
-
-	// Wait until canceled
-	<-ctx.Done()
 }
 
 func runSender(ctx context.Context, ha host.Host, targetPeer string) {

--- a/examples/echo/main_test.go
+++ b/examples/echo/main_test.go
@@ -43,7 +43,7 @@ func TestMain(t *testing.T) {
 			return
 		}
 
-		go runListener(ctx, lh, lport, true)
+		startListener(ctx, lh, lport, true)
 
 		// Make sender
 		listenAddr := getHostAddress(lh)


### PR DESCRIPTION
If we run the listener async, we might get expected events out of order.