### PR TITLE
feat: use the actual libp2p version

### DIFF
--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -188,16 +188,24 @@ func checkAddrs(t *testing.T, expected, actual []ma.Multiaddr, msg string) {
 
 func testHasProtocolVersions(t *testing.T, h host.Host, p peer.ID) {
 	v, err := h.Peerstore().Get(p, "ProtocolVersion")
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	if v == nil {
 		t.Error("no protocol version")
 		return
 	}
-	if v.(string) != identify.LibP2PVersion {
-		t.Error("protocol mismatch", err)
+	if v.(string) != "github.com/libp2p/go-libp2p" { // this is the default libp2p version
+		t.Errorf("protocol mismatch %s != %s", v.(string), "github.com/libp2p/go-libp2p")
 	}
 	v, err = h.Peerstore().Get(p, "AgentVersion")
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	if v.(string) != "github.com/libp2p/go-libp2p" { // this is the default user agent
-		t.Error("agent version mismatch", err)
+		t.Errorf("agent version %s != %s", v.(string), "github.com/libp2p/go-libp2p")
 	}
 }
 


### PR DESCRIPTION
fixes #714

Problem: using "ipfs/0.1.0" for the protocol version doesn't make sense in libp2p.
Solution: set it to the go libp2p version (per #714).

The question is, does this even make sense? The protocol version was _supposed_ to identify the libp2p _protocol_ version, allowing peers to determine if they should even bother speaking to each other in the first place. Given that, using the go-libp2p version doesn't make any sense.

However, I feel like systems should just do something like what Filecoin does and have a simple "hello" protocol to determine if two peers want to speak. It's often more complicated than a simple string test (Filecoin tests genesis blocks).

Should we just "rebrand" the "ProtocolVersion" to "Libp2pVersion"?