### PR TITLE
fix(basic_host): stream not closed when context done

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -623,6 +623,7 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 	select {
 	case <-h.ids.IdentifyWait(s.Conn()):
 	case <-ctx.Done():
+		_ = s.Reset()
 		return nil, ctx.Err()
 	}
 


### PR DESCRIPTION
When i create some `NewStream`
A long time later,GetStreams() resulted many unused stream.
Finnally, I found the cause of the error