### PR TITLE
fix: deflake multipro echo test

### DIFF
--- a/examples/multipro/echo.go
+++ b/examples/multipro/echo.go
@@ -86,6 +86,7 @@ func (e *EchoProtocol) onEchoRequest(s network.Stream) {
 	if ok {
 		log.Printf("%s: Echo response to %s sent.", s.Conn().LocalPeer().String(), s.Conn().RemotePeer().String())
 	}
+	e.done <- true
 }
 
 // remote echo response handler

--- a/examples/multipro/main.go
+++ b/examples/multipro/main.go
@@ -57,7 +57,7 @@ func run(h1, h2 *Node, done <-chan bool) {
 	h2.Echo(h1.Host)
 
 	// block until all responses have been processed
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 8; i++ {
 		<-done
 	}
 }

--- a/examples/multipro/ping.go
+++ b/examples/multipro/ping.go
@@ -82,6 +82,7 @@ func (p *PingProtocol) onPingRequest(s network.Stream) {
 	if ok {
 		log.Printf("%s: Ping response to %s sent.", s.Conn().LocalPeer().String(), s.Conn().RemotePeer().String())
 	}
+	p.done <- true
 }
 
 // remote ping response handler


### PR DESCRIPTION
Specifically, wait for the handlers to finish printing before exiting.