### PR TITLE
don't use a context for closing the ObservedAddrManager

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -87,8 +87,6 @@ type IDService struct {
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
-	// ensure we shutdown ONLY once
-	closeSync sync.Once
 	// track resources that need to be shut down before we shut down
 	refCount sync.WaitGroup
 
@@ -276,10 +274,8 @@ func (ids *IDService) loop() {
 
 // Close shuts down the IDService
 func (ids *IDService) Close() error {
-	ids.closeSync.Do(func() {
-		ids.ctxCancel()
-		ids.refCount.Wait()
-	})
+	ids.ctxCancel()
+	ids.refCount.Wait()
 	return nil
 }
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -124,25 +124,23 @@ func NewIDService(h host.Host, opts ...Option) (*IDService, error) {
 		userAgent = cfg.userAgent
 	}
 
-	hostCtx, cancel := context.WithCancel(context.Background())
 	s := &IDService{
 		Host:      h,
 		UserAgent: userAgent,
 
-		ctx:       hostCtx,
-		ctxCancel: cancel,
-		conns:     make(map[network.Conn]chan struct{}),
+		conns: make(map[network.Conn]chan struct{}),
 
 		disableSignedPeerRecord: cfg.disableSignedPeerRecord,
 
 		addPeerHandlerCh: make(chan addPeerHandlerReq),
 		rmPeerHandlerCh:  make(chan rmPeerHandlerReq),
 	}
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 
 	// handle local protocol handler updates, and push deltas to peers.
 	var err error
 
-	observedAddrs, err := NewObservedAddrManager(hostCtx, h)
+	observedAddrs, err := NewObservedAddrManager(h)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create observed address manager: %s", err)
 	}


### PR DESCRIPTION
This is part of the ongoing effort to stop using contexts to control shutdowns.
Most importantly, this PR removes a dependency on the swarm's `Process` in https://github.com/libp2p/go-libp2p/blob/fd4d2a47e21fc516dc97fa0077c2b8a87c35d2c3/p2p/protocol/identify/obsaddr.go#L257.