### PR TITLE
remove recommendation about Go module proxy from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,6 @@ You can start using go-libp2p in your Go application simply by adding imports fr
 import "github.com/libp2p/go-libp2p"
 ```
 
-Run `go get` or `go build`, excluding the libp2p repos from Go modules proxy usage. You only need to do this the first time you import go-libp2p to make sure you latch onto the correct version lineage (see [golang/go#34189](https://github.com/golang/go/issues/34189) for context):
-
-```sh
-$ GOPRIVATE='github.com/libp2p/*' go get ./...
-```
-
-The Go build tools will look for [available releases](https://github.com/libp2p/go-libp2p/releases), and will pick the highest available one.
-
-As new releases of go-libp2p are made available, you can upgrade your application by manually editing your `go.mod` file, or using the [Go tools](https://golang.org/cmd/go/#hdr-Maintaining_module_requirements) to maintain module requirements.
-
 ### API
 
 [![GoDoc](https://godoc.org/github.com/libp2p/go-libp2p?status.svg)](https://godoc.org/github.com/libp2p/go-libp2p)


### PR DESCRIPTION
One can love or hate the Go module proxy, but there's no need to burden go-libp2p users with doing anything out of the ordinary.