### PR TITLE
Tag relay hops in relay implementations

### DIFF
--- a/p2p/protocol/circuitv1/relay/relay.go
+++ b/p2p/protocol/circuitv1/relay/relay.go
@@ -282,7 +282,7 @@ func (r *Relay) rmConn(p peer.ID) {
 	} else {
 		delete(r.conns, p)
 	}
-	if conns < MaxRelayHopTag {
+	if conns <= MaxRelayHopTag {
 		r.host.ConnManager().UpsertTag(p, RelayHopTag, func(v int) int { return v - 1 })
 	}
 

--- a/p2p/protocol/circuitv1/relay/relay.go
+++ b/p2p/protocol/circuitv1/relay/relay.go
@@ -29,8 +29,8 @@ const (
 	ConnectTimeout   = 30 * time.Second
 	HandshakeTimeout = time.Minute
 
-	RelayHopTag      = "relay-v1-hop"
-	RelayHopTagValue = 2
+	relayHopTag      = "relay-v1-hop"
+	relayHopTagValue = 2
 
 	maxMessageSize = 4096
 )
@@ -270,7 +270,7 @@ func (r *Relay) addConn(p peer.ID) {
 	conns++
 	r.conns[p] = conns
 	if conns == 1 {
-		r.host.ConnManager().TagPeer(p, RelayHopTag, RelayHopTagValue)
+		r.host.ConnManager().TagPeer(p, relayHopTag, relayHopTagValue)
 	}
 }
 
@@ -281,7 +281,7 @@ func (r *Relay) rmConn(p peer.ID) {
 		r.conns[p] = conns
 	} else {
 		delete(r.conns, p)
-		r.host.ConnManager().UntagPeer(p, RelayHopTag)
+		r.host.ConnManager().UntagPeer(p, relayHopTag)
 	}
 }
 

--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -346,7 +346,7 @@ func (r *Relay) addConn(p peer.ID) {
 	conns := r.conns[p]
 	conns++
 	r.conns[p] = conns
-	if conns < MaxRelayHopTag {
+	if conns <= MaxRelayHopTag {
 		r.host.ConnManager().UpsertTag(p, RelayHopTag, func(v int) int { return v + 1 })
 	}
 }

--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -30,8 +30,8 @@ const (
 	ConnectTimeout   = 30 * time.Second
 	HandshakeTimeout = time.Minute
 
-	RelayHopTag    = "relay-hop"
-	MaxRelayHopTag = 5
+	RelayHopTag      = "relay-v2-hop"
+	RelayHopTagValue = 2
 
 	maxMessageSize = 4096
 )
@@ -346,8 +346,8 @@ func (r *Relay) addConn(p peer.ID) {
 	conns := r.conns[p]
 	conns++
 	r.conns[p] = conns
-	if conns <= MaxRelayHopTag {
-		r.host.ConnManager().UpsertTag(p, RelayHopTag, func(v int) int { return v + 1 })
+	if conns == 1 {
+		r.host.ConnManager().TagPeer(p, RelayHopTag, RelayHopTagValue)
 	}
 }
 
@@ -358,9 +358,7 @@ func (r *Relay) rmConn(p peer.ID) {
 		r.conns[p] = conns
 	} else {
 		delete(r.conns, p)
-	}
-	if conns < MaxRelayHopTag {
-		r.host.ConnManager().UpsertTag(p, RelayHopTag, func(v int) int { return v - 1 })
+		r.host.ConnManager().UntagPeer(p, RelayHopTag)
 	}
 }
 

--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -30,8 +30,8 @@ const (
 	ConnectTimeout   = 30 * time.Second
 	HandshakeTimeout = time.Minute
 
-	RelayHopTag      = "relay-v2-hop"
-	RelayHopTagValue = 2
+	relayHopTag      = "relay-v2-hop"
+	relayHopTagValue = 2
 
 	maxMessageSize = 4096
 )
@@ -347,7 +347,7 @@ func (r *Relay) addConn(p peer.ID) {
 	conns++
 	r.conns[p] = conns
 	if conns == 1 {
-		r.host.ConnManager().TagPeer(p, RelayHopTag, RelayHopTagValue)
+		r.host.ConnManager().TagPeer(p, relayHopTag, relayHopTagValue)
 	}
 }
 
@@ -358,7 +358,7 @@ func (r *Relay) rmConn(p peer.ID) {
 		r.conns[p] = conns
 	} else {
 		delete(r.conns, p)
-		r.host.ConnManager().UntagPeer(p, RelayHopTag)
+		r.host.ConnManager().UntagPeer(p, relayHopTag)
 	}
 }
 

--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -30,6 +30,9 @@ const (
 	ConnectTimeout   = 30 * time.Second
 	HandshakeTimeout = time.Minute
 
+	RelayHopTag    = "relay-hop"
+	MaxRelayHopTag = 5
+
 	maxMessageSize = 4096
 )
 
@@ -215,23 +218,23 @@ func (r *Relay) handleConnect(s network.Stream, msg *pbv2.HopMessage) {
 		r.handleError(s, pbv2.Status_RESOURCE_LIMIT_EXCEEDED)
 		return
 	}
-	r.conns[src]++
 
 	destConns := r.conns[dest.ID]
 	if destConns >= r.rc.MaxCircuits {
-		r.conns[src]--
 		r.mx.Unlock()
 		log.Debugf("refusing connection from %s to %s; too many connecitons to %s", src, dest.ID, dest.ID)
 		r.handleError(s, pbv2.Status_RESOURCE_LIMIT_EXCEEDED)
 		return
 	}
-	r.conns[dest.ID]++
+
+	r.addConn(src)
+	r.addConn(dest.ID)
 	r.mx.Unlock()
 
 	cleanup := func() {
 		r.mx.Lock()
-		r.conns[src]--
-		r.conns[dest.ID]--
+		r.rmConn(src)
+		r.rmConn(dest.ID)
 		r.mx.Unlock()
 	}
 
@@ -336,6 +339,28 @@ func (r *Relay) handleConnect(s network.Stream, msg *pbv2.HopMessage) {
 	} else {
 		go r.relayUnlimited(s, bs, src, dest.ID, done)
 		go r.relayUnlimited(bs, s, dest.ID, src, done)
+	}
+}
+
+func (r *Relay) addConn(p peer.ID) {
+	conns := r.conns[p]
+	conns++
+	r.conns[p] = conns
+	if conns < MaxRelayHopTag {
+		r.host.ConnManager().UpsertTag(p, RelayHopTag, func(v int) int { return v + 1 })
+	}
+}
+
+func (r *Relay) rmConn(p peer.ID) {
+	conns := r.conns[p]
+	conns--
+	if conns > 0 {
+		r.conns[p] = conns
+	} else {
+		delete(r.conns, p)
+	}
+	if conns < MaxRelayHopTag {
+		r.host.ConnManager().UpsertTag(p, RelayHopTag, func(v int) int { return v - 1 })
 	}
 }
 


### PR DESCRIPTION
On top of #1186 
In both relay v1 and v2 implementations, with a fixed value of 2. The value is purposefully very low, serving as an indicator to distinguish idle connections from connections with hop circuits during connection manager prunes.