### PR TITLE
add an option to start the relay v2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ import (
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
 	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 
 	autonat "github.com/libp2p/go-libp2p-autonat"
@@ -74,7 +75,10 @@ type Config struct {
 	PSK                pnet.PSK
 
 	RelayCustom bool
-	Relay       bool
+	Relay       bool // should the relay transport be used
+
+	EnableRelayService bool // should we run a circuitv2 relay (if publicly reachable)
+	RelayServiceOpts   []relayv2.Option
 
 	ListenAddrs     []ma.Multiaddr
 	AddrsFactory    bhost.AddrsFactory
@@ -196,6 +200,8 @@ func (cfg *Config) NewNode() (host.Host, error) {
 		MultiaddrResolver:   cfg.MultiaddrResolver,
 		EnableHolePunching:  cfg.EnableHolePunching,
 		HolePunchingOptions: cfg.HolePunchingOptions,
+		EnableRelayService:  cfg.EnableRelayService,
+		RelayServiceOpts:    cfg.RelayServiceOpts,
 	})
 	if err != nil {
 		swrm.Close()

--- a/examples/pubsub/chat/go.sum
+++ b/examples/pubsub/chat/go.sum
@@ -324,6 +324,7 @@ github.com/ipfs/go-datastore v0.4.1/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13X
 github.com/ipfs/go-datastore v0.4.4/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-datastore v0.4.5/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w3fyfrmmJs=
 github.com/ipfs/go-datastore v0.4.6/go.mod h1:XSipLSc64rFKSFRFGo1ecQl+WhYce3K7frtpHkyPFUc=
+github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
 github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=

--- a/options.go
+++ b/options.go
@@ -17,9 +17,10 @@ import (
 	"github.com/libp2p/go-libp2p-core/pnet"
 
 	"github.com/libp2p/go-libp2p/config"
-	autorelay "github.com/libp2p/go-libp2p/p2p/host/autorelay"
+	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
-	holepunch "github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
+	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 
 	ma "github.com/multiformats/go-multiaddr"
 	madns "github.com/multiformats/go-multiaddr-dns"
@@ -227,6 +228,16 @@ func DisableRelay() Option {
 	return func(cfg *Config) error {
 		cfg.RelayCustom = true
 		cfg.Relay = false
+		return nil
+	}
+}
+
+// EnableRelayService configures libp2p to run a circuit v2 relay,
+// if we dected that we're publicly reachable.
+func EnableRelayService(opts ...relayv2.Option) Option {
+	return func(cfg *Config) error {
+		cfg.EnableRelayService = true
+		cfg.RelayServiceOpts = opts
 		return nil
 	}
 }

--- a/p2p/host/relaysvc/relay.go
+++ b/p2p/host/relaysvc/relay.go
@@ -1,0 +1,91 @@
+package relaysvc
+
+import (
+	"context"
+	"sync"
+
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
+
+	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+type RelayManager struct {
+	host host.Host
+
+	mutex sync.Mutex
+	relay *relayv2.Relay
+	opts  []relayv2.Option
+
+	refCount  sync.WaitGroup
+	ctxCancel context.CancelFunc
+}
+
+func NewRelayManager(host host.Host, opts ...relayv2.Option) *RelayManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &RelayManager{
+		host:      host,
+		opts:      opts,
+		ctxCancel: cancel,
+	}
+	m.refCount.Add(1)
+	go m.background(ctx)
+	return m
+}
+
+func (m *RelayManager) background(ctx context.Context) {
+	defer m.refCount.Done()
+	defer func() {
+		m.mutex.Lock()
+		if m.relay != nil {
+			m.relay.Close()
+		}
+		m.mutex.Unlock()
+	}()
+
+	subReachability, _ := m.host.EventBus().Subscribe(new(event.EvtLocalReachabilityChanged))
+	defer subReachability.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-subReachability.Out():
+			if !ok {
+				return
+			}
+			if err := m.reachabilityChanged(ev.(event.EvtLocalReachabilityChanged).Reachability); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (m *RelayManager) reachabilityChanged(r network.Reachability) error {
+	switch r {
+	case network.ReachabilityPublic:
+		relay, err := relayv2.New(m.host, m.opts...)
+		if err != nil {
+			return err
+		}
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+		m.relay = relay
+	case network.ReachabilityPrivate:
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+		if m.relay != nil {
+			err := m.relay.Close()
+			m.relay = nil
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *RelayManager) Close() error {
+	m.ctxCancel()
+	m.refCount.Wait()
+	return nil
+}


### PR DESCRIPTION
I'm not satisfied with the names for the config options, but I struggle to come up with something better. Suggestions would be highly appreciated.

I wish we could use `EnableRelay()` here, but unfortunately this is already taken to enable the *relay transport*.