### PR TITLE
autorelay support for circuitv2 relays

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -331,19 +331,9 @@ func (cfg *Config) NewNode() (host.Host, error) {
 		ho = routed.Wrap(h, router)
 	}
 	if ar != nil {
-		return &autoRelayHost{Host: ho, autoRelay: ar}, nil
+		return autorelay.NewAutoRelayHost(ho, ar), nil
 	}
 	return ho, nil
-}
-
-type autoRelayHost struct {
-	host.Host
-	autoRelay *autorelay.AutoRelay
-}
-
-func (h *autoRelayHost) Close() error {
-	_ = h.autoRelay.Close()
-	return h.Host.Close()
 }
 
 // Option is a libp2p config option that can be given to the libp2p constructor

--- a/config/config.go
+++ b/config/config.go
@@ -17,8 +17,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/transport"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 
+	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
-	"github.com/libp2p/go-libp2p/p2p/host/relay"
 	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
 	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
@@ -209,7 +209,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 		// TODO: We shouldn't be doing this here.
 		oldFactory := h.AddrsFactory
 		h.AddrsFactory = func(addrs []ma.Multiaddr) []ma.Multiaddr {
-			return oldFactory(relay.Filter(addrs))
+			return oldFactory(autorelay.Filter(addrs))
 		}
 	}
 
@@ -237,7 +237,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 
 	// Note: h.AddrsFactory may be changed by AutoRelay, but non-relay version is
 	// used by AutoNAT below.
-	var autorelay *relay.AutoRelay
+	var ar *autorelay.AutoRelay
 	addrF := h.AddrsFactory
 	if cfg.EnableAutoRelay {
 		if !cfg.Relay {
@@ -246,7 +246,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 		}
 
 		if len(cfg.StaticRelays) > 0 {
-			autorelay = relay.NewAutoRelay(h, nil, router, cfg.StaticRelays)
+			ar = autorelay.NewAutoRelay(h, nil, router, cfg.StaticRelays)
 		} else {
 			if router == nil {
 				h.Close()
@@ -259,7 +259,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			}
 
 			discovery := discovery.NewRoutingDiscovery(crouter)
-			autorelay = relay.NewAutoRelay(h, discovery, router, cfg.StaticRelays)
+			ar = autorelay.NewAutoRelay(h, discovery, router, cfg.StaticRelays)
 		}
 	}
 
@@ -330,15 +330,15 @@ func (cfg *Config) NewNode() (host.Host, error) {
 	if router != nil {
 		ho = routed.Wrap(h, router)
 	}
-	if autorelay != nil {
-		return &autoRelayHost{Host: ho, autoRelay: autorelay}, nil
+	if ar != nil {
+		return &autoRelayHost{Host: ho, autoRelay: ar}, nil
 	}
 	return ho, nil
 }
 
 type autoRelayHost struct {
 	host.Host
-	autoRelay *relay.AutoRelay
+	autoRelay *autorelay.AutoRelay
 }
 
 func (h *autoRelayHost) Close() error {

--- a/examples/pubsub/chat/go.sum
+++ b/examples/pubsub/chat/go.sum
@@ -404,6 +404,7 @@ github.com/libp2p/go-addr-util v0.1.0/go.mod h1:6I3ZYuFr2O/9D+SoyM0zEw0EF3YkldtT
 github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
 github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
+github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-conn-security-multistream v0.2.0/go.mod h1:hZN4MjlNetKD3Rq5Jb/P5ohUnFLNzEAR4DLSzpn2QLU=
 github.com/libp2p/go-conn-security-multistream v0.2.1/go.mod h1:cR1d8gA0Hr59Fj6NhaTpFhJZrjSYuNmhpT2r25zYR70=
@@ -414,6 +415,7 @@ github.com/libp2p/go-eventbus v0.2.1/go.mod h1:jc2S4SoEVPP48H9Wpzm5aiGwUCBMfGhVh
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-flow-metrics v0.0.3 h1:8tAs/hSdNvUiLgtlSy3mxwxWP4I9y/jlkPFT7epKdeM=
 github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
+github.com/libp2p/go-libp2p-asn-util v0.0.0-20210818120414-1f382a4aa43a h1:6yEuCOY31elgeJ2KA2JiREZjIznvH6lOWCdHRuhgEgc=
 github.com/libp2p/go-libp2p-asn-util v0.0.0-20210818120414-1f382a4aa43a/go.mod h1:wu+AnM9Ii2KgO5jMmS1rz9dvzTdj8BXqsPR9HR0XB7I=
 github.com/libp2p/go-libp2p-autonat v0.5.0 h1:/+3+4NcQV47DQ/duvRyFDP8oxv6CQTvSKYD5iWoPcYs=
 github.com/libp2p/go-libp2p-autonat v0.5.0/go.mod h1:085tmmuXn0nXgFwuF7a2tt4UxgTjuapbuml27v4htKY=

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.0.0-20210813211128-0a44fdfbc16e // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/grpc v1.40.0 // indirect

--- a/options.go
+++ b/options.go
@@ -17,8 +17,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/pnet"
 
 	"github.com/libp2p/go-libp2p/config"
+	autorelay "github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
-	autorelay "github.com/libp2p/go-libp2p/p2p/host/relay"
 	holepunch "github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 
 	ma "github.com/multiformats/go-multiaddr"

--- a/p2p/host/autorelay/addrsplosion.go
+++ b/p2p/host/autorelay/addrsplosion.go
@@ -1,4 +1,4 @@
-package relay
+package autorelay
 
 import (
 	"encoding/binary"

--- a/p2p/host/autorelay/addrsplosion_test.go
+++ b/p2p/host/autorelay/addrsplosion_test.go
@@ -1,4 +1,4 @@
-package relay
+package autorelay
 
 import (
 	"testing"

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -1,4 +1,4 @@
-package relay
+package autorelay
 
 import (
 	"context"

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -28,6 +28,8 @@ const (
 
 	rsvpRefreshInterval = time.Minute
 	rsvpExpirationSlack = 2 * time.Minute
+
+	autorelayTag = "autorelay"
 )
 
 var (
@@ -154,7 +156,7 @@ func (ar *AutoRelay) refreshReservations(ctx context.Context, now time.Time) boo
 	if ar.status == network.ReachabilityPublic {
 		// we are public, forget about the relays, unprotect peers
 		for p := range ar.relays {
-			ar.host.ConnManager().Unprotect(p, "autorelay")
+			ar.host.ConnManager().Unprotect(p, autorelayTag)
 			delete(ar.relays, p)
 		}
 
@@ -199,7 +201,7 @@ func (ar *AutoRelay) refreshRelayReservation(ctx context.Context, p peer.ID, wg 
 
 		delete(ar.relays, p)
 		// unprotect the connection
-		ar.host.ConnManager().Unprotect(p, "autorelay")
+		ar.host.ConnManager().Unprotect(p, autorelayTag)
 		// increment fail counter
 		atomic.AddInt32(fail, 1)
 	} else {
@@ -333,7 +335,7 @@ func (ar *AutoRelay) tryRelay(ctx context.Context, pi peer.AddrInfo) bool {
 	ar.relays[pi.ID] = rsvp
 
 	// protect the connection
-	ar.host.ConnManager().Protect(pi.ID, "autorelay")
+	ar.host.ConnManager().Protect(pi.ID, autorelayTag)
 
 	return true
 }

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -30,6 +30,9 @@ const (
 	rsvpExpirationSlack = 2 * time.Minute
 
 	autorelayTag = "autorelay"
+
+	protoIDv1 = string(relayv1.ProtoID)
+	protoIDv2 = string(circuitv2_proto.ProtoIDv2Hop)
 )
 
 var (
@@ -279,8 +282,6 @@ func (ar *AutoRelay) tryRelay(ctx context.Context, pi peer.AddrInfo) bool {
 		return false
 	}
 
-	protoIDv1 := string(relayv1.ProtoID)
-	protoIDv2 := string(circuitv2_proto.ProtoIDv2Hop)
 	protos, err := ar.host.Peerstore().SupportsProtocols(pi.ID, protoIDv1, protoIDv2)
 	if err != nil {
 		log.Debugf("error checking relay protocol support for peer %s: %s", pi.ID, err)

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -175,6 +175,7 @@ func (ar *AutoRelay) refreshReservations(ctx context.Context, now time.Time) boo
 
 	for p, rsvp := range ar.relays {
 		if rsvp == nil {
+			// this is a circuitv1 relay, there is no reservation
 			continue
 		}
 

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -185,6 +185,7 @@ func (ar *AutoRelay) refreshReservations(ctx context.Context, now time.Time) boo
 			continue
 		}
 
+		p := p
 		g.Go(func() error {
 			return ar.refreshRelayReservation(ctx, p)
 		})

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -1,4 +1,4 @@
-package relay_test
+package autorelay_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/p2p/host/relay"
+	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
 
 	"github.com/libp2p/go-libp2p-core/event"
@@ -27,8 +27,8 @@ import (
 
 // test specific parameters
 func init() {
-	relay.BootDelay = 1 * time.Second
-	relay.AdvertiseBootDelay = 100 * time.Millisecond
+	autorelay.BootDelay = 1 * time.Second
+	autorelay.AdvertiseBootDelay = 100 * time.Millisecond
 }
 
 // mock routing
@@ -133,16 +133,18 @@ func TestAutoRelay(t *testing.T) {
 	// this is the relay host
 	// announce dns addrs because filter out private addresses from relays,
 	// and we consider dns addresses "public".
-	relayHost, err := libp2p.New(libp2p.DisableRelay(), libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
-		for i, addr := range addrs {
-			saddr := addr.String()
-			if strings.HasPrefix(saddr, "/ip4/127.0.0.1/") {
-				addrNoIP := strings.TrimPrefix(saddr, "/ip4/127.0.0.1")
-				addrs[i] = ma.StringCast("/dns4/localhost" + addrNoIP)
+	relayHost, err := libp2p.New(
+		libp2p.DisableRelay(),
+		libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
+			for i, addr := range addrs {
+				saddr := addr.String()
+				if strings.HasPrefix(saddr, "/ip4/127.0.0.1/") {
+					addrNoIP := strings.TrimPrefix(saddr, "/ip4/127.0.0.1")
+					addrs[i] = ma.StringCast("/dns4/localhost" + addrNoIP)
+				}
 			}
-		}
-		return addrs
-	}))
+			return addrs
+		}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +162,7 @@ func TestAutoRelay(t *testing.T) {
 		t.Fatal(err)
 	}
 	relayDiscovery := discovery.NewRoutingDiscovery(relayRouting)
-	relay.Advertise(ctx, relayDiscovery)
+	autorelay.Advertise(ctx, relayDiscovery)
 
 	// the client hosts
 	h1, err := libp2p.New(libp2p.EnableRelay())

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -116,17 +116,16 @@ func connect(t *testing.T, a, b host.Host) {
 }
 
 // and the actual test!
-func TestAutoRelayv1(t *testing.T) {
-	testAutoRelay(t, false)
-}
+func TestAutoRelay(t *testing.T) {
+	manet.Private4 = []*net.IPNet{}
 
-func TestAutoRelayv2(t *testing.T) {
+	t.Log("testing autorelay with circuitv1 relay")
+	testAutoRelay(t, false)
+	t.Log("testing autorelay with circuitv2 relay")
 	testAutoRelay(t, true)
 }
 
 func testAutoRelay(t *testing.T, useRelayv2 bool) {
-	manet.Private4 = []*net.IPNet{}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 
 	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -115,7 +116,15 @@ func connect(t *testing.T, a, b host.Host) {
 }
 
 // and the actual test!
-func TestAutoRelay(t *testing.T) {
+func TestAutoRelayv1(t *testing.T) {
+	testAutoRelay(t, false)
+}
+
+func TestAutoRelayv2(t *testing.T) {
+	testAutoRelay(t, true)
+}
+
+func testAutoRelay(t *testing.T, useRelayv2 bool) {
 	manet.Private4 = []*net.IPNet{}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -150,11 +159,19 @@ func TestAutoRelay(t *testing.T) {
 	}
 
 	// instantiate the relay
-	r, err := relayv1.NewRelay(relayHost)
-	if err != nil {
-		t.Fatal(err)
+	if useRelayv2 {
+		r, err := relayv2.New(relayHost)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+	} else {
+		r, err := relayv1.NewRelay(relayHost)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
 	}
-	defer r.Close()
 
 	// advertise the relay
 	relayRouting, err := makeRouting(relayHost)

--- a/p2p/host/autorelay/doc.go
+++ b/p2p/host/autorelay/doc.go
@@ -25,4 +25,4 @@ How it works:
   advertising relay addresses.  The new set of addresses is propagated to
   connected peers through the `identify/push` protocol.
 */
-package relay
+package autorelay

--- a/p2p/host/autorelay/host.go
+++ b/p2p/host/autorelay/host.go
@@ -1,0 +1,19 @@
+package autorelay
+
+import (
+	"github.com/libp2p/go-libp2p-core/host"
+)
+
+type AutoRelayHost struct {
+	host.Host
+	ar *AutoRelay
+}
+
+func (h *AutoRelayHost) Close() error {
+	_ = h.ar.Close()
+	return h.Host.Close()
+}
+
+func NewAutoRelayHost(h host.Host, ar *AutoRelay) *AutoRelayHost {
+	return &AutoRelayHost{Host: h, ar: ar}
+}

--- a/p2p/host/autorelay/log.go
+++ b/p2p/host/autorelay/log.go
@@ -1,4 +1,4 @@
-package relay
+package autorelay
 
 import (
 	logging "github.com/ipfs/go-log/v2"

--- a/p2p/host/autorelay/relay.go
+++ b/p2p/host/autorelay/relay.go
@@ -1,4 +1,4 @@
-package relay
+package autorelay
 
 import (
 	"context"


### PR DESCRIPTION
Changes:
- Move the autorelay code to `p2p/host/autorelay`
- Move the host wrapper to the autorelay package.
- Add support for circuitv2 relays

Next steps: refactor the relay discovery logic to support the Flare strategy of an army of relays; this can happen in a subsequent pr, and we can even wait for deployment before we do it.
For now, user must configure relays statically.