### PR TITLE
fix: skip variadic params in constructors

### DIFF
--- a/config/reflection_magic.go
+++ b/config/reflection_magic.go
@@ -81,7 +81,11 @@ func callConstructor(c reflect.Value, args []reflect.Value) (interface{}, error)
 type constructor func(h host.Host, u *tptu.Upgrader, cg connmgr.ConnectionGater) interface{}
 
 func makeArgumentConstructors(fnType reflect.Type, argTypes map[reflect.Type]constructor) ([]constructor, error) {
-	out := make([]constructor, fnType.NumIn())
+	params := fnType.NumIn()
+	if fnType.IsVariadic() {
+		params--
+	}
+	out := make([]constructor, params)
 	for i := range out {
 		argType := fnType.In(i)
 		c, ok := argTypes[argType]

--- a/config/transport_test.go
+++ b/config/transport_test.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/transport"
+)
+
+func TestTransportVariadicOptions(t *testing.T) {
+	_, err := TransportConstructor(func(_ peer.ID, _ ...int) transport.Transport { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
We use them for "options". Ideally we'd be able to forward options through, but that would require real dependency injection.