### PR TITLE
make it possible to pass options to a transport constructor

### DIFF
--- a/config/transport.go
+++ b/config/transport.go
@@ -36,14 +36,14 @@ var transportArgTypes = argTypes
 //
 // And returns a type implementing transport.Transport and, optionally, an error
 // (as the second argument).
-func TransportConstructor(tpt interface{}) (TptC, error) {
+func TransportConstructor(tpt interface{}, opts ...interface{}) (TptC, error) {
 	// Already constructed?
 	if t, ok := tpt.(transport.Transport); ok {
 		return func(_ host.Host, _ *tptu.Upgrader, _ connmgr.ConnectionGater) (transport.Transport, error) {
 			return t, nil
 		}, nil
 	}
-	ctor, err := makeConstructor(tpt, transportType, transportArgTypes)
+	ctor, err := makeConstructor(tpt, transportType, transportArgTypes, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/config/transport_test.go
+++ b/config/transport_test.go
@@ -5,11 +5,25 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/transport"
+	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
+	"github.com/libp2p/go-tcp-transport"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransportVariadicOptions(t *testing.T) {
 	_, err := TransportConstructor(func(_ peer.ID, _ ...int) transport.Transport { return nil })
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+}
+
+func TestConstructorWithOpts(t *testing.T) {
+	var options []int
+	c, err := TransportConstructor(func(_ *tptu.Upgrader, opts ...int) transport.Transport {
+		options = opts
+		return tcp.NewTCPTransport(nil)
+	}, 42, 1337)
+	require.NoError(t, err)
+	_, err = c(nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, options, []int{42, 1337})
 }

--- a/config/transport_test.go
+++ b/config/transport_test.go
@@ -16,6 +16,20 @@ func TestTransportVariadicOptions(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestConstructorWithoutOptsCalledWithOpts(t *testing.T) {
+	_, err := TransportConstructor(func(_ *tptu.Upgrader) transport.Transport {
+		return nil
+	}, 42)
+	require.EqualError(t, err, "constructor doesn't accept any options")
+}
+
+func TestConstructorWithOptsTypeMismatch(t *testing.T) {
+	_, err := TransportConstructor(func(_ *tptu.Upgrader, opts ...int) transport.Transport {
+		return nil
+	}, 42, "foo")
+	require.EqualError(t, err, "expected option of type int, got string")
+}
+
 func TestConstructorWithOpts(t *testing.T) {
 	var options []int
 	c, err := TransportConstructor(func(_ *tptu.Upgrader, opts ...int) transport.Transport {
@@ -25,5 +39,5 @@ func TestConstructorWithOpts(t *testing.T) {
 	require.NoError(t, err)
 	_, err = c(nil, nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, options, []int{42, 1337})
+	require.Equal(t, []int{42, 1337}, options)
 }

--- a/options.go
+++ b/options.go
@@ -125,8 +125,8 @@ func Muxer(name string, tpt interface{}) Option {
 // * Public Key
 // * Address filter (filter.Filter)
 // * Peerstore
-func Transport(tpt interface{}) Option {
-	tptc, err := config.TransportConstructor(tpt)
+func Transport(tpt interface{}, opts ...interface{}) Option {
+	tptc, err := config.TransportConstructor(tpt, opts...)
 	err = traceError(err, 1)
 	return func(cfg *Config) error {
 		if err != nil {


### PR DESCRIPTION
Background: The libp2p constructor uses reflection magic to figure out the arguments that a `Transport` requires. This allows us to write
```go
host, err := libp2p.New(
     libp2p.Transport(tcp.NewTCPTransport),
     libp2p.Transport(quic.NewTransport),
)
```
even though the TCP and the QUIC constructor have completely different signatures.

https://github.com/libp2p/go-tcp-transport/pull/99 now adds TCP options as variadic parameters to the TCP constructor. #1204 added a fix to simply ignore all variadic parameters, making it possible to merge the PR in the TCP repository, but leaving us unable to actually use these options.

This PR now makes it possible to use the option. For example, you can now write
```go
host, err := libp2p.New(
     libp2p.Transport(tcp.NewTCPTransport, tcp.DisableReuseport(), tcp.WithTimeout(42*time.Second)),
)
```

Variadic function parameters are then passed to the constructor, after we've checked that the constructor actually accepts options and after checking that the type of the parameters passed into `libp2p.Transport` matches the type expected by the constructor.

@mvdan, can I ask you for a review of this PR?