### PR TITLE
fix the instance name used for the zeroconf server

### DIFF
--- a/p2p/discovery/mdns/mdns.go
+++ b/p2p/discovery/mdns/mdns.go
@@ -105,10 +105,6 @@ func (s *mdnsService) getIPs(addrs []ma.Multiaddr) ([]string, error) {
 	return ips, nil
 }
 
-func (s *mdnsService) mdnsInstance() string {
-	return string(s.host.ID())
-}
-
 func (s *mdnsService) startServer() error {
 	interfaceAddrs, err := s.host.Network().InterfaceListenAddresses()
 	if err != nil {
@@ -134,7 +130,7 @@ func (s *mdnsService) startServer() error {
 	}
 
 	server, err := zeroconf.RegisterProxy(
-		s.mdnsInstance(),
+		s.host.ID().Pretty(), // TODO: deals with peer IDs longer than 63 characters
 		s.serviceName,
 		mdnsDomain,
 		4001,                 // we have to pass in a port number here, but libp2p only uses the TXT records


### PR DESCRIPTION
Fixes #1207. Requesting a review from @mxinden, since this is more of a spec-compliance issue here than a coding issue.

The effect would be that the host name we use is not `\018\ *\198*\229\139\238e\188..\002K?\172#\'\000\249LY\248<\177\131\ \246<\2081\154\009._p2p._udp.local.`, but `Qmxxx._p2p._udp.local`.