### PR TITLE
reject hole punching attempts when we don't have any public addresses

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -75,7 +75,7 @@ type BasicHost struct {
 
 	network      network.Network
 	mux          *msmux.MultistreamMuxer
-	ids          *identify.IDService
+	ids          identify.IDService
 	hps          *holepunch.Service
 	pings        *ping.PingService
 	natmgr       NATManager
@@ -542,7 +542,7 @@ func (h *BasicHost) Mux() protocol.Switch {
 }
 
 // IDService returns
-func (h *BasicHost) IDService() *identify.IDService {
+func (h *BasicHost) IDService() identify.IDService {
 	return h.ids
 }
 

--- a/p2p/protocol/holepunch/coordination.go
+++ b/p2p/protocol/holepunch/coordination.go
@@ -47,7 +47,7 @@ type Service struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	ids  *identify.IDService
+	ids  identify.IDService
 	host host.Host
 
 	tracer *tracer
@@ -64,7 +64,7 @@ type Service struct {
 type Option func(*Service) error
 
 // NewService creates a new service that can be used for hole punching
-func NewService(h host.Host, ids *identify.IDService, opts ...Option) (*Service, error) {
+func NewService(h host.Host, ids identify.IDService, opts ...Option) (*Service, error) {
 	if ids == nil {
 		return nil, errors.New("identify service can't be nil")
 	}

--- a/p2p/protocol/identify/id_delta.go
+++ b/p2p/protocol/identify/id_delta.go
@@ -1,11 +1,12 @@
 package identify
 
 import (
+	"time"
+
 	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
-	"time"
 
 	pb "github.com/libp2p/go-libp2p/p2p/protocol/identify/pb"
 
@@ -15,7 +16,7 @@ import (
 const IDDelta = "/p2p/id/delta/1.0.0"
 
 // deltaHandler handles incoming delta updates from peers.
-func (ids *IDService) deltaHandler(s network.Stream) {
+func (ids *idService) deltaHandler(s network.Stream) {
 	_ = s.SetReadDeadline(time.Now().Add(StreamReadTimeout))
 
 	c := s.Conn()
@@ -46,7 +47,7 @@ func (ids *IDService) deltaHandler(s network.Stream) {
 
 // consumeDelta processes an incoming delta from a peer, updating the peerstore
 // and emitting the appropriate events.
-func (ids *IDService) consumeDelta(id peer.ID, delta *pb.Delta) error {
+func (ids *idService) consumeDelta(id peer.ID, delta *pb.Delta) error {
 	err := ids.Host.Peerstore().AddProtocols(id, delta.GetAddedProtocols()...)
 	if err != nil {
 		return err

--- a/p2p/protocol/identify/id_push.go
+++ b/p2p/protocol/identify/id_push.go
@@ -12,6 +12,6 @@ import (
 const IDPush = "/ipfs/id/push/1.0.0"
 
 // pushHandler handles incoming identify push streams. The behaviour is identical to the ordinary identify protocol.
-func (ids *IDService) pushHandler(s network.Stream) {
+func (ids *idService) pushHandler(s network.Stream) {
 	ids.handleIdentifyResponse(s)
 }

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -81,7 +81,7 @@ func subtestIDService(t *testing.T) {
 
 	ids1.IdentifyConn(h1t2c[0])
 
-	// the IDService should be opened automatically, by the network.
+	// the idService should be opened automatically, by the network.
 	// what we should see now is that both peers know about each others listen addresses.
 	t.Log("test peer1 has peer2 addrs correctly")
 	testKnowsAddrs(t, h1, h2p, h2.Addrs())                       // has them
@@ -857,7 +857,7 @@ func TestLargeIdentifyMessage(t *testing.T) {
 
 	ids1.IdentifyConn(h1t2c[0])
 
-	// the IDService should be opened automatically, by the network.
+	// the idService should be opened automatically, by the network.
 	// what we should see now is that both peers know about each others listen addresses.
 	t.Log("test peer1 has peer2 addrs correctly")
 	testKnowsAddrs(t, h1, h2p, h2.Addrs())                       // has them

--- a/p2p/protocol/identify/peer_loop.go
+++ b/p2p/protocol/identify/peer_loop.go
@@ -27,7 +27,7 @@ type identifySnapshot struct {
 }
 
 type peerHandler struct {
-	ids *IDService
+	ids *idService
 
 	cancel context.CancelFunc
 
@@ -40,7 +40,7 @@ type peerHandler struct {
 	deltaCh chan struct{}
 }
 
-func newPeerHandler(pid peer.ID, ids *IDService) *peerHandler {
+func newPeerHandler(pid peer.ID, ids *idService) *peerHandler {
 	ph := &peerHandler{
 		ids: ids,
 		pid: pid,


### PR DESCRIPTION
If we don't have any public addresses, the hole punch attempt is bound to fail - there's no address that can be used to dial us.

Question: Any idea how to fix the tests? `IDService.OwnObservedAddrs()` always returns an empty set of addresses, as we're not really running the ID protocol (and we're only listening on localhost anyway). The obvious solution would be to mock the `IDService`, but it's not an interface.