### PR TITLE
close the ObserverAddrManager when the ID service is closed

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -273,6 +273,7 @@ func (ids *IDService) loop() {
 // Close shuts down the IDService
 func (ids *IDService) Close() error {
 	ids.ctxCancel()
+	ids.observedAddrs.Close()
 	ids.refCount.Wait()
 	return nil
 }


### PR DESCRIPTION
Fixes #1217.