### PR TITLE
disable flaky relay example test on CI

### DIFF
--- a/examples/relay/main_test.go
+++ b/examples/relay/main_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/examples/testutils"
 )
 
 func TestMain(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("This test is flaky on CI, see https://github.com/libp2p/go-libp2p/issues/1158.")
+	}
 	var h testutils.LogHarness
 	h.ExpectPrefix("Okay, no connection from h1 to h3")
 	h.ExpectPrefix("Meow! It worked!")


### PR DESCRIPTION
Fixes #1158.

Yet another flaky test due to multiple connections being established at the same time (see https://github.com/libp2p/go-libp2p/issues/1158 for a more detailed description).