### PR TITLE
remove {Un}RegisterNotifee functions from mDNS service

### DIFF
--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	fmt.Printf("\n[*] Your Multiaddress Is: /ip4/%s/tcp/%v/p2p/%s\n", cfg.listenHost, cfg.listenPort, host.ID().Pretty())
 
-	peerChan := initMDNS(ctx, host, cfg.RendezvousString)
+	peerChan := initMDNS(host, cfg.RendezvousString)
 
 	peer := <-peerChan // will block untill we discover a peer
 	fmt.Println("Found peer:", peer, ", connecting")

--- a/examples/chat-with-mdns/mdns.go
+++ b/examples/chat-with-mdns/mdns.go
@@ -18,13 +18,14 @@ func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
 
 //Initialize the MDNS service
 func initMDNS(peerhost host.Host, rendezvous string) chan peer.AddrInfo {
-	// An hour might be a long long period in practical applications. But this is fine for us
-	ser := mdns.NewMdnsService(peerhost, rendezvous)
-
-	//register with service so that we get notified about peer discovery
+	// register with service so that we get notified about peer discovery
 	n := &discoveryNotifee{}
 	n.PeerChan = make(chan peer.AddrInfo)
 
-	ser.RegisterNotifee(n)
+	// An hour might be a long long period in practical applications. But this is fine for us
+	ser := mdns.NewMdnsService(peerhost, rendezvous, n)
+	if err := ser.Start(); err != nil {
+		panic(err)
+	}
 	return n.PeerChan
 }

--- a/examples/chat-with-mdns/mdns.go
+++ b/examples/chat-with-mdns/mdns.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"context"
-	"time"
-
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
-	mdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns_legacy"
+
+	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 )
 
 type discoveryNotifee struct {
@@ -19,12 +17,9 @@ func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
 }
 
 //Initialize the MDNS service
-func initMDNS(ctx context.Context, peerhost host.Host, rendezvous string) chan peer.AddrInfo {
+func initMDNS(peerhost host.Host, rendezvous string) chan peer.AddrInfo {
 	// An hour might be a long long period in practical applications. But this is fine for us
-	ser, err := mdns.NewMdnsService(ctx, peerhost, time.Hour, rendezvous)
-	if err != nil {
-		panic(err)
-	}
+	ser := mdns.NewMdnsService(peerhost, rendezvous)
 
 	//register with service so that we get notified about peer discovery
 	n := &discoveryNotifee{}

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -875,7 +875,6 @@ github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a/go.mod h1:x6AKhvS
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
-github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9 h1:Y1/FEOpaCpD21WxrmfeIYCFPuVPRCY2XZTWzTNHGw30=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=

--- a/examples/ipfs-camp-2019/06-Pubsub/main.go
+++ b/examples/ipfs-camp-2019/06-Pubsub/main.go
@@ -100,9 +100,11 @@ func main() {
 		fmt.Println("Connected to", targetInfo.ID)
 	}
 
-	mdns := mdns.NewMdnsService(host, "")
 	notifee := &discoveryNotifee{h: host, ctx: ctx}
-	mdns.RegisterNotifee(notifee)
+	mdns := mdns.NewMdnsService(host, "", notifee)
+	if err := mdns.Start(); err != nil {
+		panic(err)
+	}
 
 	err = dht.Bootstrap(ctx)
 	if err != nil {

--- a/examples/ipfs-camp-2019/07-Messaging/main.go
+++ b/examples/ipfs-camp-2019/07-Messaging/main.go
@@ -108,8 +108,10 @@ func main() {
 
 	fmt.Println("Connected to", targetInfo.ID)
 
-	mdns := mdns.NewMdnsService(host, "")
-	mdns.RegisterNotifee(&mdnsNotifee{h: host, ctx: ctx})
+	mdns := mdns.NewMdnsService(host, "", &mdnsNotifee{h: host, ctx: ctx})
+	if err := mdns.Start(); err != nil {
+		panic(err)
+	}
 
 	err = dht.Bootstrap(ctx)
 	if err != nil {

--- a/examples/ipfs-camp-2019/08-End/main.go
+++ b/examples/ipfs-camp-2019/08-End/main.go
@@ -107,8 +107,10 @@ func main() {
 
 	fmt.Println("Connected to", targetInfo.ID)
 
-	mdns := mdns.NewMdnsService(host, "")
-	mdns.RegisterNotifee(&mdnsNotifee{h: host, ctx: ctx})
+	mdns := mdns.NewMdnsService(host, "", &mdnsNotifee{h: host, ctx: ctx})
+	if err := mdns.Start(); err != nil {
+		panic(err)
+	}
 
 	err = dht.Bootstrap(ctx)
 	if err != nil {

--- a/examples/pubsub/chat/main.go
+++ b/examples/pubsub/chat/main.go
@@ -41,8 +41,7 @@ func main() {
 	}
 
 	// setup local mDNS discovery
-	err = setupDiscovery(ctx, h)
-	if err != nil {
+	if err := setupDiscovery(h); err != nil {
 		panic(err)
 	}
 
@@ -103,11 +102,8 @@ func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
 
 // setupDiscovery creates an mDNS discovery service and attaches it to the libp2p Host.
 // This lets us automatically discover peers on the same LAN and connect to them.
-func setupDiscovery(ctx context.Context, h host.Host) error {
+func setupDiscovery(h host.Host) error {
 	// setup mDNS discovery to find local peers
-	disc := mdns.NewMdnsService(h, DiscoveryServiceTag)
-
-	n := discoveryNotifee{h: h}
-	disc.RegisterNotifee(&n)
-	return nil
+	s := mdns.NewMdnsService(h, DiscoveryServiceTag, &discoveryNotifee{h: h})
+	return s.Start()
 }

--- a/p2p/discovery/mdns/mdns_test.go
+++ b/p2p/discovery/mdns/mdns_test.go
@@ -16,8 +16,8 @@ func setupMDNS(t *testing.T, notifee Notifee) peer.ID {
 	t.Helper()
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
-	s := NewMdnsService(host, "")
-	s.RegisterNotifee(notifee)
+	s := NewMdnsService(host, "", notifee)
+	require.NoError(t, s.Start())
 	t.Cleanup(func() {
 		host.Close()
 		s.Close()

--- a/p2p/discovery/mdns_legacy/mdns.go
+++ b/p2p/discovery/mdns_legacy/mdns.go
@@ -3,6 +3,7 @@ package mdns_legacy
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -26,7 +27,12 @@ var log = logging.Logger("mdns_legacy")
 
 const ServiceTag = "_ipfs-discovery._udp"
 
-type Service = mdnsnew.Service
+type Service interface {
+	io.Closer
+	RegisterNotifee(Notifee)
+	UnregisterNotifee(Notifee)
+}
+
 type Notifee = mdnsnew.Notifee
 
 type mdnsService struct {


### PR DESCRIPTION
Fixes #1167. Alternative to #1215. Closes #1215.

Also introduces a `Start` method.