### PR TITLE
don't call HandlePeerFound in a go routine, when finding a peer via mDNS

### DIFF
--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -124,16 +124,16 @@ func main() {
 
 	// open a stream, this stream will be handled by handleStream other end
 	stream, err := host.NewStream(ctx, peer.ID, protocol.ID(cfg.ProtocolID))
-
 	if err != nil {
 		fmt.Println("Stream open failed", err)
-	} else {
-		rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
-
-		go writeData(rw)
-		go readData(rw)
-		fmt.Println("Connected to:", peer)
+		return
 	}
+
+	rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
+
+	go writeData(rw)
+	go readData(rw)
+	fmt.Println("Connected to:", peer)
 
 	select {} //wait here
 }

--- a/examples/ipfs-camp-2019/06-Pubsub/main.go
+++ b/examples/ipfs-camp-2019/06-Pubsub/main.go
@@ -31,7 +31,7 @@ type discoveryNotifee struct {
 func (m *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
 	if m.h.Network().Connectedness(pi.ID) != network.Connected {
 		fmt.Printf("Found %s!\n", pi.ID.ShortString())
-		m.h.Connect(m.ctx, pi)
+		go m.h.Connect(m.ctx, pi)
 	}
 }
 

--- a/examples/ipfs-camp-2019/07-Messaging/main.go
+++ b/examples/ipfs-camp-2019/07-Messaging/main.go
@@ -28,7 +28,7 @@ type mdnsNotifee struct {
 }
 
 func (m *mdnsNotifee) HandlePeerFound(pi peer.AddrInfo) {
-	m.h.Connect(m.ctx, pi)
+	go m.h.Connect(m.ctx, pi)
 }
 
 func main() {

--- a/examples/ipfs-camp-2019/08-End/main.go
+++ b/examples/ipfs-camp-2019/08-End/main.go
@@ -28,7 +28,7 @@ type mdnsNotifee struct {
 }
 
 func (m *mdnsNotifee) HandlePeerFound(pi peer.AddrInfo) {
-	m.h.Connect(m.ctx, pi)
+	go m.h.Connect(m.ctx, pi)
 }
 
 func main() {

--- a/examples/pubsub/chat/main.go
+++ b/examples/pubsub/chat/main.go
@@ -94,10 +94,12 @@ type discoveryNotifee struct {
 // support PubSub.
 func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
 	fmt.Printf("discovered new peer %s\n", pi.ID.Pretty())
-	err := n.h.Connect(context.Background(), pi)
-	if err != nil {
-		fmt.Printf("error connecting to peer %s: %s\n", pi.ID.Pretty(), err)
-	}
+
+	go func() {
+		if err := n.h.Connect(context.Background(), pi); err != nil {
+			fmt.Printf("error connecting to peer %s: %s\n", pi.ID.Pretty(), err)
+		}
+	}()
 }
 
 // setupDiscovery creates an mDNS discovery service and attaches it to the libp2p Host.

--- a/p2p/discovery/mdns/mdns.go
+++ b/p2p/discovery/mdns/mdns.go
@@ -31,6 +31,8 @@ type Service interface {
 }
 
 type Notifee interface {
+	// HandlePeerFound is called when a new peer is discovered via mDNS.
+	// Calling this function must not block.
 	HandlePeerFound(peer.AddrInfo)
 }
 
@@ -182,7 +184,7 @@ func (s *mdnsService) startResolver(ctx context.Context) {
 				continue
 			}
 			for _, info := range infos {
-				go s.notifee.HandlePeerFound(info)
+				s.notifee.HandlePeerFound(info)
 			}
 		}
 	}()


### PR DESCRIPTION
If we start a go routine, we must control its shutdown. Here we don't. Shutting down the mDNS service doesn't cancel or even wait for completion of these go routines.

There are two ways to fix this:
1. cancel and wait for these go routines
2. make this the responsibility of the caller

Option 2 seems the more desirable, since there are cases where you don't do anything blocking / computationally expensive when finding a new peer, so there wouldn't be a need to start a go routine in the first place.