### PR TITLE
pass static relays to EnableAutoRelay, deprecate libp2p.StaticRelays and libp2p.DefaultStaticRelays

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,7 +252,11 @@ func (cfg *Config) NewNode() (host.Host, error) {
 		}
 
 		if len(cfg.StaticRelays) > 0 {
-			ar = autorelay.NewAutoRelay(h, nil, router, cfg.StaticRelays)
+			var err error
+			ar, err = autorelay.NewAutoRelay(h, router, autorelay.WithStaticRelays(cfg.StaticRelays))
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			if router == nil {
 				h.Close()
@@ -263,9 +267,16 @@ func (cfg *Config) NewNode() (host.Host, error) {
 				h.Close()
 				return nil, fmt.Errorf("cannot enable autorelay; no suitable routing for discovery")
 			}
-
-			discovery := discovery.NewRoutingDiscovery(crouter)
-			ar = autorelay.NewAutoRelay(h, discovery, router, cfg.StaticRelays)
+			var err error
+			ar, err = autorelay.NewAutoRelay(
+				h,
+				router,
+				autorelay.WithDiscoverer(discovery.NewRoutingDiscovery(crouter)),
+				autorelay.WithStaticRelays(cfg.StaticRelays),
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -271,11 +271,7 @@ func StaticRelays(relays []peer.AddrInfo) Option {
 func DefaultStaticRelays() Option {
 	return func(cfg *Config) error {
 		for _, addr := range autorelay.DefaultRelays {
-			a, err := ma.NewMultiaddr(addr)
-			if err != nil {
-				return err
-			}
-			pi, err := peer.AddrInfoFromP2pAddr(a)
+			pi, err := peer.AddrInfoFromString(addr)
 			if err != nil {
 				return err
 			}

--- a/options.go
+++ b/options.go
@@ -250,8 +250,14 @@ func EnableRelayService(opts ...relayv2.Option) Option {
 //
 // This subsystem performs automatic address rewriting to advertise relay addresses when it
 // detects that the node is publicly unreachable (e.g. behind a NAT).
-func EnableAutoRelay() Option {
+func EnableAutoRelay(opts ...autorelay.StaticRelayOption) Option {
 	return func(cfg *Config) error {
+		if len(opts) > 0 {
+			if len(opts) > 1 {
+				return errors.New("only expected a single static relay configuration option")
+			}
+			cfg.StaticRelayOpt = opts[0]
+		}
 		cfg.EnableAutoRelay = true
 		return nil
 	}
@@ -260,26 +266,26 @@ func EnableAutoRelay() Option {
 // StaticRelays configures known relays for autorelay; when this option is enabled
 // then the system will use the configured relays instead of querying the DHT to
 // discover relays.
+// Deprecated: pass an autorelay.WithStaticRelays option to EnableAutoRelay.
 func StaticRelays(relays []peer.AddrInfo) Option {
 	return func(cfg *Config) error {
-		cfg.StaticRelays = append(cfg.StaticRelays, relays...)
+		cfg.StaticRelayOpt = autorelay.WithStaticRelays(relays)
 		return nil
 	}
 }
 
 // DefaultStaticRelays configures the static relays to use the known PL-operated relays.
+// Deprecated: pass autorelay.WithDefaultStaticRelays to EnableAutoRelay.
 func DefaultStaticRelays() Option {
-	return func(cfg *Config) error {
-		for _, addr := range autorelay.DefaultRelays {
-			pi, err := peer.AddrInfoFromString(addr)
-			if err != nil {
-				return err
-			}
-			cfg.StaticRelays = append(cfg.StaticRelays, *pi)
+	relays := make([]peer.AddrInfo, 0, len(autorelay.DefaultRelays))
+	for _, addr := range autorelay.DefaultRelays {
+		pi, err := peer.AddrInfoFromString(addr)
+		if err != nil {
+			panic(fmt.Sprintf("failed to initialize default static relays: %s", err))
 		}
-
-		return nil
+		relays = append(relays, *pi)
 	}
+	return StaticRelays(relays)
 }
 
 // ForceReachabilityPublic overrides automatic reachability detection in the AutoNAT subsystem,

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -53,6 +53,18 @@ var DefaultRelays = []string{
 	"/ip4/147.75.70.221/udp/4001/quic/p2p/Qme8g49gm3q4Acp7xWBKg3nAa9fxZ1YmyDJdyGgoG6LsXh",
 }
 
+var defaultStaticRelays []peer.AddrInfo
+
+func init() {
+	for _, s := range DefaultRelays {
+		pi, err := peer.AddrInfoFromString(s)
+		if err != nil {
+			panic(fmt.Sprintf("failed to initialize default static relays: %s", err))
+		}
+		defaultStaticRelays = append(defaultStaticRelays, *pi)
+	}
+}
+
 type Option func(*AutoRelay) error
 
 func WithStaticRelays(static []peer.AddrInfo) Option {
@@ -63,6 +75,10 @@ func WithStaticRelays(static []peer.AddrInfo) Option {
 		r.static = static
 		return nil
 	}
+}
+
+func WithDefaultStaticRelays() Option {
+	return WithStaticRelays(defaultStaticRelays)
 }
 
 func WithDiscoverer(discover discovery.Discoverer) Option {

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -66,8 +66,9 @@ func init() {
 }
 
 type Option func(*AutoRelay) error
+type StaticRelayOption Option
 
-func WithStaticRelays(static []peer.AddrInfo) Option {
+func WithStaticRelays(static []peer.AddrInfo) StaticRelayOption {
 	return func(r *AutoRelay) error {
 		if len(r.static) > 0 {
 			return errors.New("can't set static relays, static relays already configured")
@@ -77,7 +78,7 @@ func WithStaticRelays(static []peer.AddrInfo) Option {
 	}
 }
 
-func WithDefaultStaticRelays() Option {
+func WithDefaultStaticRelays() StaticRelayOption {
 	return WithStaticRelays(defaultStaticRelays)
 }
 


### PR DESCRIPTION
Static relays don't have any use outside of `AutoRelay`. We can clean up our config options a bit by making it an option to `EnableAutoRelay`, instead of its own option.