### PR TITLE
remove check for consistent transports in identify

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -716,35 +716,6 @@ func (ids *idService) consumeReceivedPubKey(c network.Conn, kb []byte) {
 	log.Errorf("%s local key and received key for %s do not match, but match peer.ID", lp, rp)
 }
 
-// HasConsistentTransport returns true if the address 'a' shares a
-// protocol set with any address in the green set. This is used
-// to check if a given address might be one of the addresses a peer is
-// listening on.
-func HasConsistentTransport(a ma.Multiaddr, green []ma.Multiaddr) bool {
-	protosMatch := func(a, b []ma.Protocol) bool {
-		if len(a) != len(b) {
-			return false
-		}
-
-		for i, p := range a {
-			if b[i].Code != p.Code {
-				return false
-			}
-		}
-		return true
-	}
-
-	protos := a.Protocols()
-
-	for _, ga := range green {
-		if protosMatch(protos, ga.Protocols()) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (ids *idService) consumeObservedAddress(observed []byte, c network.Conn) {
 	if observed == nil {
 		return

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -283,21 +283,6 @@ func TestIDService(t *testing.T) {
 	}
 }
 
-func TestProtoMatching(t *testing.T) {
-	tcp1, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/1234")
-	tcp2, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/2345")
-	tcp3, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/4567")
-	utp, _ := ma.NewMultiaddr("/ip4/1.2.3.4/udp/1234/utp")
-
-	if !identify.HasConsistentTransport(tcp1, []ma.Multiaddr{tcp2, tcp3, utp}) {
-		t.Fatal("expected match")
-	}
-
-	if identify.HasConsistentTransport(utp, []ma.Multiaddr{tcp2, tcp3}) {
-		t.Fatal("expected mismatch")
-	}
-}
-
 func TestLocalhostAddrFiltering(t *testing.T) {
 	t.Skip("need to fix this test")
 	ctx, cancel := context.WithCancel(context.Background())

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -381,17 +381,6 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 		return
 	}
 
-	// We should reject the connection if the observation doesn't match the
-	// transports of one of our advertised addresses.
-	if !HasConsistentTransport(observed, oas.host.Addrs()) {
-		log.Debugw(
-			"observed multiaddr doesn't match the transports of any announced addresses",
-			"from", conn.RemoteMultiaddr(),
-			"observed", observed,
-		)
-		return
-	}
-
 	// Ok, the observation is good, record it.
 	log.Debugw("added own observed listen addr", "observed", observed)
 
@@ -555,7 +544,7 @@ func (oas *ObservedAddrManager) Close() error {
 // Here, we use the root multiaddr address. This is mostly
 // IP addresses. In practice, this is what we want.
 func observerGroup(m ma.Multiaddr) string {
-	//TODO: If IPv6 rolls out we should mark /64 routing zones as one group
+	// TODO: If IPv6 rolls out we should mark /64 routing zones as one group
 	first, _ := ma.SplitFirst(m)
 	return string(first.Bytes())
 }


### PR DESCRIPTION
When using autorelay, we set an `AddrFactory` and overwrite the host's addresses. Until we receive a relay reservation, that address set will be empty, making us discard all addresses received via identify.
Furthermore, the relay might be reachable via transports that we don't speak.