### PR TITLE
use a basichost, not a blankhost when constructing autonat

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -311,7 +311,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			h.Close()
 			return nil, err
 		}
-		dialerHost, err := bhost.NewHost(dialerSwarm, nil)
+		dialerHost, err := bhost.NewHost(dialerSwarm, &bhost.HostOpts{DisableIdentify: true})
 		if err != nil {
 			h.Close()
 			return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 
 	autonat "github.com/libp2p/go-libp2p-autonat"
-	blankhost "github.com/libp2p/go-libp2p-blankhost"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
@@ -307,12 +306,16 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			Peerstore:          ps,
 		}
 
-		dialer, err := autoNatCfg.makeSwarm()
+		dialerSwarm, err := autoNatCfg.makeSwarm()
 		if err != nil {
 			h.Close()
 			return nil, err
 		}
-		dialerHost := blankhost.NewBlankHost(dialer)
+		dialerHost, err := bhost.NewHost(dialerSwarm, nil)
+		if err != nil {
+			h.Close()
+			return nil, err
+		}
 		if err := autoNatCfg.addTransports(dialerHost); err != nil {
 			dialerHost.Close()
 			h.Close()

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -134,6 +134,9 @@ type HostOpts struct {
 	// ConnManager is a libp2p connection manager
 	ConnManager connmgr.ConnManager
 
+	// DisableIdentify indicates whether to instantiate the identify service
+	DisableIdentify bool
+
 	// EnablePing indicates whether to instantiate the ping service
 	EnablePing bool
 
@@ -219,14 +222,17 @@ func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
 		h.mux = opts.MultistreamMuxer
 	}
 
-	// we can't set this as a default above because it depends on the *BasicHost.
-	if h.disableSignedPeerRecord {
-		h.ids, err = identify.NewIDService(h, identify.UserAgent(opts.UserAgent), identify.DisableSignedPeerRecord())
-	} else {
-		h.ids, err = identify.NewIDService(h, identify.UserAgent(opts.UserAgent))
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Identify service: %s", err)
+	if !opts.DisableIdentify {
+		var err error
+		// we can't set this as a default above because it depends on the *BasicHost.
+		if h.disableSignedPeerRecord {
+			h.ids, err = identify.NewIDService(h, identify.UserAgent(opts.UserAgent), identify.DisableSignedPeerRecord())
+		} else {
+			h.ids, err = identify.NewIDService(h, identify.UserAgent(opts.UserAgent))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Identify service: %s", err)
+		}
 	}
 
 	if opts.EnableHolePunching {


### PR DESCRIPTION
Is this safe to do? Our default in `NewHost` are such that we don't construct any services unless a config option is set for those, so there shouldn't be a big difference between a `BasicHost` and a `BlankHost`.

Note that this PR is not sufficient to kill the blankhost. We still use it in tests, and refactoring those will take some more effort (import loops...).