### PR TITLE
split a blank host out of the basic host

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/libp2p/go-libp2p/p2p/host/autonat"
+	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
+	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	"github.com/libp2p/go-libp2p/p2p/host/blank"
+	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
+	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
+	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
+
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -18,15 +27,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/transport"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 
-	"github.com/libp2p/go-libp2p/p2p/host/autonat"
-	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
-	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
-	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
-	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
-	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
-	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
-
-	blankhost "github.com/libp2p/go-libp2p-blankhost"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
@@ -333,7 +333,11 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			h.Close()
 			return nil, err
 		}
-		dialerHost := blankhost.NewBlankHost(dialer)
+		dialerHost, err := blank.NewHost(dialer)
+		if err != nil {
+			h.Close()
+			return nil, err
+		}
 		if err := autoNatCfg.addTransports(dialerHost); err != nil {
 			dialerHost.Close()
 			h.Close()

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/libp2p/go-conn-security-multistream v0.3.0
 	github.com/libp2p/go-eventbus v0.2.1
 	github.com/libp2p/go-libp2p-asn-util v0.1.0
-	github.com/libp2p/go-libp2p-blankhost v0.3.0
+	github.com/libp2p/go-libp2p-blankhost v0.3.0 // indirect
 	github.com/libp2p/go-libp2p-circuit v0.4.1-0.20220104091935-28fb8d25f785
 	github.com/libp2p/go-libp2p-core v0.13.1-0.20220104083644-a3dd401efe36
 	github.com/libp2p/go-libp2p-discovery v0.6.0

--- a/p2p/host/autonat/svc_test.go
+++ b/p2p/host/autonat/svc_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/p2p/host/blank"
+
 	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 
-	bhost "github.com/libp2p/go-libp2p-blankhost"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -18,8 +19,10 @@ import (
 )
 
 func makeAutoNATConfig(t *testing.T) *config {
-	h := bhost.NewBlankHost(swarmt.GenSwarm(t))
-	dh := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	h, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
+	dh, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	c := config{host: h, dialer: dh.Network()}
 	_ = defaults(&c)
 	c.forceReachability = true
@@ -29,16 +32,14 @@ func makeAutoNATConfig(t *testing.T) *config {
 
 func makeAutoNATService(t *testing.T, c *config) *autoNATService {
 	as, err := newAutoNATService(c)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	as.Enable()
-
 	return as
 }
 
 func makeAutoNATClient(t *testing.T) (host.Host, Client) {
-	h := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	h, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	cli := NewAutoNATClient(h, nil)
 	return h, cli
 }
@@ -195,9 +196,11 @@ func TestAutoNATServiceRateLimitJitter(t *testing.T) {
 }
 
 func TestAutoNATServiceStartup(t *testing.T) {
-	h := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	h, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer h.Close()
-	dh := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	dh, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer dh.Close()
 	an, err := New(h, EnableService(dh.Network()))
 	an.(*AmbientAutoNAT).config.dialPolicy.allowSelfDials = true

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/p2p/host/autonat"
-	"github.com/libp2p/go-libp2p/p2p/host/pstoremanager"
+	"github.com/libp2p/go-libp2p/p2p/host/blank"
 	"github.com/libp2p/go-libp2p/p2p/host/relaysvc"
 	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
@@ -66,6 +66,8 @@ type AddrsFactory func([]ma.Multiaddr) []ma.Multiaddr
 //  * uses an identity service to send + receive node information
 //  * uses a nat service to establish NAT port mappings
 type BasicHost struct {
+	*blank.BaseHost // a base host
+
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	// ensures we shutdown ONLY once
@@ -73,16 +75,12 @@ type BasicHost struct {
 	// keep track of resources we need to wait on before shutting down
 	refCount sync.WaitGroup
 
-	network      network.Network
-	psManager    *pstoremanager.PeerstoreManager
 	mux          *msmux.MultistreamMuxer
 	ids          identify.IDService
 	hps          *holepunch.Service
 	pings        *ping.PingService
 	natmgr       NATManager
 	maResolver   *madns.Resolver
-	cmgr         connmgr.ConnManager
-	eventbus     event.Bus
 	relayManager *relaysvc.RelayManager
 
 	AddrsFactory AddrsFactory
@@ -90,8 +88,7 @@ type BasicHost struct {
 	negtimeout time.Duration
 
 	emitters struct {
-		evtLocalProtocolsUpdated event.Emitter
-		evtLocalAddrsUpdated     event.Emitter
+		evtLocalAddrsUpdated event.Emitter
 	}
 
 	addrChangeChan chan struct{}
@@ -107,7 +104,7 @@ type BasicHost struct {
 	autoNat autonat.AutoNAT
 }
 
-var _ host.Host = (*BasicHost)(nil)
+var _ host.Host = &BasicHost{}
 
 // HostOpts holds options that can be passed to NewHost in order to
 // customize construction of the *BasicHost.
@@ -157,24 +154,28 @@ type HostOpts struct {
 
 // NewHost constructs a new *BasicHost and activates it by attaching its stream and connection handlers to the given inet.Network.
 func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
-	eventBus := eventbus.NewBus()
-	psManager, err := pstoremanager.NewPeerstoreManager(n.Peerstore(), eventBus)
-	if err != nil {
-		return nil, err
-	}
-	hostCtx, cancel := context.WithCancel(context.Background())
 	if opts == nil {
 		opts = &HostOpts{}
 	}
+	var baseOpts []blank.Option
+	if opts.MultistreamMuxer != nil {
+		baseOpts = append(baseOpts, blank.WithMultistreamMuxer(opts.MultistreamMuxer))
+	}
+	if opts.ConnManager != nil {
+		baseOpts = append(baseOpts, blank.WithConnMgr(opts.ConnManager))
+	}
+	baseHost, err := blank.NewHost(n, baseOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	hostCtx, cancel := context.WithCancel(context.Background())
 
 	h := &BasicHost{
-		network:                 n,
-		psManager:               psManager,
-		mux:                     msmux.NewMultistreamMuxer(),
+		BaseHost:                baseHost,
 		negtimeout:              DefaultNegotiationTimeout,
 		AddrsFactory:            DefaultAddrsFactory,
 		maResolver:              madns.DefaultResolver,
-		eventbus:                eventBus,
 		addrChangeChan:          make(chan struct{}, 1),
 		ctx:                     hostCtx,
 		ctxCancel:               cancel,
@@ -183,17 +184,9 @@ func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
 
 	h.updateLocalIpAddr()
 
-	if h.emitters.evtLocalProtocolsUpdated, err = h.eventbus.Emitter(&event.EvtLocalProtocolsUpdated{}); err != nil {
+	if h.emitters.evtLocalAddrsUpdated, err = h.EventBus().Emitter(&event.EvtLocalAddressesUpdated{}, eventbus.Stateful); err != nil {
 		return nil, err
 	}
-	if h.emitters.evtLocalAddrsUpdated, err = h.eventbus.Emitter(&event.EvtLocalAddressesUpdated{}, eventbus.Stateful); err != nil {
-		return nil, err
-	}
-	evtPeerConnectednessChanged, err := h.eventbus.Emitter(&event.EvtPeerConnectednessChanged{})
-	if err != nil {
-		return nil, err
-	}
-	h.Network().Notify(newPeerConnectWatcher(evtPeerConnectednessChanged))
 
 	if !h.disableSignedPeerRecord {
 		cab, ok := peerstore.GetCertifiedAddrBook(n.Peerstore())
@@ -256,13 +249,6 @@ func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
 
 	if opts.MultiaddrResolver != nil {
 		h.maResolver = opts.MultiaddrResolver
-	}
-
-	if opts.ConnManager == nil {
-		h.cmgr = &connmgr.NullConnMgr{}
-	} else {
-		h.cmgr = opts.ConnManager
-		n.Notify(h.cmgr.Notifee())
 	}
 
 	if opts.EnableRelayService {
@@ -358,7 +344,7 @@ func (h *BasicHost) updateLocalIpAddr() {
 
 // Start starts background tasks in the host
 func (h *BasicHost) Start() {
-	h.psManager.Start()
+	h.BaseHost.Start()
 	h.refCount.Add(1)
 	go h.background()
 }
@@ -510,7 +496,7 @@ func (h *BasicHost) background() {
 	defer ticker.Stop()
 
 	for {
-		if len(h.network.ListenAddresses()) > 0 {
+		if len(h.Network().ListenAddresses()) > 0 {
 			h.updateLocalIpAddr()
 		}
 		// Request addresses anyways because, technically, address filters still apply.
@@ -528,71 +514,9 @@ func (h *BasicHost) background() {
 	}
 }
 
-// ID returns the (local) peer.ID associated with this Host
-func (h *BasicHost) ID() peer.ID {
-	return h.Network().LocalPeer()
-}
-
-// Peerstore returns the Host's repository of Peer Addresses and Keys.
-func (h *BasicHost) Peerstore() peerstore.Peerstore {
-	return h.Network().Peerstore()
-}
-
-// Network returns the Network interface of the Host
-func (h *BasicHost) Network() network.Network {
-	return h.network
-}
-
-// Mux returns the Mux multiplexing incoming streams to protocol handlers
-func (h *BasicHost) Mux() protocol.Switch {
-	return h.mux
-}
-
 // IDService returns
 func (h *BasicHost) IDService() identify.IDService {
 	return h.ids
-}
-
-func (h *BasicHost) EventBus() event.Bus {
-	return h.eventbus
-}
-
-// SetStreamHandler sets the protocol handler on the Host's Mux.
-// This is equivalent to:
-//   host.Mux().SetHandler(proto, handler)
-// (Threadsafe)
-func (h *BasicHost) SetStreamHandler(pid protocol.ID, handler network.StreamHandler) {
-	h.Mux().AddHandler(string(pid), func(p string, rwc io.ReadWriteCloser) error {
-		is := rwc.(network.Stream)
-		is.SetProtocol(protocol.ID(p))
-		handler(is)
-		return nil
-	})
-	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
-		Added: []protocol.ID{pid},
-	})
-}
-
-// SetStreamHandlerMatch sets the protocol handler on the Host's Mux
-// using a matching function to do protocol comparisons
-func (h *BasicHost) SetStreamHandlerMatch(pid protocol.ID, m func(string) bool, handler network.StreamHandler) {
-	h.Mux().AddHandlerWithFunc(string(pid), m, func(p string, rwc io.ReadWriteCloser) error {
-		is := rwc.(network.Stream)
-		is.SetProtocol(protocol.ID(p))
-		handler(is)
-		return nil
-	})
-	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
-		Added: []protocol.ID{pid},
-	})
-}
-
-// RemoveStreamHandler returns ..
-func (h *BasicHost) RemoveStreamHandler(pid protocol.ID) {
-	h.Mux().RemoveHandler(string(pid))
-	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
-		Removed: []protocol.ID{pid},
-	})
 }
 
 // NewStream opens a new stream to given peer p, and writes a p2p/protocol
@@ -782,10 +706,6 @@ func (h *BasicHost) dialPeer(ctx context.Context, p peer.ID) error {
 
 	log.Debugf("host %s finished dialing %s", h.ID(), p)
 	return nil
-}
-
-func (h *BasicHost) ConnManager() connmgr.ConnManager {
-	return h.cmgr
 }
 
 // Addrs returns listening addresses that are safe to announce to the network.
@@ -1019,12 +939,10 @@ func (h *BasicHost) GetAutoNat() autonat.AutoNAT {
 // Close shuts down the Host's services (network, etc).
 func (h *BasicHost) Close() error {
 	h.closeSync.Do(func() {
+		h.BaseHost.Close()
 		h.ctxCancel()
 		if h.natmgr != nil {
 			h.natmgr.Close()
-		}
-		if h.cmgr != nil {
-			h.cmgr.Close()
 		}
 		if h.ids != nil {
 			h.ids.Close()
@@ -1038,15 +956,7 @@ func (h *BasicHost) Close() error {
 		if h.hps != nil {
 			h.hps.Close()
 		}
-
-		_ = h.emitters.evtLocalProtocolsUpdated.Close()
 		_ = h.emitters.evtLocalAddrsUpdated.Close()
-		h.Network().Close()
-
-		h.psManager.Close()
-		if h.Peerstore() != nil {
-			h.Peerstore().Close()
-		}
 
 		h.refCount.Wait()
 	})

--- a/p2p/host/blank/blank_host.go
+++ b/p2p/host/blank/blank_host.go
@@ -1,0 +1,255 @@
+package blank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/p2p/host/pstoremanager"
+
+	"github.com/libp2p/go-libp2p-core/connmgr"
+	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/libp2p/go-libp2p-core/record"
+
+	"github.com/libp2p/go-eventbus"
+
+	logging "github.com/ipfs/go-log/v2"
+	ma "github.com/multiformats/go-multiaddr"
+	msmux "github.com/multiformats/go-multistream"
+)
+
+var log = logging.Logger("basehost")
+
+type Option func(*BaseHost) error
+
+func WithConnMgr(mgr connmgr.ConnManager) Option {
+	return func(h *BaseHost) error {
+		h.connmgr = mgr
+		return nil
+	}
+}
+
+func WithMultistreamMuxer(mux *msmux.MultistreamMuxer) Option {
+	return func(h *BaseHost) error {
+		h.mux = mux
+		return nil
+	}
+}
+
+type BaseHost struct {
+	network   network.Network
+	psManager *pstoremanager.PeerstoreManager
+	eventbus  event.Bus
+	mux       *msmux.MultistreamMuxer
+	connmgr   connmgr.ConnManager
+
+	closeOnce sync.Once
+
+	emitters struct {
+		evtLocalProtocolsUpdated    event.Emitter
+		evtPeerConnectednessChanged event.Emitter
+	}
+}
+
+var _ host.Host = &BaseHost{}
+
+func NewHost(n network.Network, opts ...Option) (*BaseHost, error) {
+	eventBus := eventbus.NewBus()
+	psManager, err := pstoremanager.NewPeerstoreManager(n.Peerstore(), eventBus)
+	if err != nil {
+		return nil, err
+	}
+	h := &BaseHost{
+		network:   n,
+		eventbus:  eventBus,
+		psManager: psManager,
+	}
+	for _, opt := range opts {
+		if err := opt(h); err != nil {
+			return nil, err
+		}
+	}
+	if h.mux == nil {
+		h.mux = msmux.NewMultistreamMuxer()
+	}
+	if h.connmgr == nil {
+		h.connmgr = &connmgr.NullConnMgr{}
+	} else {
+		n.Notify(h.connmgr.Notifee())
+	}
+
+	if h.emitters.evtLocalProtocolsUpdated, err = h.eventbus.Emitter(&event.EvtLocalProtocolsUpdated{}); err != nil {
+		return nil, err
+	}
+	h.emitters.evtPeerConnectednessChanged, err = h.eventbus.Emitter(&event.EvtPeerConnectednessChanged{})
+	if err != nil {
+		return nil, err
+	}
+	n.Notify(newPeerConnectWatcher(h.emitters.evtPeerConnectednessChanged))
+
+	if err := h.initSignedRecord(); err != nil {
+		return nil, err
+	}
+	n.SetStreamHandler(h.newStreamHandler)
+	return h, nil
+}
+
+func (h *BaseHost) initSignedRecord() error {
+	cab, ok := peerstore.GetCertifiedAddrBook(h.network.Peerstore())
+	if !ok {
+		return errors.New("peerstore does not support signed records")
+	}
+	rec := peer.PeerRecordFromAddrInfo(peer.AddrInfo{ID: h.ID(), Addrs: h.Addrs()})
+	ev, err := record.Seal(rec, h.Peerstore().PrivKey(h.ID()))
+	if err != nil {
+		return fmt.Errorf("failed to create signed record for self: %s", err)
+	}
+	if _, err := cab.ConsumePeerRecord(ev, peerstore.PermanentAddrTTL); err != nil {
+		return fmt.Errorf("failed to persist signed record for self: %s", err)
+	}
+	return nil
+}
+
+func (h *BaseHost) Start() {
+	h.psManager.Start()
+}
+
+func (h *BaseHost) Addrs() []ma.Multiaddr {
+	addrs, err := h.Network().InterfaceListenAddresses()
+	if err != nil {
+		log.Debug("error retrieving network interface addrs: ", err)
+		return nil
+	}
+	return addrs
+}
+
+func (h *BaseHost) Connect(ctx context.Context, ai peer.AddrInfo) error {
+	// absorb addresses into peerstore
+	h.Peerstore().AddAddrs(ai.ID, ai.Addrs, peerstore.TempAddrTTL)
+
+	cs := h.Network().ConnsToPeer(ai.ID)
+	if len(cs) > 0 {
+		return nil
+	}
+
+	_, err := h.Network().DialPeer(ctx, ai.ID)
+	return err
+}
+
+func (h *BaseHost) ConnManager() connmgr.ConnManager {
+	return h.connmgr
+}
+
+func (h *BaseHost) Close() error {
+	h.closeOnce.Do(func() {
+		h.Network().Close()
+		h.connmgr.Close()
+		h.emitters.evtLocalProtocolsUpdated.Close()
+		h.emitters.evtPeerConnectednessChanged.Close()
+
+		h.psManager.Close()
+		if h.Peerstore() != nil {
+			h.Peerstore().Close()
+		}
+	})
+	return nil
+}
+
+func (h *BaseHost) EventBus() event.Bus {
+	return h.eventbus
+}
+
+func (h *BaseHost) Peerstore() peerstore.Peerstore {
+	return h.Network().Peerstore()
+}
+
+// Network returns the Network interface of the Host
+func (h *BaseHost) Network() network.Network {
+	return h.network
+}
+
+// Mux returns the Mux multiplexing incoming streams to protocol handlers
+func (h *BaseHost) Mux() protocol.Switch {
+	return h.mux
+}
+
+func (h *BaseHost) ID() peer.ID {
+	return h.Network().LocalPeer()
+}
+
+// newStreamHandler is the remote-opened stream handler for network.Network
+func (h *BaseHost) newStreamHandler(s network.Stream) {
+	protoID, handle, err := h.Mux().Negotiate(s)
+	if err != nil {
+		log.Infow("protocol negotiation failed", "error", err)
+		s.Reset()
+		return
+	}
+
+	s.SetProtocol(protocol.ID(protoID))
+	go handle(protoID, s)
+}
+
+func (h *BaseHost) NewStream(ctx context.Context, p peer.ID, protos ...protocol.ID) (network.Stream, error) {
+	s, err := h.Network().NewStream(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+
+	selected, err := msmux.SelectOneOf(protocol.ConvertToStrings(protos), s)
+	if err != nil {
+		s.Reset()
+		return nil, err
+	}
+
+	selpid := protocol.ID(selected)
+	s.SetProtocol(selpid)
+	h.Peerstore().AddProtocols(p, selected)
+
+	return s, nil
+}
+
+// SetStreamHandler sets the protocol handler on the Host's Mux.
+// This is equivalent to:
+//   host.Mux().SetHandler(proto, handler)
+// (Threadsafe)
+func (h *BaseHost) SetStreamHandler(pid protocol.ID, handler network.StreamHandler) {
+	h.Mux().AddHandler(string(pid), func(p string, rwc io.ReadWriteCloser) error {
+		is := rwc.(network.Stream)
+		is.SetProtocol(protocol.ID(p))
+		handler(is)
+		return nil
+	})
+	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
+		Added: []protocol.ID{pid},
+	})
+}
+
+// SetStreamHandlerMatch sets the protocol handler on the Host's Mux
+// using a matching function to do protocol comparisons
+func (h *BaseHost) SetStreamHandlerMatch(pid protocol.ID, m func(string) bool, handler network.StreamHandler) {
+	h.Mux().AddHandlerWithFunc(string(pid), m, func(p string, rwc io.ReadWriteCloser) error {
+		is := rwc.(network.Stream)
+		is.SetProtocol(protocol.ID(p))
+		handler(is)
+		return nil
+	})
+	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
+		Added: []protocol.ID{pid},
+	})
+}
+
+// RemoveStreamHandler returns ..
+func (h *BaseHost) RemoveStreamHandler(pid protocol.ID) {
+	h.Mux().RemoveHandler(string(pid))
+	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
+		Removed: []protocol.ID{pid},
+	})
+}

--- a/p2p/host/blank/peer_connectedness.go
+++ b/p2p/host/blank/peer_connectedness.go
@@ -1,4 +1,4 @@
-package basichost
+package blank
 
 import (
 	"sync"

--- a/p2p/host/blank/peer_connectedness_test.go
+++ b/p2p/host/blank/peer_connectedness_test.go
@@ -1,4 +1,4 @@
-package basichost
+package blank
 
 import (
 	"context"
@@ -14,10 +14,10 @@ import (
 )
 
 func TestPeerConnectedness(t *testing.T) {
-	h1, err := NewHost(swarmt.GenSwarm(t), nil)
+	h1, err := NewHost(swarmt.GenSwarm(t))
 	require.NoError(t, err)
 	defer h1.Close()
-	h2, err := NewHost(swarmt.GenSwarm(t), nil)
+	h2, err := NewHost(swarmt.GenSwarm(t))
 	require.NoError(t, err)
 
 	sub1, err := h1.EventBus().Subscribe(&event.EvtPeerConnectednessChanged{})

--- a/p2p/protocol/circuitv2/relay/relay_test.go
+++ b/p2p/protocol/circuitv2/relay/relay_test.go
@@ -9,24 +9,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/transport"
-
-	"github.com/libp2p/go-tcp-transport"
-
+	"github.com/libp2p/go-libp2p/p2p/host/blank"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/transport"
 
-	bhost "github.com/libp2p/go-libp2p-blankhost"
-	"github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
+	"github.com/libp2p/go-tcp-transport"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -73,7 +71,11 @@ func getNetHosts(t *testing.T, ctx context.Context, n int) (hosts []host.Host, u
 			t.Fatal(err)
 		}
 
-		h := bhost.NewBlankHost(netw)
+		h, err := blank.NewHost(netw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Start()
 
 		hosts = append(hosts, h)
 	}

--- a/p2p/protocol/identify/id_glass_test.go
+++ b/p2p/protocol/identify/id_glass_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
-	blhost "github.com/libp2p/go-libp2p-blankhost"
+	"github.com/libp2p/go-libp2p/p2p/host/blank"
+
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +22,8 @@ func TestFastDisconnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	target := blhost.NewBlankHost(swarmt.GenSwarm(t))
+	target, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer target.Close()
 	ids, err := NewIDService(target)
 	require.NoError(t, err)
@@ -60,7 +63,8 @@ func TestFastDisconnect(t *testing.T) {
 		}
 	})
 
-	source := blhost.NewBlankHost(swarmt.GenSwarm(t))
+	source, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer source.Close()
 
 	// only connect to the first address, to make sure we only end up with one connection

--- a/p2p/protocol/identify/peer_loop_test.go
+++ b/p2p/protocol/identify/peer_loop_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/p2p/host/blank"
+
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	blhost "github.com/libp2p/go-libp2p-blankhost"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,10 +18,14 @@ func TestMakeApplyDelta(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
+	h1, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer h1.Close()
+
 	ids1, err := NewIDService(h1)
 	require.NoError(t, err)
+	defer ids1.Close()
+
 	ph := newPeerHandler(h1.ID(), ids1)
 	ph.start(ctx, func() {})
 	defer ph.stop()
@@ -64,10 +68,13 @@ func TestHandlerClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
+	h1, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer h1.Close()
 	ids1, err := NewIDService(h1)
 	require.NoError(t, err)
+	defer ids1.Close()
+
 	ph := newPeerHandler(h1.ID(), ids1)
 	closedCh := make(chan struct{}, 2)
 	ph.start(ctx, func() {
@@ -93,10 +100,13 @@ func TestPeerSupportsProto(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
+	h1, err := blank.NewHost(swarmt.GenSwarm(t))
+	require.NoError(t, err)
 	defer h1.Close()
+
 	ids1, err := NewIDService(h1)
 	require.NoError(t, err)
+	defer ids1.Close()
 
 	rp := peer.ID("test")
 	ph := newPeerHandler(rp, ids1)

--- a/package-list.json
+++ b/package-list.json
@@ -9,7 +9,6 @@
     "Libp2p",
     ["libp2p/go-libp2p", "go-libp2p", "go-libp2p entry point"],
     ["libp2p/go-libp2p-core", "go-libp2p-core", "core interfaces, types, and abstractions"],
-    ["libp2p/go-libp2p-blankhost", "go-libp2p-blankhost", "minimal implementation of the \"host\" interface"],
 
     "Network",
     ["libp2p/go-libp2p-swarm", "go-libp2p-swarm", "reference implementation of network state machine"],


### PR DESCRIPTION
Fixes #1247.

As suggested by @Stebalien in https://github.com/libp2p/go-libp2p/pull/1257#issuecomment-990616783.

We probably need to work on naming here. Should we rename the `basic` package to `full`?