### PR TITLE
move go-libp2p-discovery to p2p/discovery/generic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/transport"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 
+	discovery "github.com/libp2p/go-libp2p/p2p/discovery/generic"
 	"github.com/libp2p/go-libp2p/p2p/host/autonat"
 	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
@@ -26,7 +27,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 
 	blankhost "github.com/libp2p/go-libp2p-blankhost"
-	discovery "github.com/libp2p/go-libp2p-discovery"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
 

--- a/examples/chat-with-rendezvous/README.md
+++ b/examples/chat-with-rendezvous/README.md
@@ -80,7 +80,7 @@ for _, addr := range bootstrapPeers {
 
 5. **Announce your presence using a rendezvous point.**
 
-[routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.Advertise) makes this node announce that it can provide a value for the given key. Where a key in this case is ```rendezvousString```. Other peers will hit the same key to find other peers.
+[routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p/p2p/discovery/generic#RoutingDiscovery.Advertise) makes this node announce that it can provide a value for the given key. Where a key in this case is ```rendezvousString```. Other peers will hit the same key to find other peers.
 
 ```go
 routingDiscovery := discovery.NewRoutingDiscovery(kademliaDHT)
@@ -89,15 +89,15 @@ discovery.Advertise(ctx, routingDiscovery, config.RendezvousString)
 
 6. **Find nearby peers.**
 
-[routingDiscovery.FindPeers](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.FindPeers) will return a channel of peers who have announced their presence.
+[routingDiscovery.FindPeers](https://godoc.org/github.com/libp2p/go-libp2p/p2p/discovery/generic#RoutingDiscovery.FindPeers) will return a channel of peers who have announced their presence.
 
 ```go
 peerChan, err := routingDiscovery.FindPeers(ctx, config.RendezvousString)
 ```
 
-The [discovery](https://godoc.org/github.com/libp2p/go-libp2p-discovery#pkg-index) package uses the DHT internally to [provide](https://godoc.org/github.com/libp2p/go-libp2p-kad-dht#IpfsDHT.Provide) and [findProviders](https://godoc.org/github.com/libp2p/go-libp2p-kad-dht#IpfsDHT.FindProviders).
+The [discovery](https://godoc.org/github.com/libp2p/go-libp2p/p2p/discovery/generic#pkg-index) package uses the DHT internally to [provide](https://godoc.org/github.com/libp2p/go-libp2p-kad-dht#IpfsDHT.Provide) and [findProviders](https://godoc.org/github.com/libp2p/go-libp2p-kad-dht#IpfsDHT.FindProviders).
 
-**Note:** Although [routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.Advertise) and [routingDiscovery.FindPeers](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.FindPeers) works for a rendezvous peer discovery, this is not the right way of doing it. Libp2p is currently working on an actual rendezvous protocol ([libp2p/specs#56](https://github.com/libp2p/specs/pull/56)) which can be used for bootstrap purposes, real time peer discovery and application specific routing.
+**Note:** Although [routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p/p2p/discovery/generic#RoutingDiscovery.Advertise) and [routingDiscovery.FindPeers](https://godoc.org/github.com/libp2p/go-libp2p/p2p/discovery/generic#RoutingDiscovery.FindPeers) works for a rendezvous peer discovery, this is not the right way of doing it. Libp2p is currently working on an actual rendezvous protocol ([libp2p/specs#56](https://github.com/libp2p/specs/pull/56)) which can be used for bootstrap purposes, real time peer discovery and application specific routing.
 
 7. **Open streams to newly discovered peers.**
 

--- a/examples/chat-with-rendezvous/chat.go
+++ b/examples/chat-with-rendezvous/chat.go
@@ -9,15 +9,15 @@ import (
 	"sync"
 
 	"github.com/libp2p/go-libp2p"
+	discovery "github.com/libp2p/go-libp2p/p2p/discovery/generic"
+
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
-	discovery "github.com/libp2p/go-libp2p-discovery"
-
-	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/multiformats/go-multiaddr"
 
 	"github.com/ipfs/go-log/v2"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/multiformats/go-multiaddr"
 )
 
 var logger = log.Logger("rendezvous")

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/libp2p/go-libp2p v0.14.4
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-discovery v0.6.0
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
 	github.com/libp2p/go-libp2p-noise v0.3.0
 	github.com/libp2p/go-libp2p-swarm v0.9.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -465,8 +465,6 @@ github.com/libp2p/go-libp2p-core v0.11.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQR
 github.com/libp2p/go-libp2p-core v0.12.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
 github.com/libp2p/go-libp2p-core v0.13.0 h1:IFG/s8dN6JN2OTrXX9eq2wNU/Zlz2KLdwZUp5FplgXI=
 github.com/libp2p/go-libp2p-core v0.13.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
-github.com/libp2p/go-libp2p-discovery v0.6.0 h1:1XdPmhMJr8Tmj/yUfkJMIi8mgwWrLUsCB3bMxdT+DSo=
-github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVCWPna2dXmPNHc2zR9S8=
 github.com/libp2p/go-libp2p-kad-dht v0.15.0 h1:Ke+Oj78gX5UDXnA6HBdrgvi+fStJxgYTDa51U0TsCLo=
 github.com/libp2p/go-libp2p-kad-dht v0.15.0/go.mod h1:rZtPxYu1TnHHz6n1RggdGrxUX/tA1C2/Wiw3ZMUDrU0=
 github.com/libp2p/go-libp2p-kbucket v0.3.1/go.mod h1:oyjT5O7tS9CQurok++ERgc46YLwEpuGoFq9ubvoUOio=

--- a/examples/ipfs-camp-2019/06-Pubsub/main.go
+++ b/examples/ipfs-camp-2019/06-Pubsub/main.go
@@ -8,18 +8,21 @@ import (
 	"syscall"
 
 	"github.com/libp2p/go-libp2p"
+	disc "github.com/libp2p/go-libp2p/p2p/discovery/generic"
+	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
+
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
-	disc "github.com/libp2p/go-libp2p-discovery"
+
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	mplex "github.com/libp2p/go-libp2p-mplex"
 	tls "github.com/libp2p/go-libp2p-tls"
 	yamux "github.com/libp2p/go-libp2p-yamux"
-	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/libp2p/go-tcp-transport"
 	ws "github.com/libp2p/go-ws-transport"
+
 	"github.com/multiformats/go-multiaddr"
 )
 

--- a/examples/ipfs-camp-2019/go.mod
+++ b/examples/ipfs-camp-2019/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/libp2p/go-libp2p v0.14.4
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-discovery v0.6.0
+	github.com/libp2p/go-libp2p-discovery v0.6.0 // indirect
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
 	github.com/libp2p/go-libp2p-mplex v0.4.1
 	github.com/libp2p/go-libp2p-pubsub v0.5.3

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/huin/goupnp v1.0.2 // indirect
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.5.0
@@ -22,7 +23,6 @@ require (
 	github.com/libp2p/go-libp2p-blankhost v0.3.0
 	github.com/libp2p/go-libp2p-circuit v0.4.0
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-discovery v0.6.0
 	github.com/libp2p/go-libp2p-mplex v0.4.1
 	github.com/libp2p/go-libp2p-nat v0.1.0
 	github.com/libp2p/go-libp2p-netutil v0.1.0
@@ -42,6 +42,7 @@ require (
 	github.com/libp2p/zeroconf/v2 v2.1.1
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
+	github.com/multiformats/go-multihash v0.0.15
 	github.com/multiformats/go-multistream v0.2.2
 	github.com/multiformats/go-varint v0.0.6
 	github.com/prometheus/common v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,6 @@ github.com/libp2p/go-libp2p-core v0.11.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQR
 github.com/libp2p/go-libp2p-core v0.12.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
 github.com/libp2p/go-libp2p-core v0.13.0 h1:IFG/s8dN6JN2OTrXX9eq2wNU/Zlz2KLdwZUp5FplgXI=
 github.com/libp2p/go-libp2p-core v0.13.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
-github.com/libp2p/go-libp2p-discovery v0.6.0 h1:1XdPmhMJr8Tmj/yUfkJMIi8mgwWrLUsCB3bMxdT+DSo=
-github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVCWPna2dXmPNHc2zR9S8=
 github.com/libp2p/go-libp2p-loggables v0.1.0/go.mod h1:EyumB2Y6PrYjr55Q3/tiJ/o3xoDasoRYM7nOzEpoa90=
 github.com/libp2p/go-libp2p-mplex v0.2.1/go.mod h1:SC99Rxs8Vuzrf/6WhmH41kNn13TiYdAWNYHrwImKLnE=
 github.com/libp2p/go-libp2p-mplex v0.2.3/go.mod h1:CK3p2+9qH9x+7ER/gWWDYJ3QW5ZxWDkm+dVvjfuG3ek=

--- a/p2p/discovery/generic/backoff.go
+++ b/p2p/discovery/generic/backoff.go
@@ -1,0 +1,228 @@
+package discovery
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type BackoffFactory func() BackoffStrategy
+
+// BackoffStrategy describes how backoff will be implemented. BackoffStratgies are stateful.
+type BackoffStrategy interface {
+	// Delay calculates how long the next backoff duration should be, given the prior calls to Delay
+	Delay() time.Duration
+	// Reset clears the internal state of the BackoffStrategy
+	Reset()
+}
+
+// Jitter implementations taken roughly from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+
+// Jitter must return a duration between min and max. Min must be lower than, or equal to, max.
+type Jitter func(duration, min, max time.Duration, rng *rand.Rand) time.Duration
+
+// FullJitter returns a random number uniformly chose from the range [min, boundedDur].
+// boundedDur is the duration bounded between min and max.
+func FullJitter(duration, min, max time.Duration, rng *rand.Rand) time.Duration {
+	if duration <= min {
+		return min
+	}
+
+	normalizedDur := boundedDuration(duration, min, max) - min
+
+	return boundedDuration(time.Duration(rng.Int63n(int64(normalizedDur)))+min, min, max)
+}
+
+// NoJitter returns the duration bounded between min and max
+func NoJitter(duration, min, max time.Duration, rng *rand.Rand) time.Duration {
+	return boundedDuration(duration, min, max)
+}
+
+type randomizedBackoff struct {
+	min time.Duration
+	max time.Duration
+	rng *rand.Rand
+}
+
+func (b *randomizedBackoff) BoundedDelay(duration time.Duration) time.Duration {
+	return boundedDuration(duration, b.min, b.max)
+}
+
+func boundedDuration(d, min, max time.Duration) time.Duration {
+	if d < min {
+		return min
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+type attemptBackoff struct {
+	attempt int
+	jitter  Jitter
+	randomizedBackoff
+}
+
+func (b *attemptBackoff) Reset() {
+	b.attempt = 0
+}
+
+// NewFixedBackoff creates a BackoffFactory with a constant backoff duration
+func NewFixedBackoff(delay time.Duration) BackoffFactory {
+	return func() BackoffStrategy {
+		return &fixedBackoff{delay: delay}
+	}
+}
+
+type fixedBackoff struct {
+	delay time.Duration
+}
+
+func (b *fixedBackoff) Delay() time.Duration {
+	return b.delay
+}
+
+func (b *fixedBackoff) Reset() {}
+
+// NewPolynomialBackoff creates a BackoffFactory with backoff of the form c0*x^0, c1*x^1, ...cn*x^n where x is the attempt number
+// jitter is the function for adding randomness around the backoff
+// timeUnits are the units of time the polynomial is evaluated in
+// polyCoefs is the array of polynomial coefficients from [c0, c1, ... cn]
+func NewPolynomialBackoff(min, max time.Duration, jitter Jitter,
+	timeUnits time.Duration, polyCoefs []float64, rngSrc rand.Source) BackoffFactory {
+	rng := rand.New(&lockedSource{src: rngSrc})
+	return func() BackoffStrategy {
+		return &polynomialBackoff{
+			attemptBackoff: attemptBackoff{
+				randomizedBackoff: randomizedBackoff{
+					min: min,
+					max: max,
+					rng: rng,
+				},
+				jitter: jitter,
+			},
+			timeUnits: timeUnits,
+			poly:      polyCoefs,
+		}
+	}
+}
+
+type polynomialBackoff struct {
+	attemptBackoff
+	timeUnits time.Duration
+	poly      []float64
+}
+
+func (b *polynomialBackoff) Delay() time.Duration {
+	var polySum float64
+	switch len(b.poly) {
+	case 0:
+		return 0
+	case 1:
+		polySum = b.poly[0]
+	default:
+		polySum = b.poly[0]
+		exp := 1
+		attempt := b.attempt
+		b.attempt++
+
+		for _, c := range b.poly[1:] {
+			exp *= attempt
+			polySum += float64(exp) * c
+		}
+	}
+	return b.jitter(time.Duration(float64(b.timeUnits)*polySum), b.min, b.max, b.rng)
+}
+
+// NewExponentialBackoff creates a BackoffFactory with backoff of the form base^x + offset where x is the attempt number
+// jitter is the function for adding randomness around the backoff
+// timeUnits are the units of time the base^x is evaluated in
+func NewExponentialBackoff(min, max time.Duration, jitter Jitter,
+	timeUnits time.Duration, base float64, offset time.Duration, rngSrc rand.Source) BackoffFactory {
+	rng := rand.New(&lockedSource{src: rngSrc})
+	return func() BackoffStrategy {
+		return &exponentialBackoff{
+			attemptBackoff: attemptBackoff{
+				randomizedBackoff: randomizedBackoff{
+					min: min,
+					max: max,
+					rng: rng,
+				},
+				jitter: jitter,
+			},
+			timeUnits: timeUnits,
+			base:      base,
+			offset:    offset,
+		}
+	}
+}
+
+type exponentialBackoff struct {
+	attemptBackoff
+	timeUnits time.Duration
+	base      float64
+	offset    time.Duration
+}
+
+func (b *exponentialBackoff) Delay() time.Duration {
+	attempt := b.attempt
+	b.attempt++
+	return b.jitter(
+		time.Duration(math.Pow(b.base, float64(attempt))*float64(b.timeUnits))+b.offset, b.min, b.max, b.rng)
+}
+
+// NewExponentialDecorrelatedJitter creates a BackoffFactory with backoff of the roughly of the form base^x where x is the attempt number.
+// Delays start at the minimum duration and after each attempt delay = rand(min, delay * base), bounded by the max
+// See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ for more information
+func NewExponentialDecorrelatedJitter(min, max time.Duration, base float64, rngSrc rand.Source) BackoffFactory {
+	rng := rand.New(&lockedSource{src: rngSrc})
+	return func() BackoffStrategy {
+		return &exponentialDecorrelatedJitter{
+			randomizedBackoff: randomizedBackoff{
+				min: min,
+				max: max,
+				rng: rng,
+			},
+			base: base,
+		}
+	}
+}
+
+type exponentialDecorrelatedJitter struct {
+	randomizedBackoff
+	base      float64
+	lastDelay time.Duration
+}
+
+func (b *exponentialDecorrelatedJitter) Delay() time.Duration {
+	if b.lastDelay < b.min {
+		b.lastDelay = b.min
+		return b.lastDelay
+	}
+
+	nextMax := int64(float64(b.lastDelay) * b.base)
+	b.lastDelay = boundedDuration(time.Duration(b.rng.Int63n(nextMax-int64(b.min)))+b.min, b.min, b.max)
+	return b.lastDelay
+}
+
+func (b *exponentialDecorrelatedJitter) Reset() { b.lastDelay = 0 }
+
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}

--- a/p2p/discovery/generic/backoff_test.go
+++ b/p2p/discovery/generic/backoff_test.go
@@ -1,0 +1,191 @@
+package discovery
+
+import (
+	"fmt"
+	"golang.org/x/sync/errgroup"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func checkDelay(bkf BackoffStrategy, expected time.Duration, t *testing.T) {
+	t.Helper()
+	if calculated := bkf.Delay(); calculated != expected {
+		t.Fatalf("expected %v, got %v", expected, calculated)
+	}
+}
+
+func TestFixedBackoff(t *testing.T) {
+	startDelay := time.Second
+	delay := startDelay
+
+	bkf := NewFixedBackoff(delay)
+	delay *= 2
+	b1 := bkf()
+	delay *= 2
+	b2 := bkf()
+
+	if b1.Delay() != startDelay || b2.Delay() != startDelay {
+		t.Fatal("incorrect delay time")
+	}
+
+	if b1.Delay() != startDelay {
+		t.Fatal("backoff is stateful")
+	}
+
+	if b1.Reset(); b1.Delay() != startDelay {
+		t.Fatalf("Reset does something")
+	}
+}
+
+func TestPolynomialBackoff(t *testing.T) {
+	bkf := NewPolynomialBackoff(time.Second, time.Second*33, NoJitter, time.Second, []float64{0.5, 2, 3}, rand.NewSource(0))
+	b1 := bkf()
+	b2 := bkf()
+
+	if b1.Delay() != time.Second || b2.Delay() != time.Second {
+		t.Fatal("incorrect delay time")
+	}
+
+	checkDelay(b1, time.Millisecond*5500, t)
+	checkDelay(b1, time.Millisecond*16500, t)
+	checkDelay(b1, time.Millisecond*33000, t)
+	checkDelay(b2, time.Millisecond*5500, t)
+
+	b1.Reset()
+	b1.Delay()
+	checkDelay(b1, time.Millisecond*5500, t)
+}
+
+func TestExponentialBackoff(t *testing.T) {
+	bkf := NewExponentialBackoff(time.Millisecond*650, time.Second*7, NoJitter, time.Second, 1.5, -time.Millisecond*400, rand.NewSource(0))
+	b1 := bkf()
+	b2 := bkf()
+
+	if b1.Delay() != time.Millisecond*650 || b2.Delay() != time.Millisecond*650 {
+		t.Fatal("incorrect delay time")
+	}
+
+	checkDelay(b1, time.Millisecond*1100, t)
+	checkDelay(b1, time.Millisecond*1850, t)
+	checkDelay(b1, time.Millisecond*2975, t)
+	checkDelay(b1, time.Microsecond*4662500, t)
+	checkDelay(b1, time.Second*7, t)
+	checkDelay(b2, time.Millisecond*1100, t)
+
+	b1.Reset()
+	b1.Delay()
+	checkDelay(b1, time.Millisecond*1100, t)
+}
+
+func minMaxJitterTest(jitter Jitter, t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+	if jitter(time.Nanosecond, time.Hour*10, time.Hour*20, rng) < time.Hour*10 {
+		t.Fatal("Min not working")
+	}
+	if jitter(time.Hour, time.Nanosecond, time.Nanosecond*10, rng) > time.Nanosecond*10 {
+		t.Fatal("Max not working")
+	}
+}
+
+func TestNoJitter(t *testing.T) {
+	minMaxJitterTest(NoJitter, t)
+	for i := 0; i < 10; i++ {
+		expected := time.Second * time.Duration(i)
+		if calculated := NoJitter(expected, time.Duration(0), time.Second*100, nil); calculated != expected {
+			t.Fatalf("expected %v, got %v", expected, calculated)
+		}
+	}
+}
+
+func TestFullJitter(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+	minMaxJitterTest(FullJitter, t)
+	const numBuckets = 51
+	const multiplier = 10
+	const threshold = 20
+
+	histogram := make([]int, numBuckets)
+
+	for i := 0; i < (numBuckets-1)*multiplier; i++ {
+		started := time.Nanosecond * 50
+		calculated := FullJitter(started, 0, 100, rng)
+		histogram[calculated]++
+	}
+
+	for _, count := range histogram {
+		if count > threshold {
+			t.Fatal("jitter is not close to evenly spread")
+		}
+	}
+
+	if histogram[numBuckets-1] > 0 {
+		t.Fatal("jitter increased overall time")
+	}
+}
+
+func TestManyBackoffFactory(t *testing.T) {
+	rngSource := rand.NewSource(0)
+	concurrent := 10
+
+	t.Run("Exponential", func(t *testing.T) {
+		testManyBackoffFactoryHelper(concurrent,
+			NewExponentialBackoff(time.Millisecond*650, time.Second*7, FullJitter, time.Second, 1.5, -time.Millisecond*400, rngSource),
+		)
+	})
+	t.Run("Polynomial", func(t *testing.T) {
+		testManyBackoffFactoryHelper(concurrent,
+			NewPolynomialBackoff(time.Second, time.Second*33, NoJitter, time.Second, []float64{0.5, 2, 3}, rngSource),
+		)
+	})
+	t.Run("Fixed", func(t *testing.T) {
+		testManyBackoffFactoryHelper(concurrent,
+			NewFixedBackoff(time.Second),
+		)
+	})
+}
+
+func testManyBackoffFactoryHelper(concurrent int, bkf BackoffFactory) {
+	backoffCh := make(chan BackoffStrategy, concurrent)
+
+	errGrp := errgroup.Group{}
+	for i := 0; i < concurrent; i++ {
+		errGrp.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic %v", r)
+				}
+			}()
+			backoffCh <- bkf()
+			return
+		})
+	}
+	if err := errGrp.Wait(); err != nil {
+		panic(err)
+	}
+	close(backoffCh)
+
+	errGrp = errgroup.Group{}
+	for b := range backoffCh {
+		backoff := b
+		errGrp.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic %v", r)
+				}
+			}()
+
+			for i := 0; i < 5; i++ {
+				for j := 0; j < 10; j++ {
+					backoff.Delay()
+				}
+				backoff.Reset()
+			}
+			return
+		})
+	}
+
+	if err := errGrp.Wait(); err != nil {
+		panic(err)
+	}
+}

--- a/p2p/discovery/generic/backoffcache.go
+++ b/p2p/discovery/generic/backoffcache.go
@@ -1,0 +1,316 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// BackoffDiscovery is an implementation of discovery that caches peer data and attenuates repeated queries
+type BackoffDiscovery struct {
+	disc         discovery.Discovery
+	stratFactory BackoffFactory
+	peerCache    map[string]*backoffCache
+	peerCacheMux sync.RWMutex
+
+	parallelBufSz int
+	returnedBufSz int
+}
+
+type BackoffDiscoveryOption func(*BackoffDiscovery) error
+
+func NewBackoffDiscovery(disc discovery.Discovery, stratFactory BackoffFactory, opts ...BackoffDiscoveryOption) (discovery.Discovery, error) {
+	b := &BackoffDiscovery{
+		disc:         disc,
+		stratFactory: stratFactory,
+		peerCache:    make(map[string]*backoffCache),
+
+		parallelBufSz: 32,
+		returnedBufSz: 32,
+	}
+
+	for _, opt := range opts {
+		if err := opt(b); err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
+
+// WithBackoffDiscoverySimultaneousQueryBufferSize sets the buffer size for the channels between the main FindPeers query
+// for a given namespace and all simultaneous FindPeers queries for the namespace
+func WithBackoffDiscoverySimultaneousQueryBufferSize(size int) BackoffDiscoveryOption {
+	return func(b *BackoffDiscovery) error {
+		if size < 0 {
+			return fmt.Errorf("cannot set size to be smaller than 0")
+		}
+		b.parallelBufSz = size
+		return nil
+	}
+}
+
+// WithBackoffDiscoveryReturnedChannelSize sets the size of the buffer to be used during a FindPeer query.
+// Note: This does not apply if the query occurs during the backoff time
+func WithBackoffDiscoveryReturnedChannelSize(size int) BackoffDiscoveryOption {
+	return func(b *BackoffDiscovery) error {
+		if size < 0 {
+			return fmt.Errorf("cannot set size to be smaller than 0")
+		}
+		b.returnedBufSz = size
+		return nil
+	}
+}
+
+type backoffCache struct {
+	// strat is assigned on creation and not written to
+	strat BackoffStrategy
+
+	mux          sync.Mutex // guards writes to all following fields
+	nextDiscover time.Time
+	prevPeers    map[peer.ID]peer.AddrInfo
+	peers        map[peer.ID]peer.AddrInfo
+	sendingChs   map[chan peer.AddrInfo]int
+	ongoing      bool
+}
+
+func (d *BackoffDiscovery) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	return d.disc.Advertise(ctx, ns, opts...)
+}
+
+func (d *BackoffDiscovery) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	// Get options
+	var options discovery.Options
+	err := options.Apply(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get cached peers
+	d.peerCacheMux.RLock()
+	c, ok := d.peerCache[ns]
+	d.peerCacheMux.RUnlock()
+
+	/*
+		Overall plan:
+		If it's time to look for peers, look for peers, then return them
+		If it's not time then return cache
+		If it's time to look for peers, but we have already started looking. Get up to speed with ongoing request
+	*/
+
+	// Setup cache if we don't have one yet
+	if !ok {
+		pc := &backoffCache{
+			nextDiscover: time.Time{},
+			prevPeers:    make(map[peer.ID]peer.AddrInfo),
+			peers:        make(map[peer.ID]peer.AddrInfo),
+			sendingChs:   make(map[chan peer.AddrInfo]int),
+			strat:        d.stratFactory(),
+		}
+
+		d.peerCacheMux.Lock()
+		c, ok = d.peerCache[ns]
+
+		if !ok {
+			d.peerCache[ns] = pc
+			c = pc
+		}
+
+		d.peerCacheMux.Unlock()
+	}
+
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	timeExpired := time.Now().After(c.nextDiscover)
+
+	// If it's not yet time to search again and no searches are in progress then return cached peers
+	if !(timeExpired || c.ongoing) {
+		chLen := options.Limit
+
+		if chLen == 0 {
+			chLen = len(c.prevPeers)
+		} else if chLen > len(c.prevPeers) {
+			chLen = len(c.prevPeers)
+		}
+		pch := make(chan peer.AddrInfo, chLen)
+		for _, ai := range c.prevPeers {
+			select {
+			case pch <- ai:
+			default:
+				// skip if we have asked for a lower limit than the number of peers known
+			}
+		}
+		close(pch)
+		return pch, nil
+	}
+
+	// If a request is not already in progress setup a dispatcher channel for dispatching incoming peers
+	if !c.ongoing {
+		pch, err := d.disc.FindPeers(ctx, ns, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		c.ongoing = true
+		go findPeerDispatcher(ctx, c, pch)
+	}
+
+	// Setup receiver channel for receiving peers from ongoing requests
+	evtCh := make(chan peer.AddrInfo, d.parallelBufSz)
+	pch := make(chan peer.AddrInfo, d.returnedBufSz)
+	rcvPeers := make([]peer.AddrInfo, 0, 32)
+	for _, ai := range c.peers {
+		rcvPeers = append(rcvPeers, ai)
+	}
+	c.sendingChs[evtCh] = options.Limit
+
+	go findPeerReceiver(ctx, pch, evtCh, rcvPeers)
+
+	return pch, nil
+}
+
+func findPeerDispatcher(ctx context.Context, c *backoffCache, pch <-chan peer.AddrInfo) {
+	defer func() {
+		c.mux.Lock()
+
+		for ch := range c.sendingChs {
+			close(ch)
+		}
+
+		// If the peer addresses have changed reset the backoff
+		if checkUpdates(c.prevPeers, c.peers) {
+			c.strat.Reset()
+			c.prevPeers = c.peers
+		}
+		c.nextDiscover = time.Now().Add(c.strat.Delay())
+
+		c.ongoing = false
+		c.peers = make(map[peer.ID]peer.AddrInfo)
+		c.sendingChs = make(map[chan peer.AddrInfo]int)
+		c.mux.Unlock()
+	}()
+
+	for {
+		select {
+		case ai, ok := <-pch:
+			if !ok {
+				return
+			}
+			c.mux.Lock()
+
+			// If we receive the same peer multiple times return the address union
+			var sendAi peer.AddrInfo
+			if prevAi, ok := c.peers[ai.ID]; ok {
+				if combinedAi := mergeAddrInfos(prevAi, ai); combinedAi != nil {
+					sendAi = *combinedAi
+				} else {
+					c.mux.Unlock()
+					continue
+				}
+			} else {
+				sendAi = ai
+			}
+
+			c.peers[ai.ID] = sendAi
+
+			for ch, rem := range c.sendingChs {
+				ch <- sendAi
+				if rem == 1 {
+					close(ch)
+					delete(c.sendingChs, ch)
+					break
+				} else if rem > 0 {
+					rem--
+				}
+			}
+
+			c.mux.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func findPeerReceiver(ctx context.Context, pch, evtCh chan peer.AddrInfo, rcvPeers []peer.AddrInfo) {
+	defer close(pch)
+
+	for {
+		select {
+		case ai, ok := <-evtCh:
+			if ok {
+				rcvPeers = append(rcvPeers, ai)
+
+				sentAll := true
+			sendPeers:
+				for i, p := range rcvPeers {
+					select {
+					case pch <- p:
+					default:
+						rcvPeers = rcvPeers[i:]
+						sentAll = false
+						break sendPeers
+					}
+				}
+				if sentAll {
+					rcvPeers = []peer.AddrInfo{}
+				}
+			} else {
+				for _, p := range rcvPeers {
+					select {
+					case pch <- p:
+					case <-ctx.Done():
+						return
+					}
+				}
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func mergeAddrInfos(prevAi, newAi peer.AddrInfo) *peer.AddrInfo {
+	seen := make(map[string]struct{}, len(prevAi.Addrs))
+	combinedAddrs := make([]ma.Multiaddr, 0, len(prevAi.Addrs))
+	addAddrs := func(addrs []ma.Multiaddr) {
+		for _, addr := range addrs {
+			if _, ok := seen[addr.String()]; ok {
+				continue
+			}
+			seen[addr.String()] = struct{}{}
+			combinedAddrs = append(combinedAddrs, addr)
+		}
+	}
+	addAddrs(prevAi.Addrs)
+	addAddrs(newAi.Addrs)
+
+	if len(combinedAddrs) > len(prevAi.Addrs) {
+		combinedAi := &peer.AddrInfo{ID: prevAi.ID, Addrs: combinedAddrs}
+		return combinedAi
+	}
+	return nil
+}
+
+func checkUpdates(orig, update map[peer.ID]peer.AddrInfo) bool {
+	if len(orig) != len(update) {
+		return true
+	}
+	for p, ai := range update {
+		if prevAi, ok := orig[p]; ok {
+			if combinedAi := mergeAddrInfos(prevAi, ai); combinedAi != nil {
+				return true
+			}
+		} else {
+			return true
+		}
+	}
+	return false
+}

--- a/p2p/discovery/generic/backoffcache_test.go
+++ b/p2p/discovery/generic/backoffcache_test.go
@@ -1,0 +1,275 @@
+package discovery
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	bhost "github.com/libp2p/go-libp2p-blankhost"
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/peer"
+	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
+)
+
+type delayedDiscovery struct {
+	disc  discovery.Discovery
+	delay time.Duration
+}
+
+func (d *delayedDiscovery) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	return d.disc.Advertise(ctx, ns, opts...)
+}
+
+func (d *delayedDiscovery) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	dch, err := d.disc.FindPeers(ctx, ns, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan peer.AddrInfo, 32)
+	go func() {
+		defer close(ch)
+		for ai := range dch {
+			ch <- ai
+			time.Sleep(d.delay)
+		}
+	}()
+
+	return ch, nil
+}
+
+func assertNumPeers(t *testing.T, ctx context.Context, d discovery.Discovery, ns string, count int) {
+	t.Helper()
+	assertNumPeersWithLimit(t, ctx, d, ns, 10, count)
+}
+
+func assertNumPeersWithLimit(t *testing.T, ctx context.Context, d discovery.Discovery, ns string, limit int, count int) {
+	t.Helper()
+	peerCh, err := d.FindPeers(ctx, ns, discovery.Limit(limit))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peerset := make(map[peer.ID]struct{})
+	for p := range peerCh {
+		peerset[p.ID] = struct{}{}
+	}
+
+	if len(peerset) != count {
+		t.Fatalf("Was supposed to find %d, found %d instead", count, len(peerset))
+	}
+}
+
+func TestBackoffDiscoverySingleBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	discServer := newDiscoveryServer()
+
+	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	defer h1.Close()
+	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	defer h2.Close()
+	d1 := &mockDiscoveryClient{h1, discServer}
+	d2 := &mockDiscoveryClient{h2, discServer}
+
+	bkf := NewExponentialBackoff(time.Millisecond*100, time.Second*10, NoJitter,
+		time.Millisecond*100, 2.5, 0, rand.NewSource(0))
+	dCache, err := NewBackoffDiscovery(d1, bkf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const ns = "test"
+
+	// try adding a peer then find it
+	d1.Advertise(ctx, ns, discovery.TTL(time.Hour))
+	assertNumPeers(t, ctx, dCache, ns, 1)
+
+	// add a new peer and make sure it is still hidden by the caching layer
+	d2.Advertise(ctx, ns, discovery.TTL(time.Hour))
+	assertNumPeers(t, ctx, dCache, ns, 1)
+
+	// wait for cache to expire and check for the new peer
+	time.Sleep(time.Millisecond * 110)
+	assertNumPeers(t, ctx, dCache, ns, 2)
+}
+
+func TestBackoffDiscoveryMultipleBackoff(t *testing.T) {
+	scaleDuration := func(t time.Duration) time.Duration {
+		if os.Getenv("CI") != "" {
+			return 3 * t
+		}
+		return t
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	discServer := newDiscoveryServer()
+
+	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	defer h1.Close()
+	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	defer h2.Close()
+	d1 := &mockDiscoveryClient{h1, discServer}
+	d2 := &mockDiscoveryClient{h2, discServer}
+
+	// Startup delay is 0ms. First backoff after finding data is 100ms, second backoff is 250ms.
+	bkf := NewExponentialBackoff(
+		scaleDuration(time.Millisecond*100),
+		scaleDuration(time.Second*10),
+		NoJitter,
+		scaleDuration(time.Millisecond*100),
+		2.5,
+		0,
+		rand.NewSource(0),
+	)
+	dCache, err := NewBackoffDiscovery(d1, bkf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const ns = "test"
+
+	// try adding a peer then find it
+	d1.Advertise(ctx, ns, discovery.TTL(scaleDuration(time.Hour)))
+	assertNumPeers(t, ctx, dCache, ns, 1)
+
+	// wait a little to make sure the extra request doesn't modify the backoff
+	time.Sleep(scaleDuration(time.Millisecond * 50)) // 50 < 100
+	assertNumPeers(t, ctx, dCache, ns, 1)
+
+	// wait for backoff to expire and check if we increase it
+	time.Sleep(scaleDuration(time.Millisecond * 60)) // 50+60 > 100
+	assertNumPeers(t, ctx, dCache, ns, 1)
+
+	d2.Advertise(ctx, ns, discovery.TTL(scaleDuration(time.Millisecond*400)))
+
+	time.Sleep(scaleDuration(time.Millisecond * 150)) // 150 < 250
+	assertNumPeers(t, ctx, dCache, ns, 1)
+
+	time.Sleep(scaleDuration(time.Millisecond * 150)) // 150 + 150 > 250
+	assertNumPeers(t, ctx, dCache, ns, 2)
+
+	// check that the backoff has been reset
+	// also checks that we can decrease our peer count (i.e. not just growing a set)
+	time.Sleep(scaleDuration(time.Millisecond * 110)) // 110 > 100, also 150+150+110>400
+	assertNumPeers(t, ctx, dCache, ns, 1)
+}
+
+func TestBackoffDiscoverySimultaneousQuery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	discServer := newDiscoveryServer()
+
+	// Testing with n larger than most internal buffer sizes (32)
+	n := 40
+	advertisers := make([]discovery.Discovery, n)
+
+	for i := 0; i < n; i++ {
+		h := bhost.NewBlankHost(swarmt.GenSwarm(t))
+		defer h.Close()
+		advertisers[i] = &mockDiscoveryClient{h, discServer}
+	}
+
+	d1 := &delayedDiscovery{advertisers[0], time.Millisecond * 10}
+
+	bkf := NewFixedBackoff(time.Millisecond * 200)
+	dCache, err := NewBackoffDiscovery(d1, bkf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const ns = "test"
+
+	for _, a := range advertisers {
+		if _, err := a.Advertise(ctx, ns, discovery.TTL(time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ch1, err := dCache.FindPeers(ctx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-ch1
+	ch2, err := dCache.FindPeers(ctx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	szCh2 := 0
+	for ai := range ch2 {
+		_ = ai
+		szCh2++
+	}
+
+	szCh1 := 1
+	for range ch1 {
+		szCh1++
+	}
+
+	if szCh1 != n && szCh2 != n {
+		t.Fatalf("Channels returned %d, %d elements instead of %d", szCh1, szCh2, n)
+	}
+}
+
+func TestBackoffDiscoveryCacheCapacity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	discServer := newDiscoveryServer()
+
+	// Testing with n larger than most internal buffer sizes (32)
+	n := 40
+	advertisers := make([]discovery.Discovery, n)
+
+	for i := 0; i < n; i++ {
+		h := bhost.NewBlankHost(swarmt.GenSwarm(t))
+		defer h.Close()
+		advertisers[i] = &mockDiscoveryClient{h, discServer}
+	}
+
+	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	d1 := &mockDiscoveryClient{h1, discServer}
+
+	const discoveryInterval = time.Millisecond * 100
+
+	bkf := NewFixedBackoff(discoveryInterval)
+	dCache, err := NewBackoffDiscovery(d1, bkf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const ns = "test"
+
+	// add speers
+	for i := 0; i < n; i++ {
+		advertisers[i].Advertise(ctx, ns, discovery.TTL(time.Hour))
+	}
+
+	// Request all peers, all will be present
+	assertNumPeersWithLimit(t, ctx, dCache, ns, n, n)
+
+	// Request peers with a lower limit
+	assertNumPeersWithLimit(t, ctx, dCache, ns, n-1, n-1)
+
+	// Wait a little time but don't allow cache to expire
+	time.Sleep(discoveryInterval / 10)
+
+	// Request peers with a lower limit this time using cache
+	// Here we are testing that the cache logic does not block when there are more peers known than the limit requested
+	// See https://github.com/libp2p/go-libp2p-discovery/issues/67
+	assertNumPeersWithLimit(t, ctx, dCache, ns, n-1, n-1)
+
+	// Wait for next discovery so next request will bypass cache
+	time.Sleep(time.Millisecond * 100)
+
+	// Ask for all peers again
+	assertNumPeersWithLimit(t, ctx, dCache, ns, n, n)
+}

--- a/p2p/discovery/generic/backoffconnector.go
+++ b/p2p/discovery/generic/backoffconnector.go
@@ -1,0 +1,95 @@
+package discovery
+
+import (
+	"context"
+	lru "github.com/hashicorp/golang-lru"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// BackoffConnector is a utility to connect to peers, but only if we have not recently tried connecting to them already
+type BackoffConnector struct {
+	cache      *lru.TwoQueueCache
+	host       host.Host
+	connTryDur time.Duration
+	backoff    BackoffFactory
+	mux        sync.Mutex
+}
+
+// NewBackoffConnector creates a utility to connect to peers, but only if we have not recently tried connecting to them already
+// cacheSize is the size of a TwoQueueCache
+// connectionTryDuration is how long we attempt to connect to a peer before giving up
+// backoff describes the strategy used to decide how long to backoff after previously attempting to connect to a peer
+func NewBackoffConnector(h host.Host, cacheSize int, connectionTryDuration time.Duration, backoff BackoffFactory) (*BackoffConnector, error) {
+	cache, err := lru.New2Q(cacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BackoffConnector{
+		cache:      cache,
+		host:       h,
+		connTryDur: connectionTryDuration,
+		backoff:    backoff,
+	}, nil
+}
+
+type connCacheData struct {
+	nextTry time.Time
+	strat   BackoffStrategy
+}
+
+// Connect attempts to connect to the peers passed in by peerCh. Will not connect to peers if they are within the backoff period.
+// As Connect will attempt to dial peers as soon as it learns about them, the caller should try to keep the number,
+// and rate, of inbound peers manageable.
+func (c *BackoffConnector) Connect(ctx context.Context, peerCh <-chan peer.AddrInfo) {
+	for {
+		select {
+		case pi, ok := <-peerCh:
+			if !ok {
+				return
+			}
+
+			if pi.ID == c.host.ID() || pi.ID == "" {
+				continue
+			}
+
+			c.mux.Lock()
+			val, ok := c.cache.Get(pi.ID)
+			var cachedPeer *connCacheData
+			if ok {
+				tv := val.(*connCacheData)
+				now := time.Now()
+				if now.Before(tv.nextTry) {
+					c.mux.Unlock()
+					continue
+				}
+
+				tv.nextTry = now.Add(tv.strat.Delay())
+			} else {
+				cachedPeer = &connCacheData{strat: c.backoff()}
+				cachedPeer.nextTry = time.Now().Add(cachedPeer.strat.Delay())
+				c.cache.Add(pi.ID, cachedPeer)
+			}
+			c.mux.Unlock()
+
+			go func(pi peer.AddrInfo) {
+				ctx, cancel := context.WithTimeout(ctx, c.connTryDur)
+				defer cancel()
+
+				err := c.host.Connect(ctx, pi)
+				if err != nil {
+					log.Debugf("Error connecting to pubsub peer %s: %s", pi.ID, err.Error())
+					return
+				}
+			}(pi)
+
+		case <-ctx.Done():
+			log.Infof("discovery: backoff connector context error %v", ctx.Err())
+			return
+		}
+	}
+}

--- a/p2p/discovery/generic/backoffconnector_test.go
+++ b/p2p/discovery/generic/backoffconnector_test.go
@@ -1,0 +1,109 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	bhost "github.com/libp2p/go-libp2p-blankhost"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
+)
+
+type maxDialHost struct {
+	host.Host
+
+	mux            sync.Mutex
+	timesDialed    map[peer.ID]int
+	maxTimesToDial map[peer.ID]int
+}
+
+func (h *maxDialHost) Connect(ctx context.Context, ai peer.AddrInfo) error {
+	pid := ai.ID
+
+	h.mux.Lock()
+	defer h.mux.Unlock()
+	numDials := h.timesDialed[pid]
+	numDials += 1
+	h.timesDialed[pid] = numDials
+
+	if maxDials, ok := h.maxTimesToDial[pid]; ok && numDials > maxDials {
+		return fmt.Errorf("should not be dialing peer %s", pid.String())
+	}
+
+	return h.Host.Connect(ctx, ai)
+}
+
+func getNetHosts(t *testing.T, ctx context.Context, n int) []host.Host {
+	var out []host.Host
+
+	for i := 0; i < n; i++ {
+		netw := swarmt.GenSwarm(t)
+		h := bhost.NewBlankHost(netw)
+		t.Cleanup(func() { h.Close() })
+		out = append(out, h)
+	}
+
+	return out
+}
+
+func loadCh(peers []host.Host) <-chan peer.AddrInfo {
+	ch := make(chan peer.AddrInfo, len(peers))
+	for _, p := range peers {
+		ch <- p.Peerstore().PeerInfo(p.ID())
+	}
+	close(ch)
+	return ch
+}
+
+func TestBackoffConnector(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := getNetHosts(t, ctx, 5)
+	primary := &maxDialHost{
+		Host:        hosts[0],
+		mux:         sync.Mutex{},
+		timesDialed: make(map[peer.ID]int),
+		maxTimesToDial: map[peer.ID]int{
+			hosts[1].ID(): 1,
+			hosts[2].ID(): 2,
+		},
+	}
+
+	bc, err := NewBackoffConnector(primary, 10, time.Minute, NewFixedBackoff(time.Millisecond*1500))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bc.Connect(ctx, loadCh(hosts))
+
+	time.Sleep(time.Millisecond * 100)
+	if expected, actual := len(hosts)-1, len(primary.Network().Conns()); actual != expected {
+		t.Fatalf("wrong number of connections. expected %d, actual %d", expected, actual)
+	}
+
+	for _, c := range primary.Network().Conns() {
+		c.Close()
+	}
+
+	for len(primary.Network().Conns()) > 0 {
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	bc.Connect(ctx, loadCh(hosts))
+	if numConns := len(primary.Network().Conns()); numConns != 0 {
+		t.Fatal("shouldn't be connected to any peers")
+	}
+
+	time.Sleep(time.Millisecond * 1600)
+	bc.Connect(ctx, loadCh(hosts))
+
+	time.Sleep(time.Millisecond * 100)
+	if expected, actual := len(hosts)-2, len(primary.Network().Conns()); actual != expected {
+		t.Fatalf("wrong number of connections. expected %d, actual %d", expected, actual)
+	}
+}

--- a/p2p/discovery/generic/mocks_test.go
+++ b/p2p/discovery/generic/mocks_test.go
@@ -1,0 +1,101 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type mockDiscoveryServer struct {
+	mx sync.Mutex
+	db map[string]map[peer.ID]*discoveryRegistration
+}
+
+type discoveryRegistration struct {
+	info       peer.AddrInfo
+	expiration time.Time
+}
+
+func newDiscoveryServer() *mockDiscoveryServer {
+	return &mockDiscoveryServer{
+		db: make(map[string]map[peer.ID]*discoveryRegistration),
+	}
+}
+
+func (s *mockDiscoveryServer) Advertise(ns string, info peer.AddrInfo, ttl time.Duration) (time.Duration, error) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	peers, ok := s.db[ns]
+	if !ok {
+		peers = make(map[peer.ID]*discoveryRegistration)
+		s.db[ns] = peers
+	}
+	peers[info.ID] = &discoveryRegistration{info, time.Now().Add(ttl)}
+	return ttl, nil
+}
+
+func (s *mockDiscoveryServer) FindPeers(ns string, limit int) (<-chan peer.AddrInfo, error) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	peers, ok := s.db[ns]
+	if !ok || len(peers) == 0 {
+		emptyCh := make(chan peer.AddrInfo)
+		close(emptyCh)
+		return emptyCh, nil
+	}
+
+	count := len(peers)
+	if limit != 0 && count > limit {
+		count = limit
+	}
+
+	iterTime := time.Now()
+	ch := make(chan peer.AddrInfo, count)
+	numSent := 0
+	for p, reg := range peers {
+		if numSent == count {
+			break
+		}
+		if iterTime.After(reg.expiration) {
+			delete(peers, p)
+			continue
+		}
+
+		numSent++
+		ch <- reg.info
+	}
+	close(ch)
+
+	return ch, nil
+}
+
+type mockDiscoveryClient struct {
+	host   host.Host
+	server *mockDiscoveryServer
+}
+
+func (d *mockDiscoveryClient) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	var options discovery.Options
+	err := options.Apply(opts...)
+	if err != nil {
+		return 0, err
+	}
+
+	return d.server.Advertise(ns, *host.InfoFromHost(d.host), options.Ttl)
+}
+
+func (d *mockDiscoveryClient) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	var options discovery.Options
+	err := options.Apply(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.server.FindPeers(ns, options.Limit)
+}

--- a/p2p/discovery/generic/routing.go
+++ b/p2p/discovery/generic/routing.go
@@ -1,0 +1,113 @@
+package discovery
+
+import (
+	"context"
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"time"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/routing"
+
+	mh "github.com/multiformats/go-multihash"
+)
+
+// RoutingDiscovery is an implementation of discovery using ContentRouting.
+// Namespaces are translated to Cids using the SHA256 hash.
+type RoutingDiscovery struct {
+	routing.ContentRouting
+}
+
+func NewRoutingDiscovery(router routing.ContentRouting) *RoutingDiscovery {
+	return &RoutingDiscovery{router}
+}
+
+func (d *RoutingDiscovery) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	var options discovery.Options
+	err := options.Apply(opts...)
+	if err != nil {
+		return 0, err
+	}
+
+	ttl := options.Ttl
+	if ttl == 0 || ttl > 3*time.Hour {
+		// the DHT provider record validity is 24hrs, but it is recommnded to republish at least every 6hrs
+		// we go one step further and republish every 3hrs
+		ttl = 3 * time.Hour
+	}
+
+	cid, err := nsToCid(ns)
+	if err != nil {
+		return 0, err
+	}
+
+	// this context requires a timeout; it determines how long the DHT looks for
+	// closest peers to the key/CID before it goes on to provide the record to them.
+	// Not setting a timeout here will make the DHT wander forever.
+	pctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	err = d.Provide(pctx, cid, true)
+	if err != nil {
+		return 0, err
+	}
+
+	return ttl, nil
+}
+
+func (d *RoutingDiscovery) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	var options discovery.Options
+	err := options.Apply(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := options.Limit
+	if limit == 0 {
+		limit = 100 // that's just arbitrary, but FindProvidersAsync needs a count
+	}
+
+	cid, err := nsToCid(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.FindProvidersAsync(ctx, cid, limit), nil
+}
+
+func nsToCid(ns string) (cid.Cid, error) {
+	h, err := mh.Sum([]byte(ns), mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return cid.NewCidV1(cid.Raw, h), nil
+}
+
+func NewDiscoveryRouting(disc discovery.Discovery, opts ...discovery.Option) *DiscoveryRouting {
+	return &DiscoveryRouting{disc, opts}
+}
+
+type DiscoveryRouting struct {
+	discovery.Discovery
+	opts []discovery.Option
+}
+
+func (r *DiscoveryRouting) Provide(ctx context.Context, c cid.Cid, bcast bool) error {
+	if !bcast {
+		return nil
+	}
+
+	_, err := r.Advertise(ctx, cidToNs(c), r.opts...)
+	return err
+}
+
+func (r *DiscoveryRouting) FindProvidersAsync(ctx context.Context, c cid.Cid, limit int) <-chan peer.AddrInfo {
+	ch, _ := r.FindPeers(ctx, cidToNs(c), append([]discovery.Option{discovery.Limit(limit)}, r.opts...)...)
+	return ch
+}
+
+func cidToNs(c cid.Cid) string {
+	return "/provider/" + c.String()
+}

--- a/p2p/discovery/generic/routing_test.go
+++ b/p2p/discovery/generic/routing_test.go
@@ -1,0 +1,146 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	bhost "github.com/libp2p/go-libp2p-blankhost"
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
+)
+
+type mockRoutingTable struct {
+	mx        sync.Mutex
+	providers map[string]map[peer.ID]peer.AddrInfo
+}
+
+type mockRouting struct {
+	h   host.Host
+	tab *mockRoutingTable
+}
+
+func NewMockRoutingTable() *mockRoutingTable {
+	return &mockRoutingTable{providers: make(map[string]map[peer.ID]peer.AddrInfo)}
+}
+
+func NewMockRouting(h host.Host, tab *mockRoutingTable) *mockRouting {
+	return &mockRouting{h: h, tab: tab}
+}
+
+func (m *mockRouting) Provide(ctx context.Context, cid cid.Cid, bcast bool) error {
+	m.tab.mx.Lock()
+	defer m.tab.mx.Unlock()
+
+	pmap, ok := m.tab.providers[cid.String()]
+	if !ok {
+		pmap = make(map[peer.ID]peer.AddrInfo)
+		m.tab.providers[cid.String()] = pmap
+	}
+
+	pmap[m.h.ID()] = peer.AddrInfo{ID: m.h.ID(), Addrs: m.h.Addrs()}
+
+	return nil
+}
+
+func (m *mockRouting) FindProvidersAsync(ctx context.Context, cid cid.Cid, limit int) <-chan peer.AddrInfo {
+	ch := make(chan peer.AddrInfo)
+	go func() {
+		defer close(ch)
+		m.tab.mx.Lock()
+		defer m.tab.mx.Unlock()
+
+		pmap, ok := m.tab.providers[cid.String()]
+		if !ok {
+			return
+		}
+
+		for _, pi := range pmap {
+			select {
+			case ch <- pi:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch
+}
+
+func TestRoutingDiscovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+
+	mtab := NewMockRoutingTable()
+	mr1 := NewMockRouting(h1, mtab)
+	mr2 := NewMockRouting(h2, mtab)
+
+	d1 := NewRoutingDiscovery(mr1)
+	d2 := NewRoutingDiscovery(mr2)
+
+	_, err := d1.Advertise(ctx, "/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pis, err := FindPeers(ctx, d2, "/test", discovery.Limit(20))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pis) != 1 {
+		t.Fatalf("Expected 1 peer, got %d", len(pis))
+	}
+
+	pi := pis[0]
+	if pi.ID != h1.ID() {
+		t.Fatalf("Unexpected peer: %s", pi.ID)
+	}
+}
+
+func TestDiscoveryRouting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))
+
+	dserver := newDiscoveryServer()
+	d1 := &mockDiscoveryClient{h1, dserver}
+	d2 := &mockDiscoveryClient{h2, dserver}
+
+	r1 := NewDiscoveryRouting(d1, discovery.TTL(time.Hour))
+	r2 := NewDiscoveryRouting(d2, discovery.TTL(time.Hour))
+
+	c, err := nsToCid("/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r1.Provide(ctx, c, true); err != nil {
+		t.Fatal(err)
+	}
+
+	pch := r2.FindProvidersAsync(ctx, c, 20)
+
+	var allAIs []peer.AddrInfo
+	for ai := range pch {
+		allAIs = append(allAIs, ai)
+	}
+
+	if len(allAIs) != 1 {
+		t.Fatalf("Expected 1 peer, got %d", len(allAIs))
+	}
+
+	ai := allAIs[0]
+	if ai.ID != h1.ID() {
+		t.Fatalf("Unexpected peer: %s", ai.ID)
+	}
+}

--- a/p2p/discovery/generic/util.go
+++ b/p2p/discovery/generic/util.go
@@ -1,0 +1,58 @@
+package discovery
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("discovery")
+
+// FindPeers is a utility function that synchronously collects peers from a Discoverer.
+func FindPeers(ctx context.Context, d discovery.Discoverer, ns string, opts ...discovery.Option) ([]peer.AddrInfo, error) {
+	var res []peer.AddrInfo
+
+	ch, err := d.FindPeers(ctx, ns, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	for pi := range ch {
+		res = append(res, pi)
+	}
+
+	return res, nil
+}
+
+// Advertise is a utility function that persistently advertises a service through an Advertiser.
+func Advertise(ctx context.Context, a discovery.Advertiser, ns string, opts ...discovery.Option) {
+	go func() {
+		for {
+			ttl, err := a.Advertise(ctx, ns, opts...)
+			if err != nil {
+				log.Debugf("Error advertising %s: %s", ns, err.Error())
+				if ctx.Err() != nil {
+					return
+				}
+
+				select {
+				case <-time.After(2 * time.Minute):
+					continue
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			wait := 7 * ttl / 8
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
+	discovery "github.com/libp2p/go-libp2p/p2p/discovery/generic"
 	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
 	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
@@ -18,8 +19,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
-
-	discovery "github.com/libp2p/go-libp2p-discovery"
 
 	"github.com/ipfs/go-cid"
 	ma "github.com/multiformats/go-multiaddr"


### PR DESCRIPTION
I'm not really happy with the name `generic` here, but it's the best I can come up with.
We already have a `p2p/discovery` folder (which contains `mdns`). @Stebalien, any ideas for a better name?