### PR TITLE
speed up identify tests

### DIFF
--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -460,7 +460,7 @@ func TestIdentifyDeltaOnProtocolChange(t *testing.T) {
 		_, okfoo := have["foo"]
 		_, okbar := have["bar"]
 		return okfoo && okbar
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 
 	// remove one of the newly added protocols from h2, and wait for identify to send the delta.
 	h2.RemoveStreamHandler(protocol.ID("bar"))
@@ -478,7 +478,7 @@ func TestIdentifyDeltaOnProtocolChange(t *testing.T) {
 		_, okfoo := have["foo"]
 		_, okbar := have["bar"]
 		return okfoo && !okbar
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 
 	// make sure that h1 emitted events in the eventbus for h2's protocol updates.
 	done := make(chan struct{})
@@ -643,7 +643,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 	require.NotNil(t, getSignedRecord(t, h2, h1p))
 
 	// change addr on host2 and ensure host 1 gets a pus
@@ -660,7 +660,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 	require.NotNil(t, getSignedRecord(t, h1, h2p))
 
 	// change addr on host2 again
@@ -677,7 +677,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 	require.NotNil(t, getSignedRecord(t, h1, h2p))
 }
 
@@ -773,21 +773,21 @@ func TestSendPushIfDeltaNotSupported(t *testing.T) {
 	require.Eventually(t, func() bool {
 		sup, err := h1.Peerstore().SupportsProtocols(h2.ID(), []string{identify.IDDelta}...)
 		return err == nil && len(sup) == 0
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 
 	// h1 starts listening on a new protocol and h2 finds out about that through a push
 	h1.SetStreamHandler("rand", func(network.Stream) {})
 	require.Eventually(t, func() bool {
 		sup, err := h2.Peerstore().SupportsProtocols(h1.ID(), []string{"rand"}...)
 		return err == nil && len(sup) == 1 && sup[0] == "rand"
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 
 	// h1 stops listening on a protocol and h2 finds out about it via a push
 	h1.RemoveStreamHandler("rand")
 	require.Eventually(t, func() bool {
 		sup, err := h2.Peerstore().SupportsProtocols(h1.ID(), []string{"rand"}...)
 		return err == nil && len(sup) == 0
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLargeIdentifyMessage(t *testing.T) {
@@ -973,7 +973,7 @@ func TestLargePushMessage(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 	require.NotNil(t, getSignedRecord(t, h2, h1p))
 
 	// change addr on host2 and ensure host 1 gets a pus
@@ -990,7 +990,7 @@ func TestLargePushMessage(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 	testHasCertifiedAddrs(t, h1, h2p, h2.Addrs())
 
 	// change addr on host2 again
@@ -1007,7 +1007,7 @@ func TestLargePushMessage(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 500*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 	testHasCertifiedAddrs(t, h2, h1p, h1.Addrs())
 }
 

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -36,95 +36,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func subtestIDService(t *testing.T) {
-	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
-	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
-
-	h1p := h1.ID()
-	h2p := h2.ID()
-
-	ids1, err := identify.NewIDService(h1)
-	require.NoError(t, err)
-	defer ids1.Close()
-
-	ids2, err := identify.NewIDService(h2)
-	require.NoError(t, err)
-	defer ids2.Close()
-
-	sub, err := ids1.Host.EventBus().Subscribe(new(event.EvtPeerIdentificationCompleted), eventbus.BufSize(16))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{}) // nothing
-	testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{}) // nothing
-
-	// the forgetMe addr represents an address for h1 that h2 has learned out of band
-	// (not via identify protocol). During the identify exchange, it will be
-	// forgotten and replaced by the addrs h1 sends.
-	forgetMe, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/1234")
-
-	h2.Peerstore().AddAddr(h1p, forgetMe, peerstore.RecentlyConnectedAddrTTL)
-	h2pi := h2.Peerstore().PeerInfo(h2p)
-	require.NoError(t, h1.Connect(context.Background(), h2pi))
-
-	h1t2c := h1.Network().ConnsToPeer(h2p)
-	require.NotEmpty(t, h1t2c, "should have a conn here")
-
-	ids1.IdentifyConn(h1t2c[0])
-
-	// the idService should be opened automatically, by the network.
-	// what we should see now is that both peers know about each others listen addresses.
-	t.Log("test peer1 has peer2 addrs correctly")
-	testKnowsAddrs(t, h1, h2p, h2.Addrs())                       // has them
-	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p)) // should have signed addrs also
-	testHasProtocolVersions(t, h1, h2p)
-	testHasPublicKey(t, h1, h2p, h2.Peerstore().PubKey(h2p)) // h1 should have h2's public key
-
-	// now, this wait we do have to do. it's the wait for the Listening side
-	// to be done identifying the connection.
-	c := h2.Network().ConnsToPeer(h1.ID())
-	require.NotEmpty(t, c, "should have connection by now at least.")
-	ids2.IdentifyConn(c[0])
-
-	// and the protocol versions.
-	t.Log("test peer2 has peer1 addrs correctly")
-	testKnowsAddrs(t, h2, h1p, h1.Addrs()) // has them
-	testHasCertifiedAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))
-	testHasProtocolVersions(t, h2, h1p)
-	testHasPublicKey(t, h2, h1p, h1.Peerstore().PubKey(h1p)) // h1 should have h2's public key
-
-	// Need both sides to actually notice that the connection has been closed.
-	h1.Network().ClosePeer(h2p)
-	h2.Network().ClosePeer(h1p)
-	if len(h2.Network().ConnsToPeer(h1.ID())) != 0 || len(h1.Network().ConnsToPeer(h2.ID())) != 0 {
-		t.Fatal("should have no connections")
-	}
-
-	t.Log("testing addrs just after disconnect")
-	// addresses don't immediately expire on disconnect, so we should still have them
-	testKnowsAddrs(t, h2, h1p, h1.Addrs())
-	testKnowsAddrs(t, h1, h2p, h2.Addrs())
-	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p))
-	testHasCertifiedAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))
-
-	// the addrs had their TTLs reduced on disconnect, and
-	// will be forgotten soon after
-	t.Log("testing addrs after TTL expiration")
-	time.Sleep(time.Second)
-	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{})
-	testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{})
-	testHasCertifiedAddrs(t, h1, h2p, []ma.Multiaddr{})
-	testHasCertifiedAddrs(t, h2, h1p, []ma.Multiaddr{})
-
-	// test that we received the "identify completed" event.
-	select {
-	case <-sub.Out():
-	case <-time.After(3 * time.Second):
-		t.Fatalf("expected EvtPeerIdentificationCompleted event within 10 seconds; none received")
-	}
-}
-
 func testKnowsAddrs(t *testing.T, h host.Host, p peer.ID, expected []ma.Multiaddr) {
 	t.Helper()
 	assert.ElementsMatchf(t, expected, h.Peerstore().Addrs(p), fmt.Sprintf("%s did not have addr for %s", h.ID(), p))
@@ -243,9 +154,91 @@ func TestIDService(t *testing.T) {
 	peerstore.RecentlyConnectedAddrTTL = 500 * time.Millisecond
 	t.Cleanup(func() { peerstore.RecentlyConnectedAddrTTL = oldTTL })
 
-	N := 3
-	for i := 0; i < N; i++ {
-		subtestIDService(t)
+	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
+	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
+
+	h1p := h1.ID()
+	h2p := h2.ID()
+
+	ids1, err := identify.NewIDService(h1)
+	require.NoError(t, err)
+	defer ids1.Close()
+
+	ids2, err := identify.NewIDService(h2)
+	require.NoError(t, err)
+	defer ids2.Close()
+
+	sub, err := ids1.Host.EventBus().Subscribe(new(event.EvtPeerIdentificationCompleted), eventbus.BufSize(16))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{}) // nothing
+	testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{}) // nothing
+
+	// the forgetMe addr represents an address for h1 that h2 has learned out of band
+	// (not via identify protocol). During the identify exchange, it will be
+	// forgotten and replaced by the addrs h1 sends.
+	forgetMe, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/1234")
+
+	h2.Peerstore().AddAddr(h1p, forgetMe, peerstore.RecentlyConnectedAddrTTL)
+	h2pi := h2.Peerstore().PeerInfo(h2p)
+	require.NoError(t, h1.Connect(context.Background(), h2pi))
+
+	h1t2c := h1.Network().ConnsToPeer(h2p)
+	require.NotEmpty(t, h1t2c, "should have a conn here")
+
+	ids1.IdentifyConn(h1t2c[0])
+
+	// the idService should be opened automatically, by the network.
+	// what we should see now is that both peers know about each others listen addresses.
+	t.Log("test peer1 has peer2 addrs correctly")
+	testKnowsAddrs(t, h1, h2p, h2.Addrs())                       // has them
+	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p)) // should have signed addrs also
+	testHasProtocolVersions(t, h1, h2p)
+	testHasPublicKey(t, h1, h2p, h2.Peerstore().PubKey(h2p)) // h1 should have h2's public key
+
+	// now, this wait we do have to do. it's the wait for the Listening side
+	// to be done identifying the connection.
+	c := h2.Network().ConnsToPeer(h1.ID())
+	require.NotEmpty(t, c, "should have connection by now at least.")
+	ids2.IdentifyConn(c[0])
+
+	// and the protocol versions.
+	t.Log("test peer2 has peer1 addrs correctly")
+	testKnowsAddrs(t, h2, h1p, h1.Addrs()) // has them
+	testHasCertifiedAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))
+	testHasProtocolVersions(t, h2, h1p)
+	testHasPublicKey(t, h2, h1p, h1.Peerstore().PubKey(h1p)) // h1 should have h2's public key
+
+	// Need both sides to actually notice that the connection has been closed.
+	h1.Network().ClosePeer(h2p)
+	h2.Network().ClosePeer(h1p)
+	if len(h2.Network().ConnsToPeer(h1.ID())) != 0 || len(h1.Network().ConnsToPeer(h2.ID())) != 0 {
+		t.Fatal("should have no connections")
+	}
+
+	t.Log("testing addrs just after disconnect")
+	// addresses don't immediately expire on disconnect, so we should still have them
+	testKnowsAddrs(t, h2, h1p, h1.Addrs())
+	testKnowsAddrs(t, h1, h2p, h2.Addrs())
+	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p))
+	testHasCertifiedAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))
+
+	// the addrs had their TTLs reduced on disconnect, and
+	// will be forgotten soon after
+	t.Log("testing addrs after TTL expiration")
+	time.Sleep(time.Second)
+	testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{})
+	testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{})
+	testHasCertifiedAddrs(t, h1, h2p, []ma.Multiaddr{})
+	testHasCertifiedAddrs(t, h2, h1p, []ma.Multiaddr{})
+
+	// test that we received the "identify completed" event.
+	select {
+	case <-sub.Out():
+	case <-time.After(3 * time.Second):
+		t.Fatalf("expected EvtPeerIdentificationCompleted event within 10 seconds; none received")
 	}
 }
 


### PR DESCRIPTION
These changes reduce the execution time of identify tests from 30s to 13s.