### PR TITLE
add semaphore to control push/delta concurrency

### DIFF
--- a/p2p/protocol/identify/peer_loop.go
+++ b/p2p/protocol/identify/peer_loop.go
@@ -179,6 +179,11 @@ func (ph *peerHandler) openStream(ctx context.Context, protos []string) (network
 		return nil, errProtocolNotSupported
 	}
 
+	ph.ids.pushSemaphore <- struct{}{}
+	defer func() {
+		<-ph.ids.pushSemaphore
+	}()
+
 	// negotiate a stream without opening a new connection as we "should" already have a connection.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
This avoids stream storms that can clog the transient scope when we have a largish number of peers.