### PR TITLE
increase the UDP receiver buffer size on CI

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -1,0 +1,7 @@
+runs:
+  using: "composite"
+  steps:
+    - name: increase the UDP receive buffer size # see https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size
+      shell: bash
+      run: sysctl -w net.core.rmem_max=2500000
+      if: ${{ matrix.os == 'ubuntu' }}


### PR DESCRIPTION
This will prevent quic-go from spamming our logs with
```
2022/02/07 05:44:20 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.