### PR TITLE
Resolve addresses when creating a new stream

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -605,6 +605,12 @@ func (h *BasicHost) RemoveStreamHandler(pid protocol.ID) {
 // to create one. If ProtocolID is "", writes no header.
 // (Threadsafe)
 func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (network.Stream, error) {
+	resolved, err := h.resolveAddrs(ctx, h.Peerstore().PeerInfo(p))
+	if err != nil {
+		return nil, err
+	}
+	h.Peerstore().AddAddrs(p, resolved, peerstore.TempAddrTTL)
+
 	s, err := h.Network().NewStream(ctx, p)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
BasicHost.NewStream will try to establish a connection if one doesn't already exist.  This will fail if the destination host's addresses have not yet been resolved.  This PR resolves the destination host's addresses before creating the stream and possible new connection.

Fixes #1302