### PR TITLE
Close resource manager when host closes

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -1054,6 +1054,10 @@ func (h *BasicHost) Close() error {
 		}
 
 		h.refCount.Wait()
+
+		if h.Network().ResourceManager() != nil {
+			h.Network().ResourceManager().Close()
+		}
 	})
 
 	return nil


### PR DESCRIPTION
When a host is closed, it should close its resource manager.  Otherwise, goroutines are leaked.

Generally this is not a problem when a host exists for the life of a program, but can be a problem if hosts are created and closed.