### PR TITLE
fix go vet error in proxy example

### DIFF
--- a/examples/http-proxy/proxy.go
+++ b/examples/http-proxy/proxy.go
@@ -234,8 +234,7 @@ Usage: Start remote peer first with:   ./proxy
 
 Then you can do something like: curl -x "localhost:9900" "http://ipfs.io".
 This proxies sends the request through the local peer, which proxies it to
-the remote peer, which makes it and sends the response back.
-`
+the remote peer, which makes it and sends the response back.`
 
 func main() {
 	flag.Usage = func() {


### PR DESCRIPTION
So we can update to Go 1.18.