### PR TITLE
remove unneeeded build info function in Identify

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -54,19 +53,6 @@ var (
 	maxMessages      = 10
 	defaultUserAgent = "github.com/libp2p/go-libp2p"
 )
-
-func init() {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
-	}
-	version := bi.Main.Version
-	if version == "(devel)" {
-		defaultUserAgent = bi.Main.Path
-	} else {
-		defaultUserAgent = fmt.Sprintf("%s@%s", bi.Main.Path, bi.Main.Version)
-	}
-}
 
 type addPeerHandlerReq struct {
 	rp   peer.ID

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -66,21 +66,18 @@ func testHasCertifiedAddrs(t *testing.T, h host.Host, p peer.ID, expected []ma.M
 }
 
 func testHasProtocolVersions(t *testing.T, h host.Host, p peer.ID) {
+	t.Helper()
 	v, err := h.Peerstore().Get(p, "ProtocolVersion")
-	if v == nil {
-		t.Error("no protocol version")
-		return
-	}
-	if v.(string) != identify.LibP2PVersion {
-		t.Error("protocol mismatch", err)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, v, "no protocol version")
+	require.Equal(t, identify.LibP2PVersion, v.(string), "protocol mismatch")
 	v, err = h.Peerstore().Get(p, "AgentVersion")
-	if v.(string) != "github.com/libp2p/go-libp2p" { // this is the default user agent
-		t.Error("agent version mismatch", err)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "github.com/libp2p/go-libp2p", v.(string), "agent version mismatch")
 }
 
 func testHasPublicKey(t *testing.T, h host.Host, p peer.ID, shouldBe ic.PubKey) {
+	t.Helper()
 	k := h.Peerstore().PubKey(p)
 	if k == nil {
 		t.Error("no public key")
@@ -191,7 +188,7 @@ func TestIDService(t *testing.T) {
 	ids1.IdentifyConn(h1t2c[0])
 
 	// the idService should be opened automatically, by the network.
-	// what we should see now is that both peers know about each others listen addresses.
+	// what we should see now is that both peers know about each other's listen addresses.
 	t.Log("test peer1 has peer2 addrs correctly")
 	testKnowsAddrs(t, h1, h2p, h2.Addrs())                       // has them
 	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p)) // should have signed addrs also


### PR DESCRIPTION
I'm now sure if this is actually the correct fix, but it makes our tests pass with Go 1.18.

`debug.ReadBuildInfo` didn't work in Go 1.17 (`ok` was always `false`). In Go 1.18 is now suddenly works, and is failing the TestIDService test.