### PR TITLE
use the vcs information from ReadBuildInfo in Go 1.18

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -54,19 +53,6 @@ var (
 	maxMessages      = 10
 	defaultUserAgent = "github.com/libp2p/go-libp2p"
 )
-
-func init() {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
-	}
-	version := bi.Main.Version
-	if version == "(devel)" {
-		defaultUserAgent = bi.Main.Path
-	} else {
-		defaultUserAgent = fmt.Sprintf("%s@%s", bi.Main.Path, bi.Main.Version)
-	}
-}
 
 type addPeerHandlerReq struct {
 	rp   peer.ID

--- a/p2p/protocol/identify/id_go117.go
+++ b/p2p/protocol/identify/id_go117.go
@@ -1,0 +1,23 @@
+//go:build !go1.18
+// +build !go1.18
+
+package identify
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	// ok will only be true if this is built as a dependency of another module
+	if !ok {
+		return
+	}
+	version := bi.Main.Version
+	if version == "(devel)" {
+		defaultUserAgent = bi.Main.Path
+	} else {
+		defaultUserAgent = fmt.Sprintf("%s@%s", bi.Main.Path, bi.Main.Version)
+	}
+}

--- a/p2p/protocol/identify/id_go118.go
+++ b/p2p/protocol/identify/id_go118.go
@@ -30,6 +30,9 @@ func init() {
 		switch bs.Key {
 		case "vcs.revision":
 			revision = bs.Value
+			if len(revision) > 9 {
+				revision = revision[:9]
+			}
 		case "vcs.modified":
 			if bs.Value == "true" {
 				dirty = true
@@ -38,6 +41,6 @@ func init() {
 	}
 	defaultUserAgent = fmt.Sprintf("%s@%s", bi.Main.Path, revision)
 	if dirty {
-		defaultUserAgent += " (dirty)"
+		defaultUserAgent += "-dirty"
 	}
 }

--- a/p2p/protocol/identify/id_go118.go
+++ b/p2p/protocol/identify/id_go118.go
@@ -1,0 +1,43 @@
+//go:build go1.18
+// +build go1.18
+
+package identify
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	version := bi.Main.Version
+	// version will only be non-empty if built as a dependency of another module
+	if version == "" {
+		return
+	}
+
+	if version != "(devel)" {
+		defaultUserAgent = fmt.Sprintf("%s@%s", bi.Main.Path, bi.Main.Version)
+		return
+	}
+
+	var revision string
+	var dirty bool
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs.revision":
+			revision = bs.Value
+		case "vcs.modified":
+			if bs.Value == "true" {
+				dirty = true
+			}
+		}
+	}
+	defaultUserAgent = fmt.Sprintf("%s@%s", bi.Main.Path, revision)
+	if dirty {
+		defaultUserAgent += " (dirty)"
+	}
+}


### PR DESCRIPTION
For example, when built as a go-ipfs dependency, this would be: `github.com/ipfs/go-ipfs@dfd01b1e1e8d31b148290e2b5dd51b7a676605fe (dirty)`.