### PR TITLE
redirect to libp2p/specs for general libp2p ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -5,7 +5,7 @@ labels: enhancement
 ---
 
 <!--
-Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
+Note: If you'd like to suggest an idea related to libp2p but not specifically related to the Go implementation, please file an issue at https://github.com/libp2p/specs instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
 
 When requesting an _enhancement_, please be sure to include your motivation and try to be as specific as possible.
 -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -5,7 +5,7 @@ labels: enhancement
 ---
 
 <!--
-Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/libp2p instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
+Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead.
 
 When requesting an _enhancement_, please be sure to include your motivation and try to be as specific as possible.
 -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -5,7 +5,7 @@ labels: enhancement
 ---
 
 <!--
-Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead.
+Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
 
 When requesting an _enhancement_, please be sure to include your motivation and try to be as specific as possible.
 -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -5,7 +5,7 @@ labels: feature
 ---
 
 <!--
-Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
+Note: If you'd like to suggest an idea related to libp2p but not specifically related to the Go implementation, please file an issue at https://github.com/libp2p/specs instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
 
 When requesting a _feature_, please be sure to include:
   * Your motivation. Why do you need the feature?

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -5,7 +5,7 @@ labels: feature
 ---
 
 <!--
-Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead.
+Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
 
 When requesting a _feature_, please be sure to include:
   * Your motivation. Why do you need the feature?

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -5,7 +5,7 @@ labels: feature
 ---
 
 <!--
-Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/libp2p instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
+Note: If you'd like to suggest an idea related to libp2p but not specifically related to the go implementation, please file an issue at https://github.com/libp2p/specs instead.
 
 When requesting a _feature_, please be sure to include:
   * Your motivation. Why do you need the feature?


### PR DESCRIPTION
Update the issue templates to direct to https://github.com/libp2p/specs for general ideas concerning libp2p.
Discussed in https://github.com/libp2p/rust-libp2p/pull/2611#discussion_r846418526.