### PR TITLE
improve AutoRelay v1 handling

### DIFF
--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -25,6 +25,7 @@ type config struct {
 	// Number of relays we strive to obtain a reservation with.
 	desiredRelays    int
 	setMinCandidates bool
+	enableCircuitV1  bool
 }
 
 var defaultConfig = config{
@@ -141,6 +142,14 @@ func WithBackoff(d time.Duration) Option {
 func WithMaxAttempts(n int) Option {
 	return func(c *config) error {
 		c.maxAttempts = n
+		return nil
+	}
+}
+
+// WithCircuitV1Support enables support for circuit v1 relays.
+func WithCircuitV1Support() Option {
+	return func(c *config) error {
+		c.enableCircuitV1 = true
 		return nil
 	}
 }

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -273,12 +273,18 @@ func (rf *relayFinder) tryNode(ctx context.Context, pi peer.AddrInfo) (supportsR
 			supportsV2 = true
 		}
 	}
-	if !maybeSupportsV1 && !supportsV2 {
-		return false, errors.New("doesn't speak circuit v1 or v2")
-	}
+
 	if supportsV2 {
 		return true, nil
 	}
+
+	if !rf.conf.enableCircuitV1 && !supportsV2 {
+		return false, errors.New("doesn't speak circuit v2")
+	}
+	if !maybeSupportsV1 && !supportsV2 {
+		return false, errors.New("doesn't speak circuit v1 or v2")
+	}
+
 	// The node *may* support circuit v1.
 	supportsV1, err := relayv1.CanHop(ctx, rf.host, pi.ID)
 	if err != nil {

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -264,19 +264,30 @@ func (rf *relayFinder) tryNode(ctx context.Context, pi peer.AddrInfo) (supportsR
 	}
 
 	// If the node speaks both, prefer circuit v2
-	var supportsV1, supportsV2 bool
+	var maybeSupportsV1, supportsV2 bool
 	for _, proto := range protos {
 		switch proto {
 		case protoIDv1:
-			supportsV1 = true
+			maybeSupportsV1 = true
 		case protoIDv2:
 			supportsV2 = true
 		}
 	}
-	if !supportsV1 && !supportsV2 {
+	if !maybeSupportsV1 && !supportsV2 {
 		return false, errors.New("doesn't speak circuit v1 or v2")
 	}
-	return supportsV2, nil
+	if supportsV2 {
+		return true, nil
+	}
+	// The node *may* support circuit v1.
+	supportsV1, err := relayv1.CanHop(ctx, rf.host, pi.ID)
+	if err != nil {
+		return false, fmt.Errorf("CanHop failed: %w", err)
+	}
+	if !supportsV1 {
+		return false, errors.New("doesn't speak circuit v1 or v2")
+	}
+	return false, nil
 }
 
 func (rf *relayFinder) handleNewCandidate(ctx context.Context) {
@@ -335,16 +346,6 @@ func (rf *relayFinder) handleNewCandidate(ctx context.Context) {
 				if err != nil {
 					failed = true
 					log.Debugw("failed to reserve slot", "id", id, "error", err)
-				}
-			} else {
-				ok, err := relayv1.CanHop(ctx, rf.host, id)
-				if err != nil {
-					failed = true
-					log.Debugw("error querying relay for v1 hop", "id", id, "error", err)
-				}
-				if !ok {
-					failed = true
-					log.Debugw("relay can't hop", "id", id)
 				}
 			}
 			rf.candidateMx.Lock()

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
+
 	"github.com/libp2p/go-libp2p"
 
 	"github.com/libp2p/go-libp2p-core/host"
@@ -347,7 +349,7 @@ func mkHostWithStaticAutoRelay(t *testing.T, relay host.Host) host.Host {
 	h, err := libp2p.New(
 		libp2p.ListenAddrs(ma.StringCast("/ip4/127.0.0.1/tcp/0")),
 		libp2p.EnableRelay(),
-		libp2p.EnableAutoRelay(),
+		libp2p.EnableAutoRelay(autorelay.WithCircuitV1Support()),
 		libp2p.ForceReachabilityPrivate(),
 		libp2p.StaticRelays([]peer.AddrInfo{pi}),
 	)


### PR DESCRIPTION
Circuit v1 support is disabled by default. It can be reenabled using the `WithCircuitV1Support` option, and it is expected that go-ipfs will do that when static relays are in use.