### PR TITLE
fix flaky reconnect test

### DIFF
--- a/p2p/test/reconnects/reconnect_test.go
+++ b/p2p/test/reconnects/reconnect_test.go
@@ -95,9 +95,9 @@ func runRound(t *testing.T, hosts []host.Host) {
 					rand.Read(data)
 					str, err := h1.NewStream(context.Background(), h2.ID(), protocol.TestingID)
 					require.NoError(t, err)
+					defer str.Close()
 					_, err = str.Write(data)
 					require.NoError(t, err)
-					require.NoError(t, str.Close())
 				}()
 			}
 			wg.Wait()

--- a/p2p/test/reconnects/reconnect_test.go
+++ b/p2p/test/reconnects/reconnect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math/rand"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -49,6 +50,9 @@ func TestReconnect5(t *testing.T) {
 	}
 
 	t.Run("using TCP", func(t *testing.T) {
+		if runtime.GOOS == "darwin" {
+			t.Skip("TCP RST handling is flaky in OSX, see https://github.com/golang/go/issues/50254")
+		}
 		runTest(t, swarmt.OptDisableQUIC)
 	})
 
@@ -121,5 +125,5 @@ func runRound(t *testing.T, hosts []host.Host) {
 			}
 		}
 		return true
-	}, 500*time.Millisecond, 10*time.Millisecond)
+	}, 5000*time.Millisecond, 10*time.Millisecond)
 }


### PR DESCRIPTION
Fixes #1405.

https://github.com/golang/go/issues/50254 is coming back to bite us. Again.