### PR TITLE
remove flaky TestTcpSimultaneousConnect

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
@@ -16,9 +15,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/transport"
 
-	noise "github.com/libp2p/go-libp2p-noise"
-
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -167,49 +163,4 @@ func TestChainOptions(t *testing.T) {
 			t.Errorf("expected opt %d, got opt %d", i, x)
 		}
 	}
-}
-
-func TestTcpSimultaneousConnect(t *testing.T) {
-	// Host1
-	h1, err := New(Transport(tcp.NewTCPTransport), Security(noise.ID, noise.New), ListenAddrs(ma.StringCast("/ip4/0.0.0.0/tcp/0")))
-	require.NoError(t, err)
-	defer h1.Close()
-
-	// Host2
-	h2, err := New(Transport(tcp.NewTCPTransport), Security(noise.ID, noise.New), ListenAddrs(ma.StringCast("/ip4/0.0.0.0/tcp/0")))
-	require.NoError(t, err)
-	defer h2.Close()
-
-	h1Info := peer.AddrInfo{
-		ID:    h1.ID(),
-		Addrs: h1.Addrs(),
-	}
-
-	h2Info := peer.AddrInfo{
-		ID:    h2.ID(),
-		Addrs: h2.Addrs(),
-	}
-
-	wg := new(sync.WaitGroup)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 20; i++ {
-			require.NoError(t, h1.Connect(context.Background(), h2Info))
-			require.NoError(t, h1.Network().ClosePeer(h2.ID()))
-		}
-	}()
-
-	// use another peer to constantly connect/disconnect with first peer.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 20; i++ {
-			require.NoError(t, h2.Connect(context.Background(), h1Info))
-			require.NoError(t, h2.Network().ClosePeer(h1.ID()))
-		}
-	}()
-
-	wg.Wait()
 }


### PR DESCRIPTION
Fixes #1170.

This test is flaky *by design*: There's half a RTT between a connection is fully set up on one host and the other, so closing the connection right away will occasionally lead to "connection reset by peer" errors.

TCP Simultaneous Connect should (and is) tested in the swarm.