### PR TITLE
quic: add `DisableReuseport` option

### DIFF
--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -2,6 +2,7 @@ package libp2pquic
 
 import (
 	"context"
+	"net"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/network"
@@ -12,9 +13,17 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+type pConn interface {
+	net.PacketConn
+
+	// count conn reference
+	DecreaseCount()
+	IncreaseCount()
+}
+
 type conn struct {
 	quicConn  quic.Connection
-	pconn     *reuseConn
+	pconn     pConn
 	transport *transport
 	scope     network.ConnManagementScope
 

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -30,6 +30,16 @@ import (
 
 //go:generate sh -c "mockgen -package libp2pquic -destination mock_connection_gater_test.go github.com/libp2p/go-libp2p-core/connmgr ConnectionGater && goimports -w mock_connection_gater_test.go"
 
+type connTestCase struct {
+	Name    string
+	Options []Option
+}
+
+var connTestCases = []*connTestCase{
+	{"reuseport_on", []Option{}},
+	{"reuseport_off", []Option{DisableReuseport()}},
+}
+
 func createPeer(t *testing.T) (peer.ID, ic.PrivKey) {
 	var priv ic.PrivKey
 	var err error
@@ -52,20 +62,29 @@ func createPeer(t *testing.T) (peer.ID, ic.PrivKey) {
 
 func runServer(t *testing.T, tr tpt.Transport, addr string) tpt.Listener {
 	t.Helper()
+
 	ln, err := tr.Listen(ma.StringCast(addr))
 	require.NoError(t, err)
 	return ln
 }
 
 func TestHandshake(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testHandshake(t, tc)
+		})
+	}
+}
+
+func testHandshake(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
-	serverTransport, err := NewTransport(serverKey, nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 
 	handshake := func(t *testing.T, ln tpt.Listener) {
-		clientTransport, err := NewTransport(clientKey, nil, nil, nil)
+		clientTransport, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 		require.NoError(t, err)
 		defer clientTransport.(io.Closer).Close()
 		conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
@@ -100,6 +119,14 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestResourceManagerSuccess(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testResourceManagerSuccess(t, tc)
+		})
+	}
+}
+
+func testResourceManagerSuccess(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
 
@@ -107,7 +134,7 @@ func TestResourceManagerSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	serverRcmgr := mocknetwork.NewMockResourceManager(ctrl)
-	serverTransport, err := NewTransport(serverKey, nil, nil, serverRcmgr)
+	serverTransport, err := NewTransport(serverKey, nil, nil, serverRcmgr, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln, err := serverTransport.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic"))
@@ -115,7 +142,7 @@ func TestResourceManagerSuccess(t *testing.T) {
 	defer ln.Close()
 
 	clientRcmgr := mocknetwork.NewMockResourceManager(ctrl)
-	clientTransport, err := NewTransport(clientKey, nil, nil, clientRcmgr)
+	clientTransport, err := NewTransport(clientKey, nil, nil, clientRcmgr, tc.Options...)
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 
@@ -143,12 +170,20 @@ func TestResourceManagerSuccess(t *testing.T) {
 }
 
 func TestResourceManagerDialDenied(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testResourceManagerDialDenied(t, tc)
+		})
+	}
+}
+
+func testResourceManagerDialDenied(t *testing.T, tc *connTestCase) {
 	_, clientKey := createPeer(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
-	clientTransport, err := NewTransport(clientKey, nil, nil, rcmgr)
+	clientTransport, err := NewTransport(clientKey, nil, nil, rcmgr, tc.Options...)
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 
@@ -163,16 +198,25 @@ func TestResourceManagerDialDenied(t *testing.T) {
 
 	_, err = clientTransport.Dial(context.Background(), target, p)
 	require.ErrorIs(t, err, rerr)
+
 }
 
 func TestResourceManagerAcceptDenied(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testResourceManagerAcceptDenied(t, tc)
+		})
+	}
+}
+
+func testResourceManagerAcceptDenied(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	clientRcmgr := mocknetwork.NewMockResourceManager(ctrl)
-	clientTransport, err := NewTransport(clientKey, nil, nil, clientRcmgr)
+	clientTransport, err := NewTransport(clientKey, nil, nil, clientRcmgr, tc.Options...)
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 
@@ -184,7 +228,7 @@ func TestResourceManagerAcceptDenied(t *testing.T) {
 		serverConnScope.EXPECT().SetPeer(clientID).Return(rerr),
 		serverConnScope.EXPECT().Done(),
 	)
-	serverTransport, err := NewTransport(serverKey, nil, nil, serverRcmgr)
+	serverTransport, err := NewTransport(serverKey, nil, nil, serverRcmgr, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln, err := serverTransport.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic"))
@@ -216,16 +260,24 @@ func TestResourceManagerAcceptDenied(t *testing.T) {
 }
 
 func TestStreams(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testStreams(t, tc)
+		})
+	}
+}
+
+func testStreams(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 	defer ln.Close()
 
-	clientTransport, err := NewTransport(clientKey, nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 	conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
@@ -248,16 +300,24 @@ func TestStreams(t *testing.T) {
 }
 
 func TestHandshakeFailPeerIDMismatch(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testHandshakeFailPeerIDMismatch(t, tc)
+		})
+	}
+}
+
+func testHandshakeFailPeerIDMismatch(t *testing.T, tc *connTestCase) {
 	_, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 	thirdPartyID, _ := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 
-	clientTransport, err := NewTransport(clientKey, nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	// dial, but expect the wrong peer ID
 	_, err = clientTransport.Dial(context.Background(), ln.Multiaddr(), thirdPartyID)
@@ -282,6 +342,14 @@ func TestHandshakeFailPeerIDMismatch(t *testing.T) {
 }
 
 func TestConnectionGating(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testConnectionGating(t, tc)
+		})
+	}
+}
+
+func testConnectionGating(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 
@@ -290,7 +358,7 @@ func TestConnectionGating(t *testing.T) {
 	cg := NewMockConnectionGater(mockCtrl)
 
 	t.Run("accepted connections", func(t *testing.T) {
-		serverTransport, err := NewTransport(serverKey, nil, cg, nil)
+		serverTransport, err := NewTransport(serverKey, nil, cg, nil, tc.Options...)
 		defer serverTransport.(io.Closer).Close()
 		require.NoError(t, err)
 		ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic")
@@ -305,7 +373,7 @@ func TestConnectionGating(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
-		clientTransport, err := NewTransport(clientKey, nil, nil, nil)
+		clientTransport, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 		require.NoError(t, err)
 		defer clientTransport.(io.Closer).Close()
 		// make sure that connection attempts fails
@@ -335,7 +403,7 @@ func TestConnectionGating(t *testing.T) {
 	})
 
 	t.Run("secured connections", func(t *testing.T) {
-		serverTransport, err := NewTransport(serverKey, nil, nil, nil)
+		serverTransport, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 		require.NoError(t, err)
 		defer serverTransport.(io.Closer).Close()
 		ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic")
@@ -344,7 +412,7 @@ func TestConnectionGating(t *testing.T) {
 		cg := NewMockConnectionGater(mockCtrl)
 		cg.EXPECT().InterceptSecured(gomock.Any(), gomock.Any(), gomock.Any())
 
-		clientTransport, err := NewTransport(clientKey, nil, cg, nil)
+		clientTransport, err := NewTransport(clientKey, nil, cg, nil, tc.Options...)
 		require.NoError(t, err)
 		defer clientTransport.(io.Closer).Close()
 
@@ -363,16 +431,24 @@ func TestConnectionGating(t *testing.T) {
 }
 
 func TestDialTwo(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testDialTwo(t, tc)
+		})
+	}
+}
+
+func testDialTwo(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 	serverID2, serverKey2 := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln1 := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 	defer ln1.Close()
-	serverTransport2, err := NewTransport(serverKey2, nil, nil, nil)
+	serverTransport2, err := NewTransport(serverKey2, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport2.(io.Closer).Close()
 	ln2 := runServer(t, serverTransport2, "/ip4/127.0.0.1/udp/0/quic")
@@ -398,7 +474,7 @@ func TestDialTwo(t *testing.T) {
 		}
 	}()
 
-	clientTransport, err := NewTransport(clientKey, nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 	c1, err := clientTransport.Dial(context.Background(), ln1.Multiaddr(), serverID)
@@ -435,6 +511,14 @@ func TestDialTwo(t *testing.T) {
 }
 
 func TestStatelessReset(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testStatelessReset(t, tc)
+		})
+	}
+}
+
+func testStatelessReset(t *testing.T, tc *connTestCase) {
 	origGarbageCollectInterval := garbageCollectInterval
 	origMaxUnusedDuration := maxUnusedDuration
 
@@ -449,7 +533,7 @@ func TestStatelessReset(t *testing.T) {
 	serverID, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic")
@@ -466,7 +550,7 @@ func TestStatelessReset(t *testing.T) {
 	defer proxy.Close()
 
 	// establish a connection
-	clientTransport, err := NewTransport(clientKey, nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 	proxyAddr, err := toQuicMultiaddr(proxy.LocalAddr())
@@ -512,10 +596,18 @@ func TestStatelessReset(t *testing.T) {
 }
 
 func TestHolePunching(t *testing.T) {
+	for _, tc := range connTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testHolePunching(t, tc)
+		})
+	}
+}
+
+func testHolePunching(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
 
-	t1, err := NewTransport(serverKey, nil, nil, nil)
+	t1, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer t1.(io.Closer).Close()
 	laddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/quic")
@@ -529,7 +621,7 @@ func TestHolePunching(t *testing.T) {
 		require.Error(t, err, "didn't expect to accept any connections")
 	}()
 
-	t2, err := NewTransport(clientKey, nil, nil, nil)
+	t2, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
 	require.NoError(t, err)
 	defer t2.(io.Closer).Close()
 	ln2, err := t2.Listen(laddr)

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -595,19 +595,13 @@ func testStatelessReset(t *testing.T, tc *connTestCase) {
 	require.Contains(t, rerr.Error(), "received a stateless reset")
 }
 
+// Hole punching is only expected to work with reuseport enabled.
+// We don't need to test `DisableReuseport` option.
 func TestHolePunching(t *testing.T) {
-	for _, tc := range connTestCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			testHolePunching(t, tc)
-		})
-	}
-}
-
-func testHolePunching(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
 
-	t1, err := NewTransport(serverKey, nil, nil, nil, tc.Options...)
+	t1, err := NewTransport(serverKey, nil, nil, nil)
 	require.NoError(t, err)
 	defer t1.(io.Closer).Close()
 	laddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/quic")
@@ -621,7 +615,7 @@ func testHolePunching(t *testing.T, tc *connTestCase) {
 		require.Error(t, err, "didn't expect to accept any connections")
 	}()
 
-	t2, err := NewTransport(clientKey, nil, nil, nil, tc.Options...)
+	t2, err := NewTransport(clientKey, nil, nil, nil)
 	require.NoError(t, err)
 	defer t2.(io.Closer).Close()
 	ln2, err := t2.Listen(laddr)

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -21,7 +21,7 @@ var quicListen = quic.Listen // so we can mock it in tests
 // A listener listens for QUIC connections.
 type listener struct {
 	quicListener   quic.Listener
-	conn           *reuseConn
+	conn           pConn
 	transport      *transport
 	rcmgr          network.ResourceManager
 	privKey        ic.PrivKey
@@ -31,7 +31,7 @@ type listener struct {
 
 var _ tpt.Listener = &listener{}
 
-func newListener(rconn *reuseConn, t *transport, localPeer peer.ID, key ic.PrivKey, identity *p2ptls.Identity, rcmgr network.ResourceManager) (tpt.Listener, error) {
+func newListener(pconn pConn, t *transport, localPeer peer.ID, key ic.PrivKey, identity *p2ptls.Identity, rcmgr network.ResourceManager) (tpt.Listener, error) {
 	var tlsConf tls.Config
 	tlsConf.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
 		// return a tls.Config that verifies the peer's certificate chain.
@@ -41,7 +41,7 @@ func newListener(rconn *reuseConn, t *transport, localPeer peer.ID, key ic.PrivK
 		conf, _ := identity.ConfigForPeer("")
 		return conf, nil
 	}
-	ln, err := quicListen(rconn, &tlsConf, t.serverConfig)
+	ln, err := quicListen(pconn, &tlsConf, t.serverConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func newListener(rconn *reuseConn, t *transport, localPeer peer.ID, key ic.PrivK
 		return nil, err
 	}
 	return &listener{
-		conn:           rconn,
+		conn:           pconn,
 		quicListener:   ln,
 		transport:      t,
 		rcmgr:          rcmgr,

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -146,7 +146,17 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 // Close closes the listener.
 func (l *listener) Close() error {
 	defer l.conn.DecreaseCount()
-	return l.quicListener.Close()
+
+	if err := l.quicListener.Close(); err != nil {
+		return err
+	}
+
+	if _, ok := l.conn.(*noreuseConn); ok {
+		// if we use a `noreuseConn`, close the underlying connection
+		return l.conn.Close()
+	}
+
+	return nil
 }
 
 // Addr returns the address of this listener.

--- a/p2p/transport/quic/options.go
+++ b/p2p/transport/quic/options.go
@@ -1,0 +1,24 @@
+package libp2pquic
+
+type Option func(opts *config) error
+
+type config struct {
+	disableReuseport bool
+}
+
+func (cfg *config) apply(opts ...Option) error {
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func DisableReuseport() Option {
+	return func(cfg *config) error {
+		cfg.disableReuseport = true
+		return nil
+	}
+}

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -54,18 +54,26 @@ var quicConfig = &quic.Config{
 const statelessResetKeyInfo = "libp2p quic stateless reset key"
 const errorCodeConnectionGating = 0x47415445 // GATE in ASCII
 
-type connManager struct {
-	reuseUDP4 *reuse
-	reuseUDP6 *reuse
+type noreuseConn struct {
+	*net.UDPConn
 }
 
-func newConnManager() (*connManager, error) {
+func (c *noreuseConn) IncreaseCount() {}
+func (c *noreuseConn) DecreaseCount() {}
+
+type connManager struct {
+	reuseUDP4       *reuse
+	reuseUDP6       *reuse
+	reuseportEnable bool
+}
+
+func newConnManager(reuseport bool) (*connManager, error) {
 	reuseUDP4 := newReuse()
 	reuseUDP6 := newReuse()
-
 	return &connManager{
-		reuseUDP4: reuseUDP4,
-		reuseUDP6: reuseUDP6,
+		reuseUDP4:       reuseUDP4,
+		reuseUDP6:       reuseUDP6,
+		reuseportEnable: reuseport,
 	}, nil
 }
 
@@ -80,20 +88,43 @@ func (c *connManager) getReuse(network string) (*reuse, error) {
 	}
 }
 
-func (c *connManager) Listen(network string, laddr *net.UDPAddr) (*reuseConn, error) {
-	reuse, err := c.getReuse(network)
+func (c *connManager) Listen(network string, laddr *net.UDPAddr) (pConn, error) {
+	if c.reuseportEnable {
+		reuse, err := c.getReuse(network)
+		if err != nil {
+			return nil, err
+		}
+		return reuse.Listen(network, laddr)
+	}
+
+	conn, err := net.ListenUDP(network, laddr)
 	if err != nil {
 		return nil, err
 	}
-	return reuse.Listen(network, laddr)
+	return &noreuseConn{conn}, nil
 }
 
-func (c *connManager) Dial(network string, raddr *net.UDPAddr) (*reuseConn, error) {
-	reuse, err := c.getReuse(network)
+func (c *connManager) Dial(network string, raddr *net.UDPAddr) (pConn, error) {
+	if c.reuseportEnable {
+		reuse, err := c.getReuse(network)
+		if err != nil {
+			return nil, err
+		}
+		return reuse.Dial(network, raddr)
+	}
+
+	var laddr *net.UDPAddr
+	switch network {
+	case "udp4":
+		laddr = &net.UDPAddr{IP: net.IPv4zero, Port: 0}
+	case "udp6":
+		laddr = &net.UDPAddr{IP: net.IPv6zero, Port: 0}
+	}
+	conn, err := net.ListenUDP(network, laddr)
 	if err != nil {
 		return nil, err
 	}
-	return reuse.Dial(network, raddr)
+	return &noreuseConn{conn}, nil
 }
 
 func (c *connManager) Close() error {
@@ -134,7 +165,12 @@ type activeHolePunch struct {
 }
 
 // NewTransport creates a new QUIC transport
-func NewTransport(key ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater, rcmgr network.ResourceManager) (tpt.Transport, error) {
+func NewTransport(key ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater, rcmgr network.ResourceManager, opts ...Option) (tpt.Transport, error) {
+	var cfg config
+	if err := cfg.apply(opts...); err != nil {
+		return nil, fmt.Errorf("unable to apply quic-tpt option(s): %w", err)
+	}
+
 	if len(psk) > 0 {
 		log.Error("QUIC doesn't support private networks yet.")
 		return nil, errors.New("QUIC doesn't support private networks yet")
@@ -147,24 +183,24 @@ func NewTransport(key ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater, r
 	if err != nil {
 		return nil, err
 	}
-	connManager, err := newConnManager()
+	connManager, err := newConnManager(!cfg.disableReuseport)
 	if err != nil {
 		return nil, err
 	}
 	if rcmgr == nil {
 		rcmgr = network.NullResourceManager
 	}
-	config := quicConfig.Clone()
+	qconfig := quicConfig.Clone()
 	keyBytes, err := key.Raw()
 	if err != nil {
 		return nil, err
 	}
 	keyReader := hkdf.New(sha256.New, keyBytes, nil, []byte(statelessResetKeyInfo))
-	config.StatelessResetKey = make([]byte, 32)
-	if _, err := io.ReadFull(keyReader, config.StatelessResetKey); err != nil {
+	qconfig.StatelessResetKey = make([]byte, 32)
+	if _, err := io.ReadFull(keyReader, qconfig.StatelessResetKey); err != nil {
 		return nil, err
 	}
-	config.Tracer = tracer
+	qconfig.Tracer = tracer
 
 	tr := &transport{
 		privKey:      key,
@@ -176,9 +212,9 @@ func NewTransport(key ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater, r
 		conns:        make(map[quic.Connection]*conn),
 		holePunching: make(map[holePunchKey]*activeHolePunch),
 	}
-	config.AllowConnectionWindowIncrease = tr.allowWindowIncrease
-	tr.serverConfig = config
-	tr.clientConfig = config.Clone()
+	qconfig.AllowConnectionWindowIncrease = tr.allowWindowIncrease
+	tr.serverConfig = qconfig
+	tr.clientConfig = qconfig.Clone()
 	return tr, nil
 }
 
@@ -305,7 +341,7 @@ loop:
 			punchErr = err
 			break
 		}
-		if _, err := pconn.UDPConn.WriteToUDP(payload, addr); err != nil {
+		if _, err := pconn.WriteTo(payload, addr); err != nil {
 			punchErr = err
 			break
 		}

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -406,6 +406,9 @@ func (t *transport) Listen(addr ma.Multiaddr) (tpt.Listener, error) {
 	}
 	ln, err := newListener(conn, t, t.localPeer, t.privKey, t.identity, t.rcmgr)
 	if err != nil {
+		if !t.connManager.reuseportEnable {
+			conn.Close()
+		}
 		conn.DecreaseCount()
 		return nil, err
 	}


### PR DESCRIPTION
Moved from  https://github.com/libp2p/go-libp2p-quic-transport/pull/272

---

Fixes #1428 

Hey, I just started to add the `DisableReuseport` options to quic transport.  It seems to be working as expected with some cellular operators that couldn't maintain the connection (I tried with this script https://github.com/gfanton/libp2p-reuseport-test)

Just some few things:

- It seems that there is no option/configuration mechanism, so I added one. Let me know if you are ok with this or if you want to use another method to pass the argument.
- I wrapped all the `conn_tests` with a simple table test case to test everything conn related with the reuseport_on/off
- I have to use `net.ListenUDP` instead of `net.DialUDP` for the Dial method to work, otherwise the call to the `WriteTo` method fails.

Also there are two tests that currently fail with the reuseport disabled:

**TestHolePunching**
```
=== RUN   TestHolePunching/reuseport_off
    conn_test.go:59: using a Secp256k1 key: 16Uiu2HAmPxEseg6Hti88hpHTyUB3tQk9bw7paj9yS3rPkBgPnWgM
    conn_test.go:59: using a Ed25519 key: 12D3KooWAaU8sc9j783H9hH3eG3yyJDnvz9Le1LdhCQFbYe5gFyu
    conn_test.go:581: 
        	Error Trace:	conn_test.go:581
        	           				asm_arm64.s:1133
        	Error:      	An error is expected but got nil.
        	Test:       	TestHolePunching/reuseport_off
        	Messages:   	didn't expect to accept any connections
    conn_test.go:602: 
        	Error Trace:	conn_test.go:602
        	Error:      	Condition never satisfied
        	Test:       	TestHolePunching/reuseport_off
```

**TestStatelessReset**
```
=== RUN   TestStatelessReset/reuseport_off
    conn_test.go:59: using a ECDSA key: QmRoF9AeMPnxYMrErq91y2xCvjiULp9n9cJuVwDHu9Kdao
    conn_test.go:59: using a RSA key: QmNvwzR7VDFy1wFdHE3PgV8mCztJbFWz1d5NXVL3wXYVgX
    conn_test.go:534: 
        	Error Trace:	conn_test.go:66
        	           				conn_test.go:534
        	Error:      	Received unexpected error:
        	           	listen udp4 127.0.0.1:55213: bind: address already in use
        	Test:       	TestStatelessReset/reuseport_off
```

Do these tests make sense when used with resuseport disabled? 