### PR TITLE
holepunch: fix incorrect message type for the SYNC message

### DIFF
--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -228,7 +228,7 @@ func (hp *holePuncher) initiateHolePunchImpl(str network.Stream) ([]ma.Multiaddr
 		return nil, 0, errors.New("didn't receive any public addresses in CONNECT")
 	}
 
-	if err := w.WriteMsg(&pb.HolePunch{Type: pb.HolePunch_CONNECT.Enum()}); err != nil {
+	if err := w.WriteMsg(&pb.HolePunch{Type: pb.HolePunch_SYNC.Enum()}); err != nil {
 		return nil, 0, fmt.Errorf("failed to send SYNC message for hole punching: %w", err)
 	}
 	return addrs, rtt, nil


### PR DESCRIPTION
Fixes #1477.

This is **bad**. We'll need to backport this and release v0.19.2.