### PR TITLE
Support generating custom x509 certificates

### DIFF
--- a/p2p/security/tls/crypto.go
+++ b/p2p/security/tls/crypto.go
@@ -1,6 +1,7 @@
 package libp2ptls
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -38,9 +39,37 @@ type Identity struct {
 	config tls.Config
 }
 
+// IdentityConfig is used to configure an Identity
+type IdentityConfig struct {
+	CertTemplate *x509.Certificate
+}
+
+// IdentityOption transforms an IdentityConfig to apply optional settings.
+type IdentityOption func(r *IdentityConfig)
+
+// WithCertTemplate specifies the template to use when generating a new certificate.
+func WithCertTemplate(template *x509.Certificate) IdentityOption {
+	return func(c *IdentityConfig) {
+		c.CertTemplate = template
+	}
+}
+
 // NewIdentity creates a new identity
-func NewIdentity(privKey ic.PrivKey) (*Identity, error) {
-	cert, err := keyToCertificate(privKey)
+func NewIdentity(privKey ic.PrivKey, opts ...IdentityOption) (*Identity, error) {
+	config := IdentityConfig{}
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	var err error
+	if config.CertTemplate == nil {
+		config.CertTemplate, err = DefaultCertTemplate()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cert, err := keyToCertificate(privKey, config.CertTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -167,17 +196,15 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (ic.PubKey, error) {
 	return pubKey, nil
 }
 
-func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
-	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-
+// GenerateSignedExtension uses the provided private key to sign the public key, and returns the
+// signature within a pkix.Extension.
+// This extension is included in a certificate to cryptographically tie it to the libp2p private key.
+func GenerateSignedExtension(sk ic.PrivKey, pubKey crypto.PublicKey) (*pkix.Extension, error) {
 	keyBytes, err := ic.MarshalPublicKey(sk.GetPublic())
 	if err != nil {
 		return nil, err
 	}
-	certKeyPub, err := x509.MarshalPKIXPublicKey(certKey.Public())
+	certKeyPub, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -193,28 +220,26 @@ func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
 		return nil, err
 	}
 
-	bigNum := big.NewInt(1 << 62)
-	sn, err := rand.Int(rand.Reader, bigNum)
+	return &pkix.Extension{Id: extensionID, Critical: extensionCritical, Value: value}, nil
+}
+
+// keyToCertificate generates a new ECDSA private key and corresponding x509 certificate.
+// The certificate includes an extension that cryptographically ties it to the provided libp2p
+// private key to authenticate TLS connections.
+func keyToCertificate(sk ic.PrivKey, certTmpl *x509.Certificate) (*tls.Certificate, error) {
+	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
-	subjectSN, err := rand.Int(rand.Reader, bigNum)
+
+	// after calling CreateCertificate, these will end up in Certificate.Extensions
+	extension, err := GenerateSignedExtension(sk, certKey.Public())
 	if err != nil {
 		return nil, err
 	}
-	tmpl := &x509.Certificate{
-		SerialNumber: sn,
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(certValidityPeriod),
-		// According to RFC 3280, the issuer field must be set,
-		// see https://datatracker.ietf.org/doc/html/rfc3280#section-4.1.2.4.
-		Subject: pkix.Name{SerialNumber: subjectSN.String()},
-		// after calling CreateCertificate, these will end up in Certificate.Extensions
-		ExtraExtensions: []pkix.Extension{
-			{Id: extensionID, Critical: extensionCritical, Value: value},
-		},
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, certKey.Public(), certKey)
+	certTmpl.ExtraExtensions = append(certTmpl.ExtraExtensions, *extension)
+
+	certDER, err := x509.CreateCertificate(rand.Reader, certTmpl, certTmpl, certKey.Public(), certKey)
 	if err != nil {
 		return nil, err
 	}
@@ -224,12 +249,35 @@ func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
 	}, nil
 }
 
+// DefaultCertTemplate returns the default template for generating an Identity's TLS certificates.
+func DefaultCertTemplate() (*x509.Certificate, error) {
+	bigNum := big.NewInt(1 << 62)
+	sn, err := rand.Int(rand.Reader, bigNum)
+	if err != nil {
+		return nil, err
+	}
+
+	subjectSN, err := rand.Int(rand.Reader, bigNum)
+	if err != nil {
+		return nil, err
+	}
+
+	return &x509.Certificate{
+		SerialNumber: sn,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(certValidityPeriod),
+		// According to RFC 3280, the issuer field must be set,
+		// see https://datatracker.ietf.org/doc/html/rfc3280#section-4.1.2.4.
+		Subject: pkix.Name{SerialNumber: subjectSN.String()},
+	}, nil
+}
+
 // We want nodes without AES hardware (e.g. ARM) support to always use ChaCha.
 // Only if both nodes have AES hardware support (e.g. x86), AES should be used.
 // x86->x86: AES, ARM->x86: ChaCha, x86->ARM: ChaCha and ARM->ARM: Chacha
 // This function returns true if we don't have AES hardware support, and false otherwise.
 // Thus, ARM servers will always use their own cipher suite preferences (ChaCha first),
-// and x86 servers will aways use the client's cipher suite preferences.
+// and x86 servers will always use the client's cipher suite preferences.
 func preferServerCipherSuites() bool {
 	// Copied from the Go TLS implementation.
 

--- a/p2p/security/tls/crypto_test.go
+++ b/p2p/security/tls/crypto_test.go
@@ -1,0 +1,48 @@
+package libp2ptls
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewIdentityCertificates(t *testing.T) {
+	_, key := createPeer(t)
+	cn := "a.test.name"
+	email := "unittest@example.com"
+
+	t.Run("NewIdentity with default template", func(t *testing.T) {
+		// Generate an identity using the default template
+		id, err := NewIdentity(key)
+		assert.NoError(t, err)
+
+		// Extract the x509 certificate
+		x509Cert, err := x509.ParseCertificate(id.config.Certificates[0].Certificate[0])
+		assert.NoError(t, err)
+
+		// verify the common name and email are not set
+		assert.Empty(t, x509Cert.Subject.CommonName)
+		assert.Empty(t, x509Cert.EmailAddresses)
+	})
+
+	t.Run("NewIdentity with custom template", func(t *testing.T) {
+		tmpl, err := DefaultCertTemplate()
+		assert.NoError(t, err)
+
+		tmpl.Subject.CommonName = cn
+		tmpl.EmailAddresses = []string{email}
+
+		// Generate an identity using the custom template
+		id, err := NewIdentity(key, WithCertTemplate(tmpl))
+		assert.NoError(t, err)
+
+		// Extract the x509 certificate
+		x509Cert, err := x509.ParseCertificate(id.config.Certificates[0].Certificate[0])
+		assert.NoError(t, err)
+
+		// verify the common name and email are set
+		assert.Equal(t, cn, x509Cert.Subject.CommonName)
+		assert.Equal(t, email, x509Cert.EmailAddresses[0])
+	})
+}

--- a/p2p/security/tls/crypto_test.go
+++ b/p2p/security/tls/crypto_test.go
@@ -27,7 +27,7 @@ func TestNewIdentityCertificates(t *testing.T) {
 	})
 
 	t.Run("NewIdentity with custom template", func(t *testing.T) {
-		tmpl, err := DefaultCertTemplate()
+		tmpl, err := certTemplate()
 		assert.NoError(t, err)
 
 		tmpl.Subject.CommonName = cn

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -65,12 +65,7 @@ func TestHandshakeSucceeds(t *testing.T) {
 	clientID, clientKey := createPeer(t)
 	serverID, serverKey := createPeer(t)
 
-	handshake := func(t *testing.T) {
-		clientTransport, err := New(clientKey)
-		require.NoError(t, err)
-		serverTransport, err := New(serverKey)
-		require.NoError(t, err)
-
+	handshake := func(t *testing.T, clientTransport *Transport, serverTransport *Transport) {
 		clientInsecureConn, serverInsecureConn := connect(t)
 
 		serverConnChan := make(chan sec.SecureConn)
@@ -109,15 +104,54 @@ func TestHandshakeSucceeds(t *testing.T) {
 		require.Equal(t, string(b), "foobar")
 	}
 
-	t.Run("with extension not critical", func(t *testing.T) {
-		handshake(t)
+	// Use standard transports with default TLS configuration
+	clientTransport, err := New(clientKey)
+	require.NoError(t, err)
+	serverTransport, err := New(serverKey)
+	require.NoError(t, err)
+
+	t.Run("standard TLS with extension not critical", func(t *testing.T) {
+		handshake(t, clientTransport, serverTransport)
 	})
 
-	t.Run("with extension critical", func(t *testing.T) {
+	t.Run("standard TLS with extension critical", func(t *testing.T) {
 		extensionCritical = true
 		t.Cleanup(func() { extensionCritical = false })
 
-		handshake(t)
+		handshake(t, clientTransport, serverTransport)
+	})
+
+	// Use transports with custom TLS certificates
+
+	// override client identity to use a custom certificate
+	clientCertTmlp, err := certTemplate()
+	require.NoError(t, err)
+
+	clientCertTmlp.Subject.CommonName = "client.test.name"
+	clientCertTmlp.EmailAddresses = []string{"server-unittest@example.com"}
+
+	clientTransport.identity, err = NewIdentity(clientKey, WithCertTemplate(clientCertTmlp))
+	require.NoError(t, err)
+
+	// override server identity to use a custom certificate
+	serverCertTmpl, err := certTemplate()
+	require.NoError(t, err)
+
+	serverCertTmpl.Subject.CommonName = "server.test.name"
+	serverCertTmpl.EmailAddresses = []string{"server-unittest@example.com"}
+
+	serverTransport.identity, err = NewIdentity(serverKey, WithCertTemplate(serverCertTmpl))
+	require.NoError(t, err)
+
+	t.Run("custom TLS with extension not critical", func(t *testing.T) {
+		handshake(t, clientTransport, serverTransport)
+	})
+
+	t.Run("custom TLS with extension critical", func(t *testing.T) {
+		extensionCritical = true
+		t.Cleanup(func() { extensionCritical = false })
+
+		handshake(t, clientTransport, serverTransport)
 	})
 }
 

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -128,7 +128,7 @@ func TestHandshakeSucceeds(t *testing.T) {
 	require.NoError(t, err)
 
 	clientCertTmlp.Subject.CommonName = "client.test.name"
-	clientCertTmlp.EmailAddresses = []string{"server-unittest@example.com"}
+	clientCertTmlp.EmailAddresses = []string{"client-unittest@example.com"}
 
 	clientTransport.identity, err = NewIdentity(clientKey, WithCertTemplate(clientCertTmlp))
 	require.NoError(t, err)


### PR DESCRIPTION
This PR was originally opened here https://github.com/libp2p/go-libp2p-tls/pull/99 and relates to this issue: fixes https://github.com/libp2p/go-libp2p/issues/1538

## Context

`libp2ptls.NewIdentity` generates a new `Identity` which includes an x509 certificate with a special signed extension which ties the TLS key pair to a libp2p network identity. In flow, we use this key pair to secure a gRPC interface which is accessible to nodes on the network as well as external public clients, allowing them to verify that they've connected to the correct staked node.

The current implementation of `NewIdentity` does not support customizing the certificate template, and uses default options that aren't compatible with standard TLS clients (e.g. Subject doesn't include a `cn` field).

## Proposal

This PR refactors keyToCertificate into 3 methods

* `GenerateSignedExtension` (exported), which generates the signed extension
* `certTemplate` which returns the default certificate template used to generate the self-signed certificate,
* `keyToCertificate`, which accepts an `x509.Certificate` template, adds the signed extension and returns the `tls.Certificate` object.

This PR also adds a new optional parameter to `NewIdentity`, which can provide a custom certificate template.

The changes are intended to be backwards compatible and add the ability for a caller to specify the x509 certificate fields they wish to include in the generated certificate.