### PR TITLE
quic: deflake the holepunching test

### DIFF
--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -550,7 +550,13 @@ func TestHolePunching(t *testing.T) {
 	// Make sure the server role (the dial on t2) has progressed far enough.
 	// If it hasn't created the hole punch map entry, the connection will be accepted as a regular connection,
 	// which would make this test fail.
-	time.Sleep(25 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		tr := t2.(*transport)
+		tr.holePunchingMx.Lock()
+		defer tr.holePunchingMx.Unlock()
+		return len(tr.holePunching) > 0
+	}, time.Second, 10*time.Millisecond)
+
 	conn1, err := t1.Dial(
 		network.WithSimultaneousConnect(context.Background(), true, ""),
 		ln2.Multiaddr(),


### PR DESCRIPTION
Unfortunately, this uses an unexported member variable, but the only option is a long timeout.