### PR TITLE
quic: increase timeout in hole punching test

### DIFF
--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -574,7 +574,7 @@ func TestHolePunching(t *testing.T) {
 		default:
 			return false
 		}
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 	defer conn2.Close()
 	require.Equal(t, conn2.RemotePeer(), serverID)
 	ln1.Close()


### PR DESCRIPTION
Fixes #1492.

I struggled to reproduce this in any environment. A QUIC handshake is mildly expensive, I can accept that it occasionally takes longer than 100ms on CI. 