### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,74 @@
+version: 2.1
+
+orbs:
+  os-detect: circleci/os-detect@0.3.0
+  go: circleci/go@1.7.1
+  win: circleci/windows@4.1.1
+
+executors:
+  linux: &linux-executor
+    # This needs to be a machine image (not docker) so that ipv6 is supported.
+    machine:
+      image: ubuntu-2004:current
+  macos: &macos-executor
+    macos:
+      xcode: 13.3.1
+
+jobs:
+  test:
+    parameters:
+      os:
+        type: executor
+      go-version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout
+      - run:
+          name: Install Go
+          command: |
+              cd $HOME
+
+              # Find correct Go version
+              GO_VERSION=$(curl 'https://go.dev/dl/?mode=json&include=stable' | jq -r .[].version | grep $(echo "<< parameters.go-version >>" | sed "s/\./\\\./g" |  sed "s/\\\.x/\.*/"))
+              HOST_OS=$(uname | awk '{print tolower($0)}')
+              GO_ARCHIVE_EXTENSION="tar.gz"
+              if $(echo $HOST_OS | grep --quiet -i msys); then
+                HOST_OS=windows
+                GO_ARCHIVE_EXTENSION="zip"
+              fi
+              curl -L https://go.dev/dl/$GO_VERSION.$HOST_OS-amd64.$GO_ARCHIVE_EXTENSION > go.$GO_ARCHIVE_EXTENSION
+
+              if [[ "$HOST_OS" == "windows" ]]; then
+                unzip go;
+              else
+                tar -xzf go.tar.gz;
+              fi
+
+              echo 'export PATH=$HOME/go/bin:$PATH' >> $BASH_ENV
+      - go/load-cache
+      - go/mod-download
+      - go/save-cache
+      - run: go version
+      - run: go test -v -coverprofile=module-coverage.txt -coverpkg=./... ./...
+      - when:
+          condition:
+            equal: [*linux-executor, << parameters.os >> ]
+          steps:
+            # Only run race detector on linux. Remnant of GH actions running slowly on macOS and windows VMs
+            - run: go test -v -race ./...
+            # Test 32 bit linux
+            - run: GOARCH=386 go test -v ./...
+
+workflows:
+  main:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              os:
+                - linux
+                - macos
+                - name: win/default
+                  shell: bash.exe
+              go-version: ["1.17.x", "1.18.x"]

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -120,6 +120,7 @@ func newBrokenRelay(t *testing.T, workAfter int) host.Host {
 }
 
 func TestSingleRelay(t *testing.T) {
+	t.Skip("This test is broken since if you wait long enough you do add more relays. See https://github.com/libp2p/go-libp2p/issues/1440")
 	const numPeers = 5
 	peerChan := make(chan peer.AddrInfo)
 	done := make(chan struct{})
@@ -146,7 +147,7 @@ func TestSingleRelay(t *testing.T) {
 	// test that we don't add any more relays
 	require.Never(t, func() bool {
 		return len(ma.FilterAddrs(h.Addrs(), isRelayAddr)) != 1
-	}, 200*time.Millisecond, 50*time.Millisecond)
+	}, 3*time.Second, 50*time.Millisecond)
 }
 
 func TestPreferRelayV2(t *testing.T) {
@@ -174,6 +175,7 @@ func TestPreferRelayV2(t *testing.T) {
 }
 
 func TestWaitForCandidates(t *testing.T) {
+	t.Skip("Test is currently broken, see: https://github.com/libp2p/go-libp2p/issues/1384")
 	peerChan := make(chan peer.AddrInfo)
 	h := newPrivateNode(t,
 		autorelay.WithPeerSource(peerChan),

--- a/p2p/net/swarm/testing/testing.go
+++ b/p2p/net/swarm/testing/testing.go
@@ -178,6 +178,7 @@ func GenSwarm(t *testing.T, opts ...Option) *swarm.Swarm {
 	if !cfg.dialOnly {
 		s.Peerstore().AddAddrs(p.ID, s.ListenAddresses(), peerstore.PermanentAddrTTL)
 	}
+	t.Cleanup(func() { s.Close() })
 	return s
 }
 

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -829,12 +829,13 @@ func TestLargeIdentifyMessage(t *testing.T) {
 		t.Fatal("should have no connections")
 	}
 
-	t.Log("testing addrs just after disconnect")
-	// addresses don't immediately expire on disconnect, so we should still have them
-	testKnowsAddrs(t, h2, h1p, h1.Addrs())
-	testKnowsAddrs(t, h1, h2p, h2.Addrs())
-	testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p))
-	testHasCertifiedAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))
+	// Removing this check because of: https://github.com/libp2p/go-libp2p/issues/1164#issuecomment-1130232184
+	// t.Log("testing addrs just after disconnect")
+	// // addresses don't immediately expire on disconnect, so we should still have them
+	// testKnowsAddrs(t, h2, h1p, h1.Addrs())
+	// testKnowsAddrs(t, h1, h2p, h2.Addrs())
+	// testHasCertifiedAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p))
+	// testHasCertifiedAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))
 
 	// the addrs had their TTLs reduced on disconnect, and
 	// will be forgotten soon after


### PR DESCRIPTION
This adds a circle ci build that runs our test matrix for {Windows, macOS, Linux}⨯{go1.17,go1.18}.

I think we should merge this so we can see how the flakiness compares with GH Actions. Then later we can decide if we want to switch or not.

Some tests were skipped in this PR to minimize noise. Those tests are tracked here: https://github.com/libp2p/go-libp2p/issues/1505

### Motivation
We've been seeing a lot of flakiness around timings in tests. Yes, generally relying on time in tests is not ideal, but there are somethings that should happen _eventually_. [For example](https://github.com/libp2p/go-libp2p/pull/1487#pullrequestreview-974406773) takes over 100ms to check if the GC is running.

If CircleCI saves us from having to deal with a lot of these flaky conditions it seems worth the switch. However if ipdx comes along with another solution I'm happy to switch to that as well. In the mean time I'd like to have us unblocked from flaky test land.