### PR TITLE
tcp: limit the number of connections in tcp suite test on non-linux hosts

### DIFF
--- a/p2p/transport/testsuite/stream_suite.go
+++ b/p2p/transport/testsuite/stream_suite.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -417,19 +418,15 @@ func SubtestStress1Conn100Stream100Msg(t *testing.T, ta, tb transport.Transport,
 	})
 }
 
-func SubtestStress50Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+func SubtestStressManyConn10Stream50Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	connNum := 5
+	if runtime.GOOS == "linux" {
+		// Linux can handle a higher number of conns here than other platforms in CI.
+		// See https://github.com/libp2p/go-libp2p/issues/1498.
+		connNum = 50
+	}
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
-		ConnNum:   50,
-		StreamNum: 10,
-		MsgNum:    50,
-		MsgMax:    100,
-		MsgMin:    100,
-	})
-}
-
-func SubtestStress5Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
-	SubtestStress(t, ta, tb, maddr, peerA, Options{
-		ConnNum:   5,
+		ConnNum:   connNum,
 		StreamNum: 10,
 		MsgNum:    50,
 		MsgMax:    100,

--- a/p2p/transport/testsuite/stream_suite.go
+++ b/p2p/transport/testsuite/stream_suite.go
@@ -427,6 +427,16 @@ func SubtestStress50Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, 
 	})
 }
 
+func SubtestStress5Conn10Stream50Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
+	SubtestStress(t, ta, tb, maddr, peerA, Options{
+		ConnNum:   5,
+		StreamNum: 10,
+		MsgNum:    50,
+		MsgMax:    100,
+		MsgMin:    100,
+	})
+}
+
 func SubtestStress1Conn1000Stream10Msg(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID) {
 	SubtestStress(t, ta, tb, maddr, peerA, Options{
 		ConnNum:   1,

--- a/p2p/transport/testsuite/utils_suite.go
+++ b/p2p/transport/testsuite/utils_suite.go
@@ -21,7 +21,7 @@ var Subtests = []func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiad
 	SubtestStress1Conn1Stream1Msg,
 	SubtestStress1Conn1Stream100Msg,
 	SubtestStress1Conn100Stream100Msg,
-	SubtestStress5Conn10Stream50Msg,
+	SubtestStressManyConn10Stream50Msg,
 	SubtestStress1Conn1000Stream10Msg,
 	SubtestStress1Conn100Stream100Msg10MB,
 	SubtestStreamOpenStress,
@@ -36,13 +36,6 @@ func SubtestTransport(t *testing.T, ta, tb transport.Transport, addr string, pee
 	maddr, err := ma.NewMultiaddr(addr)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	if runtime.GOOS == "linux" {
-		// Only run this test on Linux since macOS runs into buffering issues on CI
-		// with this many connections. See
-		// https://github.com/libp2p/go-libp2p/issues/1498.
-		Subtests = append(Subtests, SubtestStress50Conn10Stream50Msg)
 	}
 
 	for _, f := range Subtests {

--- a/p2p/transport/testsuite/utils_suite.go
+++ b/p2p/transport/testsuite/utils_suite.go
@@ -21,7 +21,7 @@ var Subtests = []func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiad
 	SubtestStress1Conn1Stream1Msg,
 	SubtestStress1Conn1Stream100Msg,
 	SubtestStress1Conn100Stream100Msg,
-	SubtestStress50Conn10Stream50Msg,
+	SubtestStress5Conn10Stream50Msg,
 	SubtestStress1Conn1000Stream10Msg,
 	SubtestStress1Conn100Stream100Msg10MB,
 	SubtestStreamOpenStress,
@@ -37,6 +37,14 @@ func SubtestTransport(t *testing.T, ta, tb transport.Transport, addr string, pee
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if runtime.GOOS == "linux" {
+		// Only run this test on Linux since macOS runs into buffering issues on CI
+		// with this many connections. See
+		// https://github.com/libp2p/go-libp2p/issues/1498.
+		Subtests = append(Subtests, SubtestStress50Conn10Stream50Msg)
+	}
+
 	for _, f := range Subtests {
 		t.Run(getFunctionName(f), func(t *testing.T) {
 			f(t, ta, tb, maddr, peerA)


### PR DESCRIPTION
Fixes #1498

Reduces the 50 conn test to 5 conns. Then runs the 50 conn test on linux only. See the linked issue for more context.