### PR TITLE
swarm: fix flaky TestDialExistingConnection test

### DIFF
--- a/p2p/net/swarm/dial_test.go
+++ b/p2p/net/swarm/dial_test.go
@@ -479,7 +479,10 @@ func TestDialExistingConnection(t *testing.T) {
 	s1 := swarms[0]
 	s2 := swarms[1]
 
-	s1.Peerstore().AddAddrs(s2.LocalPeer(), s2.ListenAddresses(), peerstore.PermanentAddrTTL)
+	// Only use one of the addresses here.
+	// Otherwise, we might dial TCP and QUIC simultaneously here, and end up with two connections,
+	// if the handshake latencies line up exactly.
+	s1.Peerstore().AddAddrs(s2.LocalPeer(), s2.ListenAddresses()[:1], peerstore.PermanentAddrTTL)
 
 	c1, err := s1.DialPeer(context.Background(), s2.LocalPeer())
 	require.NoError(t, err)
@@ -489,7 +492,7 @@ func TestDialExistingConnection(t *testing.T) {
 
 	// can't use require.Equal here, as this does a deep comparison
 	if c1 != c2 {
-		t.Fatal("expecting the same connection from both dials")
+		t.Fatalf("expecting the same connection from both dials, got %s <-> %s vs %s <-> %s", c1.LocalMultiaddr(), c1.RemoteMultiaddr(), c2.LocalMultiaddr(), c2.RemoteMultiaddr())
 	}
 }
 


### PR DESCRIPTION
Fixes #1504.

Our good old friend, the simultaneous establishment of a TCP and a QUIC connection again...