### PR TITLE
backoff: fix flaky tests in backoff cache

### DIFF
--- a/p2p/discovery/mocks/mocks.go
+++ b/p2p/discovery/mocks/mocks.go
@@ -14,23 +14,6 @@ type clock interface {
 	Now() time.Time
 }
 
-type MockClock struct {
-	currentTime time.Time
-	mu          sync.Mutex
-}
-
-func (m *MockClock) Now() time.Time {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.currentTime
-}
-
-func (m *MockClock) Sleep(d time.Duration) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.currentTime = m.currentTime.Add(d)
-}
-
 type MockDiscoveryServer struct {
 	mx    sync.Mutex
 	db    map[string]map[peer.ID]*discoveryRegistration

--- a/p2p/discovery/routing/routing_test.go
+++ b/p2p/discovery/routing/routing_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mocks"
 	"github.com/libp2p/go-libp2p/p2p/discovery/util"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/blank"
@@ -115,7 +116,8 @@ func TestDiscoveryRouting(t *testing.T) {
 	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))
 
-	dserver := mocks.NewDiscoveryServer()
+	clock := clock.NewMock()
+	dserver := mocks.NewDiscoveryServer(clock)
 	d1 := mocks.NewDiscoveryClient(h1, dserver)
 	d2 := mocks.NewDiscoveryClient(h2, dserver)
 


### PR DESCRIPTION
Fixes #1502 by introducing a mocked clock. Time can be incremented in the mock clock and things check the clocks time via `.Now()`. If no clock is passed in, the default realClock uses `time.Now`

This means that these tests are not dependent on actual wall clock times, but our monotonically increasing mock clock.

This PR also fixes a subtle bug that would cause the limit of a `sendingChs` to be ignored. And a bug that prevented other `sendingChs` from getting sent data.

