### PR TITLE
autonat: return E_DIAL_REFUSED when skipping dial

### DIFF
--- a/p2p/host/autonat/autonat_test.go
+++ b/p2p/host/autonat/autonat_test.go
@@ -37,7 +37,7 @@ func sayPrivateStreamHandler(t *testing.T) network.StreamHandler {
 		w := protoio.NewDelimitedWriter(s)
 		res := pb.Message{
 			Type:         pb.Message_DIAL_RESPONSE.Enum(),
-			DialResponse: newDialResponseError(pb.Message_E_DIAL_ERROR, "no dialable addresses"),
+			DialResponse: newDialResponseError(pb.Message_E_DIAL_ERROR, "dial failed"),
 		}
 		w.WriteMsg(&res)
 	}

--- a/p2p/host/autonat/client.go
+++ b/p2p/host/autonat/client.go
@@ -31,6 +31,10 @@ type client struct {
 
 // DialBack asks peer p to dial us back on all addresses returned by the addrFunc.
 // It blocks until we've received a response from the peer.
+//
+// Note: A returned error Message_E_DIAL_ERROR does not imply that the server
+// actually performed a dial attempt. Servers that run a version < v0.20.0 also
+// return Message_E_DIAL_ERROR if the dial was skipped due to the dialPolicy.
 func (c *client) DialBack(ctx context.Context, p peer.ID) (ma.Multiaddr, error) {
 	s, err := c.h.NewStream(ctx, p, AutoNATProto)
 	if err != nil {

--- a/p2p/host/autonat/svc.go
+++ b/p2p/host/autonat/svc.go
@@ -126,7 +126,8 @@ func (as *autoNATService) handleDial(p peer.ID, obsaddr ma.Multiaddr, mpi *pb.Me
 	// need to know their public IP address, and it needs to be different from our public IP
 	// address.
 	if as.config.dialPolicy.skipDial(obsaddr) {
-		return newDialResponseError(pb.Message_E_DIAL_ERROR, "refusing to dial peer with blocked observed address")
+		// Note: versions < v0.20.0 return Message_E_DIAL_ERROR here, thus we can not rely on this error code.
+		return newDialResponseError(pb.Message_E_DIAL_REFUSED, "refusing to dial peer with blocked observed address")
 	}
 
 	// Determine the peer's IP address.
@@ -187,7 +188,8 @@ func (as *autoNATService) handleDial(p peer.ID, obsaddr ma.Multiaddr, mpi *pb.Me
 	}
 
 	if len(addrs) == 0 {
-		return newDialResponseError(pb.Message_E_DIAL_ERROR, "no dialable addresses")
+		// Note: versions < v0.20.0 return Message_E_DIAL_ERROR here, thus we can not rely on this error code.
+		return newDialResponseError(pb.Message_E_DIAL_REFUSED, "no dialable addresses")
 	}
 
 	return as.doDial(peer.AddrInfo{ID: p, Addrs: addrs})

--- a/p2p/host/autonat/svc_test.go
+++ b/p2p/host/autonat/svc_test.go
@@ -44,7 +44,7 @@ func makeAutoNATClient(t *testing.T) (host.Host, Client) {
 }
 
 // Note: these tests assume that the host has only private network addresses!
-func TestAutoNATServiceDialError(t *testing.T) {
+func TestAutoNATServiceDialRefused(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -64,7 +64,7 @@ func TestAutoNATServiceDialError(t *testing.T) {
 		t.Fatal("Dial back succeeded unexpectedly!")
 	}
 
-	if !IsDialError(err) {
+	if !IsDialRefused(err) {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Discussed in https://github.com/libp2p/specs/issues/411:
When skipping a dial as a server, we should return E_DIAL_REFUSED instead of E_DIAL_ERROR because we never actually tried to dial the client.

This PR replaces #1482.