### PR TITLE
fix: mkreleaselog exclude autogenerated files

### DIFF
--- a/scripts/mkreleaselog
+++ b/scripts/mkreleaselog
@@ -29,7 +29,7 @@ AUTHORS=(
 
 [[ -n "${REPO_FILTER+x}" ]] || REPO_FILTER="github.com/(${$(printf "|%s" "${AUTHORS[@]}"):1})"
 
-[[ -n "${IGNORED_FILES+x}" ]] || IGNORED_FILES='^\(\.gx\|package\.json\|\.travis\.yml\|go.mod\|go\.sum|\.github|\.circleci\)$'
+[[ -n "${IGNORED_FILES+x}" ]] || IGNORED_FILES='^\(\.gx\|package\.json\|\.travis\.yml\|go.mod\|go\.sum|\.github|\.circleci|\.gen\.go\)$'
 
 NL=$'\n'
 


### PR DESCRIPTION
Fix this:
![Capture d’écran du 2022-05-26 15-10-41](https://user-images.githubusercontent.com/24391983/170494213-68b49758-9863-4745-bb99-d84eb0c96be0.png)

