### PR TITLE
connmgr: Add sanity check to test

### DIFF
--- a/p2p/net/connmgr/decay_test.go
+++ b/p2p/net/connmgr/decay_test.go
@@ -163,6 +163,7 @@ func TestLinearDecayOverwrite(t *testing.T) {
 	_ = tag1.Bump(id, 1000)
 	waitForTag(t, mgr, id)
 
+	require.Equal(t, 1000, mgr.GetTagInfo(id).Value)
 	mockClock.Add(250 * time.Millisecond)
 	require.Equal(t, 500, mgr.GetTagInfo(id).Value)
 


### PR DESCRIPTION
I haven't been able to reproduce #1369. And this test already uses a mock clock. I'm adding this assertion with the hope that maybe it helps debug this issue in the future.


