### PR TITLE
change the default key type to Ed25519

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -56,7 +56,7 @@ var DefaultPeerstore Option = func(cfg *Config) error {
 
 // RandomIdentity generates a random identity. (default behaviour)
 var RandomIdentity = func(cfg *Config) error {
-	priv, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cryptographically, there's no reason to prefer RSA over Ed25519 (quite the contrary, actually!).

The peer ID spec says that all implementations MUST support Ed25519, so this _should_ be a safe change to make.

@vyzo @Stebalien Are you aware of any backwards compatibility issues this might cause (that wouldn't be better handled by the application that requires backwards compatibility)?