### PR TITLE
chore: log autorelay start failure error

### DIFF
--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -101,7 +101,7 @@ func (r *AutoRelay) background() {
 			switch evt.Reachability {
 			case network.ReachabilityPrivate, network.ReachabilityUnknown:
 				if err := r.relayFinder.Start(); err != nil {
-					log.Error("failed to start relay finder")
+					log.Errorw("failed to start relay finder", "error", err)
 				}
 			case network.ReachabilityPublic:
 				r.relayFinder.Stop()


### PR DESCRIPTION
I got this error from go-ipfs (probably because I put my laptop to sleep?) but I couldn't get any details.