### PR TITLE
swarm: add ListenClose

### DIFF
--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -110,6 +110,7 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 
 			if ok {
 				list.Close()
+				log.Errorf("swarm listener unintentionally closed")
 			}
 
 			// signal to our notifiees on listen close.
@@ -121,17 +122,6 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 		for {
 			c, err := list.Accept()
 			if err != nil {
-				if s.ctx.Err() == nil {
-					s.listeners.Lock()
-					_, ok := s.listeners.m[list]
-					s.listeners.Unlock()
-
-					if ok {
-						// only log if the swarm is still running and the
-						// listener has not been closed intentionally.
-						log.Errorf("swarm listener accept error: %s", err)
-					}
-				}
 				return
 			}
 

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -542,3 +542,57 @@ func TestResourceManagerAcceptStream(t *testing.T) {
 	}
 	require.EqualError(t, err, "stream reset")
 }
+
+func TestListenCloseCount(t *testing.T) {
+	s := GenSwarm(t, OptDialOnly)
+	addrsToListen := []ma.Multiaddr{
+		ma.StringCast("/ip4/0.0.0.0/tcp/0"),
+		ma.StringCast("/ip4/0.0.0.0/udp/0/quic"),
+	}
+
+	if err := s.Listen(addrsToListen...); err != nil {
+		t.Fatal(err)
+	}
+	listenedAddrs := s.ListenAddresses()
+	require.Equal(t, 2, len(listenedAddrs))
+
+	s.ListenClose(listenedAddrs...)
+	time.Sleep(time.Millisecond) // wait for deferred listener deletion
+
+	remainingAddrs := s.ListenAddresses()
+	require.Equal(t, 0, len(remainingAddrs))
+}
+
+func TestListenCloseLog(t *testing.T) {
+	var logs bytes.Buffer
+
+	// pipe logs to buffer
+	lr := logging.NewPipeReader(logging.PipeFormat(logging.PlaintextOutput))
+	defer lr.Close()
+	go io.Copy(&logs, lr)
+
+	s := GenSwarm(t, OptDialOnly)
+	addrsToListen := []ma.Multiaddr{
+		ma.StringCast("/ip4/0.0.0.0/tcp/0"),
+		ma.StringCast("/ip4/0.0.0.0/udp/0/quic"),
+	}
+
+	if err := s.Listen(addrsToListen...); err != nil {
+		t.Fatal(err)
+	}
+	listenedAddrs := s.ListenAddresses() // closed 0, opened: 2
+
+	s.ListenClose(listenedAddrs[0]) // closed 1, opened: 1
+	time.Sleep(time.Millisecond)    // wait for deferred listener deletion
+
+	require.False(t, containsError(logs, swarm.ErrSwarmListenerAcceptError))
+
+	s.ListenClose(listenedAddrs[1]) // closed 2, opened: 0
+	time.Sleep(time.Millisecond)    // wait for deferred listener deletion
+
+	require.True(t, containsError(logs, swarm.ErrSwarmListenerAcceptError))
+}
+
+func containsError(logs bytes.Buffer, err error) bool {
+	return strings.Contains(logs.String(), err.Error())
+}

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -557,42 +557,7 @@ func TestListenCloseCount(t *testing.T) {
 	require.Equal(t, 2, len(listenedAddrs))
 
 	s.ListenClose(listenedAddrs...)
-	time.Sleep(time.Millisecond) // wait for deferred listener deletion
 
 	remainingAddrs := s.ListenAddresses()
 	require.Equal(t, 0, len(remainingAddrs))
-}
-
-func TestListenCloseLog(t *testing.T) {
-	var logs bytes.Buffer
-
-	// pipe logs to buffer
-	lr := logging.NewPipeReader(logging.PipeFormat(logging.PlaintextOutput))
-	defer lr.Close()
-	go io.Copy(&logs, lr)
-
-	s := GenSwarm(t, OptDialOnly)
-	addrsToListen := []ma.Multiaddr{
-		ma.StringCast("/ip4/0.0.0.0/tcp/0"),
-		ma.StringCast("/ip4/0.0.0.0/udp/0/quic"),
-	}
-
-	if err := s.Listen(addrsToListen...); err != nil {
-		t.Fatal(err)
-	}
-	listenedAddrs := s.ListenAddresses() // closed 0, opened: 2
-
-	s.ListenClose(listenedAddrs[0]) // closed 1, opened: 1
-	time.Sleep(time.Millisecond)    // wait for deferred listener deletion
-
-	require.False(t, containsError(logs, swarm.ErrSwarmListenerAcceptError))
-
-	s.ListenClose(listenedAddrs[1]) // closed 2, opened: 0
-	time.Sleep(time.Millisecond)    // wait for deferred listener deletion
-
-	require.True(t, containsError(logs, swarm.ErrSwarmListenerAcceptError))
-}
-
-func containsError(logs bytes.Buffer, err error) bool {
-	return strings.Contains(logs.String(), err.Error())
 }


### PR DESCRIPTION
Recreating https://github.com/libp2p/go-libp2p-swarm/pull/319.

Add the missing `ListenClose` method, as it is impossible to close existing listeners.

Useful in many situations, especially on systems that no longer handle listeners after the operating system has suspended them without closing them, when applications run in the background for example (iOS).

This offers the possibility to update the network listener without completely restarting the swarm.

I think this method should also be added to the network interface.

The decision is yours