### PR TITLE
pstoremanager: fix test timeout

### DIFF
--- a/p2p/host/pstoremanager/pstoremanager_test.go
+++ b/p2p/host/pstoremanager/pstoremanager_test.go
@@ -86,11 +86,18 @@ func TestClose(t *testing.T) {
 
 	emitter, err := eventBus.Emitter(new(event.EvtPeerConnectednessChanged))
 	require.NoError(t, err)
+
+	sub, err := eventBus.Subscribe(&event.EvtPeerConnectednessChanged{})
+	require.NoError(t, err)
+
 	require.NoError(t, emitter.Emit(event.EvtPeerConnectednessChanged{
 		Peer:          "foobar",
 		Connectedness: network.NotConnected,
 	}))
-	time.Sleep(10 * time.Millisecond) // make sure the event is sent before we close
+
+	// make sure the event is sent before we close
+	<-sub.Out()
+
 	done := make(chan struct{})
 	pstore.EXPECT().RemovePeer(peer.ID("foobar")).Do(func(peer.ID) { close(done) })
 	require.NoError(t, man.Close())

--- a/p2p/host/pstoremanager/pstoremanager_test.go
+++ b/p2p/host/pstoremanager/pstoremanager_test.go
@@ -96,10 +96,18 @@ func TestClose(t *testing.T) {
 	}))
 
 	// make sure the event is sent before we close
-	<-sub.Out()
+	select {
+	case <-sub.Out():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Hit timeout")
+	}
 
 	done := make(chan struct{})
 	pstore.EXPECT().RemovePeer(peer.ID("foobar")).Do(func(peer.ID) { close(done) })
 	require.NoError(t, man.Close())
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Hit timeout")
+	}
 }


### PR DESCRIPTION
Fixes #1585 by actually making sure the event is sent before we close, instead of waiting and expecting the event to be sent by then.
