### PR TITLE
feat: allow dialing wss peers using DNS multiaddrs

### DIFF
--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -23,7 +23,7 @@ var WsFmt = mafmt.And(mafmt.TCP, mafmt.Base(ma.P_WS))
 
 // This is _not_ WsFmt because we want the transport to stick to dialing fully
 // resolved addresses.
-var dialMatcher = mafmt.And(mafmt.IP, mafmt.Base(ma.P_TCP), mafmt.Or(mafmt.Base(ma.P_WS), mafmt.Base(ma.P_WSS)))
+var dialMatcher = mafmt.And(mafmt.Or(mafmt.IP, mafmt.DNS), mafmt.Base(ma.P_TCP), mafmt.Or(mafmt.Base(ma.P_WS), mafmt.Base(ma.P_WSS)))
 
 func init() {
 	manet.RegisterFromNetAddr(ParseWebsocketNetAddr, "websocket")


### PR DESCRIPTION
fixes #1593

This fixes an issue where the WSS dialer can only handle IP multiaddrs not DNS https://github.com/libp2p/go-libp2p/blob/d7ba37217c6f1a0d739666f78ac19a87728a7280/p2p/transport/websocket/websocket.go#L26

A couple areas to consider here for improvement (recommendations or maintainers pushing commits to this PR are welcome).
- [ ] We should use the host's DNS resolver rather than the OS resolver
- [ ] The basic host should probably not resolve the DNS addresses covered by WSS, or the dialer should at least prioritize DNS WSS dials over IP ones