### PR TITLE
logging: Add canonical log for misbehaving peers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/libp2p/go-eventbus v0.2.1
 	github.com/libp2p/go-libp2p-asn-util v0.2.0
 	github.com/libp2p/go-libp2p-circuit v0.6.0
-	github.com/libp2p/go-libp2p-core v0.16.1
+	github.com/libp2p/go-libp2p-core v0.17.0
 	github.com/libp2p/go-libp2p-peerstore v0.7.0
 	github.com/libp2p/go-libp2p-resource-manager v0.3.0
 	github.com/libp2p/go-libp2p-testing v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/libp2p/go-libp2p-core v0.6.0/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX
 github.com/libp2p/go-libp2p-core v0.10.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
 github.com/libp2p/go-libp2p-core v0.12.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
 github.com/libp2p/go-libp2p-core v0.14.0/go.mod h1:tLasfcVdTXnixsLB0QYaT1syJOhsbrhG7q6pGrHtBg8=
-github.com/libp2p/go-libp2p-core v0.16.1 h1:bWoiEBqVkpJ13hbv/f69tHODp86t6mvc4fBN4DkK73M=
-github.com/libp2p/go-libp2p-core v0.16.1/go.mod h1:O3i/7y+LqUb0N+qhzXjBjjpchgptWAVMG1Voegk7b4c=
+github.com/libp2p/go-libp2p-core v0.17.0 h1:QGU8mlxHytwTc4pq/aVQX9VDoAPiCHxfe/oOSwF+YDg=
+github.com/libp2p/go-libp2p-core v0.17.0/go.mod h1:h/iAbFij28ASmI+tvXfjoipg1g2N33O4UN6LIb6QfoU=
 github.com/libp2p/go-libp2p-mplex v0.5.0/go.mod h1:eLImPJLkj3iG5t5lq68w3Vm5NAQ5BcKwrrb2VmOYb3M=
 github.com/libp2p/go-libp2p-peerstore v0.6.0/go.mod h1:DGEmKdXrcYpK9Jha3sS7MhqYdInxJy84bIPtSu65bKc=
 github.com/libp2p/go-libp2p-peerstore v0.7.0 h1:2iIUwok3vtmnWJTZeTeLgnBO6GbkXcwSRwgZHEKrQZs=

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/canonicallog"
 	"github.com/libp2p/go-libp2p/p2p/net/pnet"
 
 	"github.com/libp2p/go-libp2p-core/connmgr"
@@ -175,7 +174,6 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	smconn, err := u.setupMuxer(ctx, sconn, server, connScope.PeerScope())
 	if err != nil {
 		sconn.Close()
-		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), "muxer", err, "failed to setup muxer")
 		return nil, fmt.Errorf("failed to negotiate stream multiplexer: %s", err)
 	}
 

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -148,7 +148,6 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	sconn, server, err := u.setupSecurity(ctx, conn, p, dir)
 	if err != nil {
 		conn.Close()
-		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), "security-handshake", err, "failed to negotiate security protocol")
 		return nil, fmt.Errorf("failed to negotiate security protocol: %s", err)
 	}
 

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/canonicallog"
 	"github.com/libp2p/go-libp2p/p2p/net/pnet"
 
 	"github.com/libp2p/go-libp2p-core/connmgr"
@@ -147,6 +148,7 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	sconn, server, err := u.setupSecurity(ctx, conn, p, dir)
 	if err != nil {
 		conn.Close()
+		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), err, "failed to negotiate security protocol")
 		return nil, fmt.Errorf("failed to negotiate security protocol: %s", err)
 	}
 
@@ -174,6 +176,7 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	smconn, err := u.setupMuxer(ctx, sconn, server, connScope.PeerScope())
 	if err != nil {
 		sconn.Close()
+		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), err, "failed to setup muxer")
 		return nil, fmt.Errorf("failed to negotiate stream multiplexer: %s", err)
 	}
 

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -148,7 +148,7 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	sconn, server, err := u.setupSecurity(ctx, conn, p, dir)
 	if err != nil {
 		conn.Close()
-		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), err, "failed to negotiate security protocol")
+		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), "security-handshake", err, "failed to negotiate security protocol")
 		return nil, fmt.Errorf("failed to negotiate security protocol: %s", err)
 	}
 
@@ -176,7 +176,7 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	smconn, err := u.setupMuxer(ctx, sconn, server, connScope.PeerScope())
 	if err != nil {
 		sconn.Close()
-		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), err, "failed to setup muxer")
+		canonicallog.LogMisbehavingPeerNetAddr(p, conn.RemoteAddr(), "muxer", err, "failed to setup muxer")
 		return nil, fmt.Errorf("failed to negotiate stream multiplexer: %s", err)
 	}
 

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 
+	"github.com/libp2p/go-libp2p-core/canonicallog"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"
@@ -38,7 +39,11 @@ func New(privkey crypto.PrivKey) (*Transport, error) {
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	return newSecureSession(t, ctx, insecure, p, false)
+	c, err := newSecureSession(t, ctx, insecure, p, false)
+	if err != nil {
+		canonicallog.LogMisbehavingPeerNetAddr(p, insecure.RemoteAddr(), "noise-security-handshake", err, "failed security handshake")
+	}
+	return c, err
 }
 
 // SecureOutbound runs the Noise handshake as the initiator.

--- a/p2p/security/tls/transport.go
+++ b/p2p/security/tls/transport.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime/debug"
 
+	"github.com/libp2p/go-libp2p-core/canonicallog"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"
@@ -52,6 +53,7 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer
 	config, keyCh := t.identity.ConfigForPeer(p)
 	cs, err := t.handshake(ctx, tls.Server(insecure, config), keyCh)
 	if err != nil {
+		canonicallog.LogMisbehavingPeerNetAddr(p, insecure.RemoteAddr(), "tls-security-handshake", err, "failed security handshake")
 		insecure.Close()
 	}
 	return cs, err


### PR DESCRIPTION
Adds logging when a peer fails our security handshake or fails to setup a muxer