### PR TITLE
fix: return the best _acceptable_ conn in NewStream

### DIFF
--- a/p2p/net/swarm/dial_worker.go
+++ b/p2p/net/swarm/dial_worker.go
@@ -89,9 +89,9 @@ loop:
 				return
 			}
 
-			c := w.s.bestAcceptableConnToPeer(req.ctx, w.peer)
-			if c != nil {
-				req.resch <- dialResponse{conn: c}
+			c, err := w.s.bestAcceptableConnToPeer(req.ctx, w.peer)
+			if c != nil || err != nil {
+				req.resch <- dialResponse{conn: c, err: err}
 				continue loop
 			}
 
@@ -255,7 +255,7 @@ func (w *dialWorker) dispatchError(ad *addrDial, err error) {
 			// all addrs have erred, dispatch dial error
 			// but first do a last one check in case an acceptable connection has landed from
 			// a simultaneous dial that started later and added new acceptable addrs
-			c := w.s.bestAcceptableConnToPeer(pr.req.ctx, w.peer)
+			c, _ := w.s.bestAcceptableConnToPeer(pr.req.ctx, w.peer)
 			if c != nil {
 				pr.req.resch <- dialResponse{conn: c}
 			} else {

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -350,7 +350,7 @@ func (s *Swarm) NewStream(ctx context.Context, p peer.ID) (network.Stream, error
 	dials := 0
 	for {
 		// will prefer direct connections over relayed connections for opening streams
-		c := s.bestConnToPeer(p)
+		c := s.bestAcceptableConnToPeer(ctx, p)
 		if c == nil {
 			if nodial, _ := network.GetNoDial(ctx); nodial {
 				return nil, network.ErrNoConn

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -350,7 +350,11 @@ func (s *Swarm) NewStream(ctx context.Context, p peer.ID) (network.Stream, error
 	dials := 0
 	for {
 		// will prefer direct connections over relayed connections for opening streams
-		c := s.bestAcceptableConnToPeer(ctx, p)
+		c, err := s.bestAcceptableConnToPeer(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+
 		if c == nil {
 			if nodial, _ := network.GetNoDial(ctx); nodial {
 				return nil, network.ErrNoConn
@@ -447,15 +451,26 @@ func (s *Swarm) bestConnToPeer(p peer.ID) *Conn {
 	return best
 }
 
-func (s *Swarm) bestAcceptableConnToPeer(ctx context.Context, p peer.ID) *Conn {
+// - Returns the best "acceptable" connection, if available.
+// - Returns nothing if no such connection exists, but if we should try dialing anyways.
+// - Returns an error if no such connection exists, but we should not try dialing.
+func (s *Swarm) bestAcceptableConnToPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 	conn := s.bestConnToPeer(p)
-	if conn != nil {
-		forceDirect, _ := network.GetForceDirectDial(ctx)
-		if !forceDirect || isDirectConn(conn) {
-			return conn
-		}
+	if conn == nil {
+		return nil, nil
 	}
-	return nil
+
+	forceDirect, _ := network.GetForceDirectDial(ctx)
+	if forceDirect && !isDirectConn(conn) {
+		return nil, nil
+	}
+
+	useTransient, _ := network.GetUseTransient(ctx)
+	if useTransient || !conn.Stat().Transient {
+		return conn, nil
+	}
+
+	return nil, network.ErrTransientConn
 }
 
 func isDirectConn(c *Conn) bool {

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -248,10 +248,11 @@ func (s *Swarm) dialPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 		return nil, ErrDialToSelf
 	}
 
-	// check if we already have an open (usable) connection first
-	conn := s.bestAcceptableConnToPeer(ctx, p)
-	if conn != nil {
-		return conn, nil
+	// check if we already have an open (usable) connection first, or can't have a usable
+	// connection.
+	conn, err := s.bestAcceptableConnToPeer(ctx, p)
+	if conn != nil || err != nil {
+		return conn, err
 	}
 
 	// apply the DialPeer timeout


### PR DESCRIPTION
Otherwise, we can return, e.g., a transient connection that can't actually be used.

I noticed bitswap was trying to use transient connections, which shouldn't be possible. To really fix this issue, we'd also need to fix #1603 as well, but that's harder.