### PR TITLE
muxer: expose func to create MuxedConn from backing Conn

### DIFF
--- a/p2p/muxer/mplex/conn.go
+++ b/p2p/muxer/mplex/conn.go
@@ -12,6 +12,11 @@ type conn mp.Multiplex
 
 var _ network.MuxedConn = &conn{}
 
+// NewMuxedConn constructs a new Conn from a *mp.Multiplex.
+func NewMuxedConn(m *mp.Multiplex) network.MuxedConn {
+	return (*conn)(m)
+}
+
 func (c *conn) Close() error {
 	return c.mplex().Close()
 }

--- a/p2p/muxer/mplex/transport.go
+++ b/p2p/muxer/mplex/transport.go
@@ -22,5 +22,5 @@ func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope)
 	if err != nil {
 		return nil, err
 	}
-	return (*conn)(m), nil
+	return NewMuxedConn(m), nil
 }

--- a/p2p/muxer/yamux/conn.go
+++ b/p2p/muxer/yamux/conn.go
@@ -13,6 +13,11 @@ type conn yamux.Session
 
 var _ network.MuxedConn = &conn{}
 
+// NewMuxedConn constructs a new MuxedConn from a yamux.Session.
+func NewMuxedConn(m *yamux.Session) network.MuxedConn {
+	return (*conn)(m)
+}
+
 // Close closes underlying yamux
 func (c *conn) Close() error {
 	return c.yamux().Close()

--- a/p2p/muxer/yamux/transport.go
+++ b/p2p/muxer/yamux/transport.go
@@ -45,7 +45,10 @@ func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope)
 	} else {
 		s, err = yamux.Client(nc, t.Config(), scope)
 	}
-	return (*conn)(s), err
+	if err != nil {
+		return nil, err
+	}
+	return NewMuxedConn(s), nil
 }
 
 func (t *Transport) Config() *yamux.Config {


### PR DESCRIPTION
Expose a function to create a MuxedConn from the base type: if a user has a *mp.Multiplex or a *yamux.Session, they should be able to construct the libp2p wrapper without going through the Transport interfaces.