### PR TITLE
chore: use the new multiaddr.Contains function

### DIFF
--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -240,12 +240,7 @@ func TestAllAddrs(t *testing.T) {
 	// should contain localhost and private local addr along with previous listen address
 	require.Len(t, h.AllAddrs(), 3)
 	// Should still contain the original addr.
-	for _, a := range h.AllAddrs() {
-		if a.Equal(firstAddr) {
-			return
-		}
-	}
-	t.Fatal("expected addrs to contain original addr")
+	require.True(t, ma.Contains(h.AllAddrs(), firstAddr), "should still contain the original addr")
 }
 
 // getHostPair gets a new pair of hosts.

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -343,14 +343,7 @@ func (s *Swarm) filterKnownUndialables(p peer.ID, addrs []ma.Multiaddr) []ma.Mul
 	}
 
 	return ma.FilterAddrs(addrs,
-		func(addr ma.Multiaddr) bool {
-			for _, a := range ourAddrs {
-				if a.Equal(addr) {
-					return false
-				}
-			}
-			return true
-		},
+		func(addr ma.Multiaddr) bool { return !ma.Contains(ourAddrs, addr) },
 		s.canDial,
 		// TODO: Consider allowing link-local addresses
 		func(addr ma.Multiaddr) bool { return !manet.IsIP6LinkLocal(addr) },

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -763,15 +763,6 @@ func (ids *idService) consumeObservedAddress(observed []byte, c network.Conn) {
 	ids.observedAddrs.Record(c, maddr)
 }
 
-func addrInAddrs(a ma.Multiaddr, as []ma.Multiaddr) bool {
-	for _, b := range as {
-		if a.Equal(b) {
-			return true
-		}
-	}
-	return false
-}
-
 func signedPeerRecordFromMessage(msg *pb.Identify) (*record.Envelope, error) {
 	if msg.SignedPeerRecord == nil || len(msg.SignedPeerRecord) == 0 {
 		return nil, nil

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -641,14 +641,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 	// Wait for h2 to process the new addr
 	waitForAddrInStream(t, h2AddrStream, lad, 10*time.Second, "h2 did not receive addr change")
 
-	found := false
-	addrs := h2.Peerstore().Addrs(h1p)
-	for _, ad := range addrs {
-		if ad.Equal(lad) {
-			found = true
-		}
-	}
-	require.True(t, found)
+	require.True(t, ma.Contains(h2.Peerstore().Addrs(h1p), lad))
 	require.NotNil(t, getSignedRecord(t, h2, h1p))
 
 	// change addr on host2 and ensure host 1 gets a pus
@@ -661,14 +654,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 	// Wait for h1 to process the new addr
 	waitForAddrInStream(t, h1AddrStream, lad, 10*time.Second, "h1 did not receive addr change")
 
-	found = false
-	addrs = h1.Peerstore().Addrs(h2p)
-	for _, ad := range addrs {
-		if ad.Equal(lad) {
-			found = true
-		}
-	}
-	require.True(t, found)
+	require.True(t, ma.Contains(h1.Peerstore().Addrs(h2p), lad))
 	require.NotNil(t, getSignedRecord(t, h1, h2p))
 
 	// change addr on host2 again
@@ -680,14 +666,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 	// Wait for h1 to process the new addr
 	waitForAddrInStream(t, h1AddrStream, lad2, 10*time.Second, "h1 did not receive addr change")
 
-	found = false
-	addrs = h1.Peerstore().Addrs(h2p)
-	for _, ad := range addrs {
-		if ad.Equal(lad2) {
-			found = true
-		}
-	}
-	require.True(t, found)
+	require.True(t, ma.Contains(h1.Peerstore().Addrs(h2p), lad2))
 	require.NotNil(t, getSignedRecord(t, h1, h2p))
 }
 
@@ -961,13 +940,7 @@ func TestLargePushMessage(t *testing.T) {
 	emitAddrChangeEvt(t, h1)
 
 	require.Eventually(t, func() bool {
-		addrs := h2.Peerstore().Addrs(h1p)
-		for _, ad := range addrs {
-			if ad.Equal(lad) {
-				return true
-			}
-		}
-		return false
+		return ma.Contains(h2.Peerstore().Addrs(h1p), lad)
 	}, time.Second, 10*time.Millisecond)
 	require.NotNil(t, getSignedRecord(t, h2, h1p))
 
@@ -978,13 +951,7 @@ func TestLargePushMessage(t *testing.T) {
 	emitAddrChangeEvt(t, h2)
 
 	require.Eventually(t, func() bool {
-		addrs := h1.Peerstore().Addrs(h2p)
-		for _, ad := range addrs {
-			if ad.Equal(lad) {
-				return true
-			}
-		}
-		return false
+		return ma.Contains(h1.Peerstore().Addrs(h2p), lad)
 	}, time.Second, 10*time.Millisecond)
 	testHasCertifiedAddrs(t, h1, h2p, h2.Addrs())
 
@@ -995,13 +962,7 @@ func TestLargePushMessage(t *testing.T) {
 	emitAddrChangeEvt(t, h2)
 
 	require.Eventually(t, func() bool {
-		addrs := h1.Peerstore().Addrs(h2p)
-		for _, ad := range addrs {
-			if ad.Equal(lad2) {
-				return true
-			}
-		}
-		return false
+		return ma.Contains(h1.Peerstore().Addrs(h2p), lad2)
 	}, time.Second, 10*time.Millisecond)
 	testHasCertifiedAddrs(t, h2, h1p, h1.Addrs())
 }

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -376,7 +376,7 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 	}
 
 	local := conn.LocalMultiaddr()
-	if !addrInAddrs(local, ifaceaddrs) && !addrInAddrs(local, oas.host.Network().ListenAddresses()) {
+	if !ma.Contains(ifaceaddrs, local) && !ma.Contains(oas.host.Network().ListenAddresses(), local) {
 		// not in our list
 		return
 	}

--- a/p2p/protocol/identify/obsaddr_test.go
+++ b/p2p/protocol/identify/obsaddr_test.go
@@ -110,14 +110,7 @@ func TestObsAddrSet(t *testing.T) {
 			return false
 		}
 		for _, aa := range a {
-			var found bool
-			for _, bb := range b {
-				if aa.Equal(bb) {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !ma.Contains(b, aa) {
 				return false
 			}
 		}


### PR DESCRIPTION
No functional change expected, but this is removing 67 LoC. DRY!