### PR TITLE
ci: run testground:ping plan on pull requests

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+name: Interoperability Testing
+
+jobs:
+  run-ping-interop-cross-version:
+    uses: "libp2p/test-plans/.github/workflows/run-composition.yml@master"
+    with:
+      composition_file: "ping/_compositions/go-cross-versions.toml"
+      # NOTE: during a pull request run, github creates a merge commit referenced in `github.sha`
+      # that merge commit is not a regular commit. You won't find it with a regular `git checkout SHA` and
+      # tools like `go get repo@SHA` won't find it.
+      #
+      # As a workaround, we generate a path to the actual pull request's commit, it looks like:
+      # `github.com/external-org/go-libp2p@latest-commit-on-their-branch`
+      custom_git_target: github.com/${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
+      custom_git_reference: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Add a workflow that calls the testground interop testing on every push and pull request.

## Examples

- master: https://github.com/laurentsenta/go-libp2p/runs/7148996579?check_suite_focus=true
- pull request: https://github.com/laurentsenta/go-libp2p/pull/3
  - run: https://github.com/laurentsenta/go-libp2p/runs/7149039457?check_suite_focus=true
  - note the `GitReference=d9f4b4447188fafe7c15b66b70d98b0ba6e0eeb6 GitTarget=github.com/laurentsenta/go-libp2p` parameters in "Run the composition file" job.
- pull request that breaks the ping service: https://github.com/laurentsenta/go-libp2p/pull/4
  - run: https://github.com/laurentsenta/go-libp2p/runs/7149252149?check_suite_focus=true
  - note the `protocol not supported` errors

## Known limitation

- This PR will work with local branches & forks, but it will test the latest commit of the pull request, NOT the merge commit,
- The test takes ~14 minutes for now (5 min setup, 9 min to run),