### PR TITLE
swarm: mark dialing WebTransport addresses as expensive

### DIFF
--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -425,9 +425,10 @@ func isFdConsumingAddr(addr ma.Multiaddr) bool {
 }
 
 func isExpensiveAddr(addr ma.Multiaddr) bool {
-	_, err1 := addr.ValueForProtocol(ma.P_WS)
-	_, err2 := addr.ValueForProtocol(ma.P_WSS)
-	return err1 == nil || err2 == nil
+	_, wsErr := addr.ValueForProtocol(ma.P_WS)
+	_, wssErr := addr.ValueForProtocol(ma.P_WSS)
+	_, wtErr := addr.ValueForProtocol(ma.P_WEBTRANSPORT)
+	return wsErr == nil || wssErr == nil || wtErr == nil
 }
 
 func isRelayAddr(addr ma.Multiaddr) bool {


### PR DESCRIPTION
This is probably an insufficient change, given how many WebTransport nodes we'll see coming up once we enable it by default. But it's better than nothing.