### PR TITLE
examples: fix unresponsive pubsub chat example

### DIFF
--- a/examples/pubsub/chat/ui.go
+++ b/examples/pubsub/chat/ui.go
@@ -121,10 +121,8 @@ func (ui *ChatUI) end() {
 func (ui *ChatUI) refreshPeers() {
 	peers := ui.cr.ListPeers()
 
-	// clear is not threadsafe so we need to take the lock.
-	ui.peersList.Lock()
+	// clear is thread-safe
 	ui.peersList.Clear()
-	ui.peersList.Unlock()
 
 	for _, p := range peers {
 		fmt.Fprintln(ui.peersList, shortID(p))


### PR DESCRIPTION
Update ui for example
examples/pubsub/chat/ui.go:125

Remove unneeded lock on peersList textview.
Clear method already has lock.

```golang
// Clear removes all text from the buffer.
func (t *TextView) Clear() *TextView {
	t.Lock()
	defer t.Unlock()

	t.clear()
	return t
}
```