### PR TITLE
swarm: fix selection of transport for dialing

### DIFF
--- a/p2p/net/swarm/swarm_transport.go
+++ b/p2p/net/swarm/swarm_transport.go
@@ -19,6 +19,7 @@ func (s *Swarm) TransportForDialing(a ma.Multiaddr) transport.Transport {
 
 	s.transports.RLock()
 	defer s.transports.RUnlock()
+
 	if len(s.transports.m) == 0 {
 		// make sure we're not just shutting down.
 		if s.transports.m != nil {
@@ -26,18 +27,15 @@ func (s *Swarm) TransportForDialing(a ma.Multiaddr) transport.Transport {
 		}
 		return nil
 	}
-
-	for _, p := range protocols {
-		transport, ok := s.transports.m[p.Code]
-		if !ok {
-			continue
-		}
-		if transport.Proxy() {
-			return transport
+	if isRelayAddr(a) {
+		return s.transports.m[ma.P_CIRCUIT]
+	}
+	for _, t := range s.transports.m {
+		if t.CanDial(a) {
+			return t
 		}
 	}
-
-	return s.transports.m[protocols[len(protocols)-1].Code]
+	return nil
 }
 
 // TransportForListening retrieves the appropriate transport for listening on


### PR DESCRIPTION
With WebTransport's `/webtransport/certhash/xyz` addresses, the assumption that the last component of a multiaddr identifies the transport to use for dialing doesn't hold any more.

Note that WebRTC will probably also use the `certhash` multiaddr component to encode its certificate hashes.

This is a draft until we actually move the webtransport transport into this repo (#1737), but I'm asking for reviews nonetheless. Please review carefully, this has the potential to break us in painful ways.