### PR TITLE
feat: switch noise to use minio's SHA256 implementation

### DIFF
--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -5,10 +5,12 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"hash"
 	"os"
 	"runtime/debug"
 	"time"
 
+	"github.com/minio/sha256-simd"
 	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/libp2p/go-libp2p/p2p/security/noise/pb"
@@ -25,8 +27,15 @@ import (
 // our libp2p identity key.
 const payloadSigPrefix = "noise-libp2p-static-key:"
 
+type minioSHAFn struct{}
+
+func (h minioSHAFn) Hash() hash.Hash  { return sha256.New() }
+func (h minioSHAFn) HashName() string { return "SHA256" }
+
+var shaHashFn noise.HashFunc = minioSHAFn{}
+
 // All noise session share a fixed cipher suite
-var cipherSuite = noise.NewCipherSuite(noise.DH25519, noise.CipherChaChaPoly, noise.HashSHA256)
+var cipherSuite = noise.NewCipherSuite(noise.DH25519, noise.CipherChaChaPoly, shaHashFn)
 
 // runHandshake exchanges handshake messages with the remote peer to establish
 // a noise-libp2p session. It blocks until the handshake completes or fails.


### PR DESCRIPTION
On my 11th gen Intel laptop, this library is 3x faster than the default
one (and is the one we use in go-multihash).

See below (GEN_ is the builtin version, SHA_ is this library).

    BenchmarkHash/SHA_/8Bytes-8           94.31 ns/op	  84.82 MB/s
    BenchmarkHash/SHA_/1K-8               926.9 ns/op	1104.74 MB/s
    BenchmarkHash/SHA_/8K-8                6793 ns/op	1205.98 MB/s
    BenchmarkHash/SHA_/1M-8              883694 ns/op	1186.58 MB/s
    BenchmarkHash/SHA_/5M-8             4347298 ns/op	1206.01 MB/s
    BenchmarkHash/SHA_/10M-8            8810864 ns/op	1190.09 MB/s
    BenchmarkHash/GEN_/8Bytes-8           283.2 ns/op	  28.25 MB/s
    BenchmarkHash/GEN_/1K-8                3587 ns/op	 285.48 MB/s
    BenchmarkHash/GEN_/8K-8               27706 ns/op	 295.68 MB/s
    BenchmarkHash/GEN_/1M-8             3414827 ns/op	 307.07 MB/s
    BenchmarkHash/GEN_/5M-8            16789216 ns/op	 312.28 MB/s
    BenchmarkHash/GEN_/10M-8           34073478 ns/op	 307.74 MB/s