### PR TITLE
ping: optimize random number generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-datastore v0.5.1
-	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/klauspost/compress v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -272,7 +272,6 @@ github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46U
 github.com/ipfs/go-ds-badger v0.3.0/go.mod h1:1ke6mXNqeV8K3y5Ak2bAA0osoTfmxUdupVCGm4QUIek=
 github.com/ipfs/go-ds-leveldb v0.5.0/go.mod h1:d3XG9RUDzQ6V4SHi8+Xgj9j1XuEk1z82lquxrVbml/Q=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
-github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-ipfs-util v0.0.2/go.mod h1:CbPtkWJzjLdEcezDns2XYaehFVNXG9zrdrtMecczcsQ=
 github.com/ipfs/go-log/v2 v2.0.5/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscwkWG+dw=
 github.com/ipfs/go-log/v2 v2.3.0/go.mod h1:QqGoj30OTpnKaG/LKTGTxoP2mmQtjVMEnK72gynbe/g=

--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -3,11 +3,13 @@ package ping
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"io"
+	mrand "math/rand"
 	"time"
 
-	u "github.com/ipfs/go-ipfs-util"
 	logging "github.com/ipfs/go-log/v2"
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -120,6 +122,14 @@ func Ping(ctx context.Context, h host.Host, p peer.ID) <-chan Result {
 		return pingError(err)
 	}
 
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		log.Errorf("failed to get cryptographic random: %s", err)
+		s.Reset()
+		return pingError(err)
+	}
+	ra := mrand.New(mrand.NewSource(int64(binary.BigEndian.Uint64(b))))
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	out := make(chan Result)
@@ -129,7 +139,7 @@ func Ping(ctx context.Context, h host.Host, p peer.ID) <-chan Result {
 
 		for ctx.Err() == nil {
 			var res Result
-			res.RTT, res.Error = ping(s)
+			res.RTT, res.Error = ping(s, ra)
 
 			// canceled, ignore everything.
 			if ctx.Err() != nil {
@@ -157,7 +167,7 @@ func Ping(ctx context.Context, h host.Host, p peer.ID) <-chan Result {
 	return out
 }
 
-func ping(s network.Stream) (time.Duration, error) {
+func ping(s network.Stream, randReader io.Reader) (time.Duration, error) {
 	if err := s.Scope().ReserveMemory(2*PingSize, network.ReservationPriorityAlways); err != nil {
 		log.Debugf("error reserving memory for ping stream: %s", err)
 		s.Reset()
@@ -168,19 +178,19 @@ func ping(s network.Stream) (time.Duration, error) {
 	buf := pool.Get(PingSize)
 	defer pool.Put(buf)
 
-	u.NewTimeSeededRand().Read(buf)
+	if _, err := io.ReadFull(randReader, buf); err != nil {
+		return 0, err
+	}
 
 	before := time.Now()
-	_, err := s.Write(buf)
-	if err != nil {
+	if _, err := s.Write(buf); err != nil {
 		return 0, err
 	}
 
 	rbuf := pool.Get(PingSize)
 	defer pool.Put(rbuf)
 
-	_, err = io.ReadFull(s, rbuf)
-	if err != nil {
+	if _, err := io.ReadFull(s, rbuf); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
1. We shouldn't use time-seeded random numbers. They contain very, very little entropy.
2. We only need to initialize a `math/rand` random number generator once per `Ping` invocation.
3. We don't need to use `go-ipfs-util` for this, bringing down the number of dependencies (therefore: part of #1646).