### PR TITLE
Fix flaky TestDialSimultaneousJoin

### DIFF
--- a/p2p/net/swarm/dial_test.go
+++ b/p2p/net/swarm/dial_test.go
@@ -2,6 +2,7 @@ package swarm_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -533,7 +534,7 @@ func TestDialSimultaneousJoin(t *testing.T) {
 
 		c, err := s1.DialPeer(context.Background(), s2.LocalPeer())
 		if err != nil {
-			errs <- err
+			errs <- fmt.Errorf("first dial: %w", err)
 			connch <- nil
 			return
 		}
@@ -558,7 +559,7 @@ func TestDialSimultaneousJoin(t *testing.T) {
 
 		c, err := s1.DialPeer(context.Background(), s2.LocalPeer())
 		if err != nil {
-			errs <- err
+			errs <- fmt.Errorf("second dial: %w", err)
 			connch <- nil
 			return
 		}
@@ -576,7 +577,7 @@ func TestDialSimultaneousJoin(t *testing.T) {
 	go func() {
 		c, err := s1.DialPeer(context.Background(), s2.LocalPeer())
 		if err != nil {
-			errs <- err
+			errs <- fmt.Errorf("third dial: %w", err)
 			connch <- nil
 			return
 		}


### PR DESCRIPTION
Toward https://github.com/libp2p/go-libp2p/issues/1421.

@vyzo This is a blunt and incorrect first approximation for feedback.

The 1st and 3rd `DialPeer`s happen after the 2nd one succeeds. This passes but defeats the purpose of the test of leaving the 1st dial hanging while 2nd one connects. I need more guidance on how to do a better fine-grained simultaneity (without messing with dialing internals) to make sure the *1st dial hangs but does not timeout* while 2nd happens. (Messing with dialing internals is fine by me but I don't think is the point here.)