### PR TITLE
Some deprecated function calls and bugs were fixed in the example.

### DIFF
--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -116,6 +116,9 @@ func main() {
 	peerChan := initMDNS(host, cfg.RendezvousString)
 
 	peer := <-peerChan // will block untill we discover a peer
+	for peer.ID == host.ID() {
+		peer = <-peerChan
+	}
 	fmt.Println("Found peer:", peer, ", connecting")
 
 	if err := host.Connect(ctx, peer); err != nil {

--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -116,9 +116,6 @@ func main() {
 	peerChan := initMDNS(host, cfg.RendezvousString)
 
 	peer := <-peerChan // will block untill we discover a peer
-	for peer.ID == host.ID() {
-		peer = <-peerChan
-	}
 	fmt.Println("Found peer:", peer, ", connecting")
 
 	if err := host.Connect(ctx, peer); err != nil {

--- a/examples/chat-with-rendezvous/chat.go
+++ b/examples/chat-with-rendezvous/chat.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"os"
 	"sync"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
-	discovery "github.com/libp2p/go-libp2p-discovery"
 
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/multiformats/go-multiaddr"
@@ -134,7 +134,7 @@ func main() {
 		go func() {
 			defer wg.Done()
 			if err := host.Connect(ctx, *peerinfo); err != nil {
-				logger.Warning(err)
+				logger.Warn(err)
 			} else {
 				logger.Info("Connection established with bootstrap node:", *peerinfo)
 			}
@@ -145,8 +145,8 @@ func main() {
 	// We use a rendezvous point "meet me here" to announce our location.
 	// This is like telling your friends to meet you at the Eiffel Tower.
 	logger.Info("Announcing ourselves...")
-	routingDiscovery := discovery.NewRoutingDiscovery(kademliaDHT)
-	discovery.Advertise(ctx, routingDiscovery, config.RendezvousString)
+	routingDiscovery := routing.NewRoutingDiscovery(kademliaDHT)
+	routingDiscovery.Advertise(ctx, config.RendezvousString)
 	logger.Debug("Successfully announced!")
 
 	// Now, look for others who have announced
@@ -167,7 +167,7 @@ func main() {
 		stream, err := host.NewStream(ctx, peer.ID, protocol.ID(config.ProtocolID))
 
 		if err != nil {
-			logger.Warning("Connection failed:", err)
+			logger.Warn("Connection failed:", err)
 			continue
 		} else {
 			rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))

--- a/p2p/discovery/mdns/mdns.go
+++ b/p2p/discovery/mdns/mdns.go
@@ -176,6 +176,9 @@ func (s *mdnsService) startResolver(ctx context.Context) {
 				continue
 			}
 			for _, info := range infos {
+				if info.ID == s.host.ID() {
+					continue
+				}
 				go s.notifee.HandlePeerFound(info)
 			}
 		}


### PR DESCRIPTION
Hello, I am an M1 student in Japan. Recently, I was doing some research related to P2P, so I tried to use the library written by your organization, but I found some small problems when running the example. 

For example, some deprecated methods are used in the chapter “chat-with-rendezvous”. At the same time, there is a small bug in the chapter “chat-with-mdns” (well, in fact, I don't know whether this is a bug or not). When we start a peer in a terminal first, this peer will always try to establish a connection with itself first. So I modified this part of the code. I asked this peer not to try to connect to itself after discovering itself, but to continue to wait for a connection with a different ID from itself to be read from the peerchannel. 

looking forward to your reply.