### PR TITLE
Allow adding prologue to noise connections

### DIFF
--- a/p2p/security/noise/crypto_test.go
+++ b/p2p/security/noise/crypto_test.go
@@ -93,7 +93,7 @@ func TestCryptoFailsIfHandshakeIncomplete(t *testing.T) {
 	init, resp := net.Pipe()
 	_ = resp.Close()
 
-	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", true)
+	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", nil, true)
 	_, err := session.encrypt(nil, []byte("hi"))
 	if err == nil {
 		t.Error("expected encryption error when handshake incomplete")

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -57,6 +57,7 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 		Pattern:       noise.HandshakeXX,
 		Initiator:     s.initiator,
 		StaticKeypair: kp,
+		Prologue:      s.prologue,
 	}
 
 	hs, err := noise.NewHandshakeState(cfg)

--- a/p2p/security/noise/intermediate_transport.go
+++ b/p2p/security/noise/intermediate_transport.go
@@ -1,0 +1,50 @@
+package noise
+
+import (
+	"context"
+	"net"
+
+	"github.com/libp2p/go-libp2p-core/canonicallog"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/sec"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+type NoiseOptions struct {
+	Prologue []byte
+}
+
+var _ sec.SecureTransport = &intermediateTransport{}
+
+// intermediate transport can be used
+// to provide per-connection options
+type intermediateTransport struct {
+	t *Transport
+	// options
+	prologue []byte
+}
+
+// SecureInbound runs the Noise handshake as the responder.
+// If p is empty, connections from any peer are accepted.
+func (i *intermediateTransport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
+	c, err := newSecureSession(i.t, ctx, insecure, p, i.prologue, false)
+	if err != nil {
+		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
+		if maErr == nil {
+			canonicallog.LogPeerStatus(100, p, addr, "handshake_failure", "noise", "err", err.Error())
+		}
+	}
+	return c, err
+}
+
+// SecureOutbound runs the Noise handshake as the initiator.
+func (i *intermediateTransport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
+	return newSecureSession(i.t, ctx, insecure, p, i.prologue, true)
+}
+
+func (t *Transport) WithNoiseOptions(opts NoiseOptions) sec.SecureTransport {
+	return &intermediateTransport{
+		t:        t,
+		prologue: opts.Prologue,
+	}
+}

--- a/p2p/security/noise/session.go
+++ b/p2p/security/noise/session.go
@@ -34,11 +34,14 @@ type secureSession struct {
 
 	enc *noise.CipherState
 	dec *noise.CipherState
+
+	// noise prologue
+	prologue []byte
 }
 
 // newSecureSession creates a Noise session over the given insecureConn Conn, using
 // the libp2p identity keypair from the given Transport.
-func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, initiator bool) (*secureSession, error) {
+func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, prologue []byte, initiator bool) (*secureSession, error) {
 	s := &secureSession{
 		insecureConn:   insecure,
 		insecureReader: bufio.NewReader(insecure),
@@ -46,6 +49,7 @@ func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, re
 		localID:        tpt.localID,
 		localKey:       tpt.privateKey,
 		remoteID:       remote,
+		prologue:       prologue,
 	}
 
 	// the go-routine we create to run the handshake will

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -10,7 +10,7 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-type SessionOption = func (*SessionTransport) error
+type SessionOption = func(*SessionTransport) error
 
 var _ sec.SecureTransport = &SessionTransport{}
 
@@ -41,7 +41,7 @@ func (i *SessionTransport) SecureOutbound(ctx context.Context, insecure net.Conn
 }
 
 func (t *Transport) WithSessionOptions(opts ...SessionOption) (sec.SecureTransport, error) {
-	st := &SessionTransport{ t: t}
+	st := &SessionTransport{t: t}
 	for _, opt := range opts {
 		if err := opt(st); err != nil {
 			return nil, err
@@ -51,7 +51,7 @@ func (t *Transport) WithSessionOptions(opts ...SessionOption) (sec.SecureTranspo
 }
 
 func Prologue(prologue []byte) SessionOption {
-	return func (s *SessionTransport) error {
+	return func(s *SessionTransport) error {
 		s.prologue = prologue
 		return nil
 	}

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -40,7 +40,7 @@ func New(privkey crypto.PrivKey) (*Transport, error) {
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	c, err := newSecureSession(t, ctx, insecure, p, false)
+	c, err := newSecureSession(t, ctx, insecure, p, nil, false)
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
 		if maErr == nil {
@@ -52,5 +52,5 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer
 
 // SecureOutbound runs the Noise handshake as the initiator.
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	return newSecureSession(t, ctx, insecure, p, true)
+	return newSecureSession(t, ctx, insecure, p, nil, true)
 }

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -395,7 +395,7 @@ func TestPrologueMatches(t *testing.T) {
 	tpt, err := respTransport.
 		WithSessionOptions(Prologue(commonPrologue))
 	require.NoError(t, err)
-	conn, err:= tpt.SecureInbound(context.TODO(), respConn, "")
+	conn, err := tpt.SecureInbound(context.TODO(), respConn, "")
 	defer conn.Close()
 	require.NoError(t, err)
 	<-done

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -388,16 +388,16 @@ func TestPrologueMatches(t *testing.T) {
 			WithSessionOptions(Prologue(commonPrologue))
 		require.NoError(t, err)
 		conn, err := tpt.SecureOutbound(context.TODO(), initConn, respTransport.localID)
-		defer conn.Close()
 		require.NoError(t, err)
+		defer conn.Close()
 	}()
 
 	tpt, err := respTransport.
 		WithSessionOptions(Prologue(commonPrologue))
 	require.NoError(t, err)
 	conn, err := tpt.SecureInbound(context.TODO(), respConn, "")
-	defer conn.Close()
 	require.NoError(t, err)
+	defer conn.Close()
 	<-done
 }
 

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -402,6 +402,7 @@ func TestPrologueMatches(t *testing.T) {
 }
 
 func TestPrologueDoesNotMatchFailsHandshake(t *testing.T) {
+	initPrologue, respPrologue := []byte("initPrologue"), []byte("respPrologue")
 	initTransport := newTestTransport(t, crypto.Ed25519, 2048)
 	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
 
@@ -412,14 +413,13 @@ func TestPrologueDoesNotMatchFailsHandshake(t *testing.T) {
 	go func() {
 		defer close(done)
 		tpt, err := initTransport.
-			WithSessionOptions(Prologue([]byte("testtesttest")))
+			WithSessionOptions(Prologue(initPrologue))
 		require.NoError(t, err)
 		_, err = tpt.SecureOutbound(context.TODO(), initConn, respTransport.localID)
 		require.Error(t, err)
 	}()
 
-	tpt, err := respTransport.
-		WithSessionOptions(Prologue([]byte("testtesttesttest")))
+	tpt, err := respTransport.WithSessionOptions(Prologue(respPrologue))
 	require.NoError(t, err)
 
 	_, err = tpt.SecureInbound(context.TODO(), respConn, "")


### PR DESCRIPTION
Allows adding the prologue to an existing noise transport. This is for potential use in implementing the webrtc transport.
Related discussion: https://github.com/libp2p/specs/pull/412#discussion_r931163931