### PR TITLE
connmgr: add nowatchdog go build tag

### DIFF
--- a/p2p/net/connmgr/watchdog_cgo.go
+++ b/p2p/net/connmgr/watchdog_cgo.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && !nowatchdog
+// +build cgo,!nowatchdog
 
 package connmgr
 

--- a/p2p/net/connmgr/watchdog_no_cgo.go
+++ b/p2p/net/connmgr/watchdog_no_cgo.go
@@ -1,5 +1,5 @@
-//go:build !cgo
-// +build !cgo
+//go:build !cgo || nowatchdog
+// +build !cgo nowatchdog
 
 package connmgr
 


### PR DESCRIPTION
Add the ability to disable watchdog even if cgo is enabled.

I logicaly tested the configuration using a truth table to cover each case:

| p | q | p∧¬q | ¬p∨q | (p∧¬q)⊕(¬p∨q) |
|:-:|:-:|:----:|:----:|:-------------:|
| T | T |   F  |   T  |       T       |
| T | F |   T  |   F  |       T       |
| F | T |   F  |   T  |       T       |
| F | F |   F  |   T  |       T       |

**Where**:

- `p`: `cgo` tag
- `q`: `nowatchdog` tag
- `p∧¬q`: `watchdog_cgo.go` compiled if `true`
- `¬p∨q`: `watchdog_no_cgo.go` compiled if `true`
- `(p∧¬q)⊕(¬p∨q)`: only one of these files is compiled if `true`

## Usage (for newbies)

```shell
$ go build -tags nowatchdog .
```

## Additionnal note

This fixes an old problem I reported a few months ago: [libp2p/go-libp2p-connmgr#98](https://github.com/libp2p/go-libp2p-connmgr/issues/98).

I couldn't find a convention to write a deactivation tag, so I added the `no` prefix to `watchdog` but if you have a better proposal you're welcome.
