### PR TITLE
chore: preallocate slices with known final size

### DIFF
--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -586,7 +586,7 @@ func (rf *relayFinder) usingRelay(p peer.ID) bool {
 // selectCandidates returns an ordered slice of relay candidates.
 // Callers should attempt to obtain reservations with the candidates in this order.
 func (rf *relayFinder) selectCandidates() []*candidate {
-	var candidates []*candidate
+	candidates := make([]*candidate, 0, len(rf.candidates))
 	for _, cand := range rf.candidates {
 		candidates = append(candidates, cand)
 	}

--- a/p2p/host/blank/blank.go
+++ b/p2p/host/blank/blank.go
@@ -159,9 +159,9 @@ func (bh *BlankHost) NewStream(ctx context.Context, p peer.ID, protos ...protoco
 		return nil, err
 	}
 
-	var protoStrs []string
-	for _, pid := range protos {
-		protoStrs = append(protoStrs, string(pid))
+	protoStrs := make([]string, len(protos))
+	for i, pid := range protos {
+		protoStrs[i] = string(pid)
 	}
 
 	selected, err := mstream.SelectOneOf(protoStrs, s)

--- a/p2p/net/mock/mock_peernet.go
+++ b/p2p/net/mock/mock_peernet.go
@@ -271,7 +271,7 @@ func (pn *peernet) ClosePeer(p peer.ID) error {
 		return nil
 	}
 
-	var conns []*conn
+	conns := make([]*conn, 0, len(cs))
 	for c := range cs {
 		conns = append(conns, c)
 	}


### PR DESCRIPTION
Found with https://github.com/alexkohler/prealloc

Make my IDE complain less when I vendor libp2p and probably dirty slightly less memory.