### PR TITLE
simplify the release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -19,39 +19,13 @@ about: 'Start a new libp2p release.'
 
 - [ ] **Stage 0 - Finishing Touches**
     - [ ] Go through relevant libp2p repos looking for unreleased changes that should make it into the release. If you find any, cut releases.
-    - [ ] Run `go get -u ./...` to see if there are any out-of-date deps that look important. If there are, bubble them. Try to avoid _directly_ updating indirect deps in go-libp2p's go.mod when possible.
-    - [ ] Make sure local tests are passing.
-- [ ] **Stage 1 - Upstream Testing**
-  - Create testing branches in lotus & go-ipfs with the new go-libp2p release and run CI/tests. Many upstream projects are tested in CI, but lotus & go-ipfs are not.
-    - [ ] [filecoin-project/lotus](https://github.com/filecoin-project/lotus)
-    - [ ] [ipfs/go-ipfs](https://github.com/ipfs/go-ipfs)
-  - _(someday)_ Run upstream testground tests. Unfortunately, this is too time consuming at the moment.
-    - _(someday)_ Run bitswap testground tests.
-    - _(someday)_ Run DHT testground tests.
-- [ ] **Stage 2 - Infrastructure Testing**
-  - How: Using the testing branches created above, work with the infrastructure team to deploy the new libp2p versions to our infrastructure.
-  - Where:
-    - [ ] A go-ipfs gateway.
-      - [ ] Deploy
-      - [ ] Analyze
-        - [ ] Look at pprof profile dumps, especially CPU profiles and heap allocation profiles, noting any significant changes.
-    - [ ] A go-ipfs bootstrapper.
-      - [ ] Deploy
-      - [ ] Analyze
-        - [ ] Look at pprof profile dumps, especially CPU profiles and heap allocation profiles, noting any significant changes.
-        - [ ] Check peers (e.g., `ipfs swarm peers`) to make sure we're connecting to peers on all transports.
-        - [ ] Check advertised addresses and protocols (e.g., `ipfs id`) to make sure they're sane.
-- [ ] **Stage 3 - Release**
-  - [ ] Tag the release on master.
+    - [ ] Run `go get -u ./...` to see if there are any out-of-date deps that look important. If there are, bubble them. Try to avoid _directly_ updating indirect deps in go-libp2p's `go.mod` when possible.
+- [ ] **Stage 1 - Release**
   - [ ] Publish the release through the GitHub UI, adding the release notes. Some users rely on this to receive notifications of new releases.
   - [ ] Announce the release on the [discuss.libp2p.io](https://discuss.libp2p.io).
-- [ ] **Stage 4 - Update Upstream**
+- [ ] **Stage 2 - Update Upstream**
   - [ ] Update the examples to the final release
-  - [ ] Update the upstream testing branches to the final release and create PRs.
+  - [ ] Update the upstream dependencies to the final release and create PRs.
     - [ ] [filecoin-project/lotus](https://github.com/filecoin-project/lotus)
-    - [ ] [ipfs/go-bitswap](https://github.com/ipfs/go-bitswap)
     - [ ] [ipfs/go-ipfs](https://github.com/ipfs/go-ipfs)
-    - [ ] [libp2p/go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht)
-    - [ ] [libp2p/go-libp2p-pubsub](https://github.com/libp2p/go-libp2p-pubsub)
-    - [ ] [libp2p/go-libp2p-daemon](https://github.com/libp2p/go-libp2p-daemon)
 - [ ] Make required changes to the release process.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -27,5 +27,5 @@ about: 'Start a new libp2p release.'
   - [ ] Update the examples to the final release
   - [ ] Update the upstream dependencies to the final release and create PRs.
     - [ ] [filecoin-project/lotus](https://github.com/filecoin-project/lotus)
-    - [ ] [ipfs/go-ipfs](https://github.com/ipfs/go-ipfs)
+    - [ ] [ipfs/kubo](https://github.com/ipfs/kubo)
 - [ ] Make required changes to the release process.


### PR DESCRIPTION
If we're cutting more frequent and smaller releases, we need to cut down on the overhead a release is creating.
Most of these changes just reflect what we've been doing (or rather, what we've _not_ been doing) in the past.