### PR TITLE
quic: increase the buffer size used for encoding qlogs

### DIFF
--- a/p2p/transport/quic/tracer.go
+++ b/p2p/transport/quic/tracer.go
@@ -62,7 +62,9 @@ func newQlogger(qlogDir string, role logging.Perspective, connID []byte) io.Writ
 	return &qlogger{
 		f:        f,
 		filename: finalFilename,
-		Writer:   bufio.NewWriter(f),
+		// The size of a qlog file for a raw file download is ~2/3 of the amount of data transferred.
+		// bufio.NewWriter creates a buffer with a buffer of only 4 kB, leading to a large number of syscalls.
+		Writer: bufio.NewWriterSize(f, 128<<10),
 	}
 }
 
@@ -80,7 +82,7 @@ func (l *qlogger) Close() error {
 		return err
 	}
 	defer f.Close()
-	buf := bufio.NewWriter(f)
+	buf := bufio.NewWriterSize(f, 128<<10)
 	c, err := zstd.NewWriter(buf, zstd.WithEncoderLevel(zstd.SpeedFastest), zstd.WithWindowSize(32*1024))
 	if err != nil {
 		return err


### PR DESCRIPTION
See comments for motivation. With the standard buffer size, I'm seeing a ton of syscalls just for writing the qlog file, taking almost as much CPU time as writing QUIC packets to the wire.

This should be ok from a resource perspective, because you wouldn't run with qlogging enabled in production anyway.