### PR TITLE
connmgr: use clock interface

### DIFF
--- a/p2p/net/connmgr/decay.go
+++ b/p2p/net/connmgr/decay.go
@@ -221,7 +221,7 @@ func (d *decayer) process() {
 			s := d.mgr.segments.get(peer)
 			s.Lock()
 
-			p := s.tagInfoFor(peer)
+			p := s.tagInfoFor(peer, d.clock.Now())
 			v, ok := p.decaying[tag]
 			if !ok {
 				v = &connmgr.DecayingValue{
@@ -244,7 +244,7 @@ func (d *decayer) process() {
 			s := d.mgr.segments.get(rm.peer)
 			s.Lock()
 
-			p := s.tagInfoFor(rm.peer)
+			p := s.tagInfoFor(rm.peer, d.clock.Now())
 			v, ok := p.decaying[rm.tag]
 			if !ok {
 				s.Unlock()

--- a/p2p/net/connmgr/options.go
+++ b/p2p/net/connmgr/options.go
@@ -3,6 +3,8 @@ package connmgr
 import (
 	"errors"
 	"time"
+
+	"github.com/benbjohnson/clock"
 )
 
 // config is the configuration struct for the basic connection manager.
@@ -13,6 +15,7 @@ type config struct {
 	silencePeriod time.Duration
 	decayer       *DecayerCfg
 	emergencyTrim bool
+	clock         clock.Clock
 }
 
 // Option represents an option for the basic connection manager.
@@ -22,6 +25,14 @@ type Option func(*config) error
 func DecayerConfig(opts *DecayerCfg) Option {
 	return func(cfg *config) error {
 		cfg.decayer = opts
+		return nil
+	}
+}
+
+// WithClock sets the internal clock impl
+func WithClock(c clock.Clock) Option {
+	return func(cfg *config) error {
+		cfg.clock = c
 		return nil
 	}
 }


### PR DESCRIPTION
Uses a clock interface rather than real time. This lets tests pass a mock clock.

This also fixes the failing tests here: https://github.com/libp2p/go-libp2p-pubsub/pull/498 because that test is timing sensitive and the connmgr did a good job of keeping the conns below the hi mark. That test also used a mock clock for the decayer, but not for the connmgr which could lead to some weird behavior. The test passes if the same mock clock is passed to both the connmgr and decayer.

Also shaves 3s off our test runtime :)