### PR TITLE
rcmgr: increase default connection memory limit to 32 MB

### DIFF
--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -514,7 +514,7 @@ var DefaultLimits = ScalingLimitConfig{
 		ConnsOutbound: 1,
 		Conns:         1,
 		FD:            1,
-		Memory:        1 << 20,
+		Memory:        32 << 20,
 	},
 
 	StreamBaseLimit: BaseLimit{


### PR DESCRIPTION
Fixes #1706.