### PR TITLE
noise: don't fail handshake when early data is received without handler

### DIFF
--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -122,8 +122,6 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 			if err := s.earlyDataHandler.Received(ctx, s.insecureConn, initialPayload); err != nil {
 				return err
 			}
-		} else if len(initialPayload) > 0 {
-			return fmt.Errorf("received unexpected early data (%d bytes)", len(initialPayload))
 		}
 
 		// stage 1 //

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -510,7 +510,7 @@ func TestEarlyDataRejected(t *testing.T) {
 	}
 }
 
-func TestEarlyDataRejectedWithNoHandler(t *testing.T) {
+func TestEarlyDataAcceptedWithNoHandler(t *testing.T) {
 	clientEDH := &earlyDataHandler{
 		send: func(ctx context.Context, conn net.Conn, id peer.ID) []byte { return []byte("foobar") },
 	}
@@ -526,14 +526,14 @@ func TestEarlyDataRejectedWithNoHandler(t *testing.T) {
 		errChan <- err
 	}()
 
-	_, err = initTransport.SecureOutbound(context.Background(), respConn, respTransport.localID)
-	require.Error(t, err)
+	conn, err := initTransport.SecureOutbound(context.Background(), respConn, respTransport.localID)
+	require.NoError(t, err)
+	defer conn.Close()
 
 	select {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timeout")
 	case err := <-errChan:
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "received unexpected early data")
+		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
I just realized that the change we introduced in #1728 would preclude us from rolling out the change that @julian88110 is working on (see https://github.com/libp2p/specs/pull/446). This means that this PR must make it into v0.23.0.