### PR TITLE
noise: make it possible for the server to send early data

### DIFF
--- a/p2p/security/noise/crypto_test.go
+++ b/p2p/security/noise/crypto_test.go
@@ -93,7 +93,7 @@ func TestCryptoFailsIfHandshakeIncomplete(t *testing.T) {
 	init, resp := net.Pipe()
 	_ = resp.Close()
 
-	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", nil, nil, true)
+	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", nil, nil, nil, true)
 	_, err := session.encrypt(nil, []byte("hi"))
 	if err == nil {
 		t.Error("expected encryption error when handshake incomplete")

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -10,8 +10,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"golang.org/x/crypto/chacha20poly1305"
-
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/security/noise/pb"
@@ -73,12 +71,8 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 		}
 	}
 
-	// We can re-use this buffer for all handshake messages as its size
-	// will be the size of the maximum handshake message for the Noise XX pattern.
-	// Also, since we prefix every noise handshake message with its length, we need to account for
-	// it when we fetch the buffer from the pool
-	maxMsgSize := 2*noise.DH25519.DHLen() + 2*chacha20poly1305.Overhead + 1024 /* payload */
-	hbuf := pool.Get(maxMsgSize + LengthPrefixLength)
+	// We can re-use this buffer for all handshake messages.
+	hbuf := pool.Get(2 << 10)
 	defer pool.Put(hbuf)
 
 	if s.initiator {

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -85,8 +85,8 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 		// stage 0 //
 		// Handshake Msg Len = len(DH ephemeral key)
 		var ed []byte
-		if s.earlyDataHandler != nil {
-			ed = s.earlyDataHandler.Send(ctx, s.insecureConn, s.remoteID)
+		if s.initiatorEarlyDataHandler != nil {
+			ed = s.initiatorEarlyDataHandler.Send(ctx, s.insecureConn, s.remoteID)
 		}
 		if err := s.sendHandshakeMessage(hs, ed, hbuf); err != nil {
 			return fmt.Errorf("error sending handshake message: %w", err)
@@ -101,8 +101,8 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		if s.earlyDataHandler != nil {
-			if err := s.earlyDataHandler.Received(ctx, s.insecureConn, rcvdEd); err != nil {
+		if s.initiatorEarlyDataHandler != nil {
+			if err := s.initiatorEarlyDataHandler.Received(ctx, s.insecureConn, rcvdEd); err != nil {
 				return err
 			}
 		}
@@ -123,8 +123,8 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 		if err != nil {
 			return fmt.Errorf("error reading handshake message: %w", err)
 		}
-		if s.earlyDataHandler != nil {
-			if err := s.earlyDataHandler.Received(ctx, s.insecureConn, initialPayload); err != nil {
+		if s.responderEarlyDataHandler != nil {
+			if err := s.responderEarlyDataHandler.Received(ctx, s.insecureConn, initialPayload); err != nil {
 				return err
 			}
 		}
@@ -133,8 +133,8 @@ func (s *secureSession) runHandshake(ctx context.Context) (err error) {
 		// Handshake Msg Len = len(DH ephemeral key) + len(DHT static key) +  MAC(static key is encrypted) + len(Payload) +
 		// MAC(payload is encrypted)
 		var ed []byte
-		if s.earlyDataHandler != nil {
-			ed = s.earlyDataHandler.Send(ctx, s.insecureConn, s.remoteID)
+		if s.responderEarlyDataHandler != nil {
+			ed = s.responderEarlyDataHandler.Send(ctx, s.insecureConn, s.remoteID)
 		}
 		payload, err := s.generateHandshakePayload(kp, ed)
 		if err != nil {

--- a/p2p/security/noise/session.go
+++ b/p2p/security/noise/session.go
@@ -36,22 +36,24 @@ type secureSession struct {
 	dec *noise.CipherState
 
 	// noise prologue
-	prologue         []byte
-	earlyDataHandler EarlyDataHandler
+	prologue []byte
+
+	initiatorEarlyDataHandler, responderEarlyDataHandler EarlyDataHandler
 }
 
 // newSecureSession creates a Noise session over the given insecureConn Conn, using
 // the libp2p identity keypair from the given Transport.
-func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, prologue []byte, edh EarlyDataHandler, initiator bool) (*secureSession, error) {
+func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, prologue []byte, initiatorEDH, responderEDH EarlyDataHandler, initiator bool) (*secureSession, error) {
 	s := &secureSession{
-		insecureConn:     insecure,
-		insecureReader:   bufio.NewReader(insecure),
-		initiator:        initiator,
-		localID:          tpt.localID,
-		localKey:         tpt.privateKey,
-		remoteID:         remote,
-		prologue:         prologue,
-		earlyDataHandler: edh,
+		insecureConn:              insecure,
+		insecureReader:            bufio.NewReader(insecure),
+		initiator:                 initiator,
+		localID:                   tpt.localID,
+		localKey:                  tpt.privateKey,
+		remoteID:                  remote,
+		prologue:                  prologue,
+		initiatorEarlyDataHandler: initiatorEDH,
+		responderEarlyDataHandler: responderEDH,
 	}
 
 	// the go-routine we create to run the handshake will

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -23,7 +23,7 @@ func Prologue(prologue []byte) SessionOption {
 }
 
 // EarlyDataHandler defines what the application payload is for either the second
-// (if initiator) or third (if responder) handshake message, and defines the
+// (if responder) or third (if initiator) handshake message, and defines the
 // logic for handling the other side's early data. Note the early data in the
 // second handshake message is encrypted, but the peer is not authenticated at that point.
 type EarlyDataHandler interface {

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -22,27 +22,24 @@ func Prologue(prologue []byte) SessionOption {
 	}
 }
 
-// EarlyDataHandler defines what the application payload is for either the first
-// (if initiator) or second (if responder) handshake message. And defines the
+// EarlyDataHandler defines what the application payload is for either the second
+// (if initiator) or third (if responder) handshake message, and defines the
 // logic for handling the other side's early data. Note the early data in the
-// first handshake message is **unencrypted**, but will be retroactively
-// authenticated if the handshake completes.
+// second handshake message is encrypted, but the peer is not authenticated at that point.
 type EarlyDataHandler interface {
-	// Send for the initiator is called for the client before sending the first
-	// handshake message. Defines the application payload for the first message.
-	// This payload is sent **unencrypted**.
-	// Send for the responder is called before sending the second handshake message. This is encrypted.
+	// Send for the initiator is called for the client before sending the third
+	// handshake message. Defines the application payload for the third message.
+	// Send for the responder is called before sending the second handshake message.
 	Send(context.Context, net.Conn, peer.ID) []byte
 	// Received for the initiator is called when the second handshake message
 	// from the responder is received.
-	// Received for the responder is called when the first handshake message
+	// Received for the responder is called when the third handshake message
 	// from the initiator is received.
 	Received(context.Context, net.Conn, []byte) error
 }
 
 // EarlyData sets the `EarlyDataHandler` for the initiator and responder roles.
-// See `EarlyDataHandler` for more details. Note: an initiator's early data will
-// be sent **unencrypted** in the first handshake message.
+// See `EarlyDataHandler` for more details.
 func EarlyData(initiator, responder EarlyDataHandler) SessionOption {
 	return func(s *SessionTransport) error {
 		s.initiatorEarlyDataHandler = initiator

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -41,7 +41,7 @@ func New(privkey crypto.PrivKey) (*Transport, error) {
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	c, err := newSecureSession(t, ctx, insecure, p, nil, nil, false)
+	c, err := newSecureSession(t, ctx, insecure, p, nil, nil, nil, false)
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
 		if maErr == nil {
@@ -53,7 +53,7 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer
 
 // SecureOutbound runs the Noise handshake as the initiator.
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	return newSecureSession(t, ctx, insecure, p, nil, nil, true)
+	return newSecureSession(t, ctx, insecure, p, nil, nil, nil, true)
 }
 
 func (t *Transport) WithSessionOptions(opts ...SessionOption) (sec.SecureTransport, error) {

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -449,10 +449,10 @@ func (e *earlyDataHandler) Received(ctx context.Context, conn net.Conn, data []b
 func TestEarlyDataAccepted(t *testing.T) {
 	handshake := func(t *testing.T, client, server EarlyDataHandler) {
 		t.Helper()
-		initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(client))
+		initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(client, nil))
 		require.NoError(t, err)
 		tpt := newTestTransport(t, crypto.Ed25519, 2048)
-		respTransport, err := tpt.WithSessionOptions(EarlyData(server))
+		respTransport, err := tpt.WithSessionOptions(EarlyData(nil, server))
 		require.NoError(t, err)
 
 		initConn, respConn := newConnPair(t)
@@ -495,10 +495,10 @@ func TestEarlyDataAccepted(t *testing.T) {
 func TestEarlyDataRejected(t *testing.T) {
 	handshake := func(t *testing.T, client, server EarlyDataHandler) (clientErr, serverErr error) {
 		t.Helper()
-		initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(client))
+		initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(client, nil))
 		require.NoError(t, err)
 		tpt := newTestTransport(t, crypto.Ed25519, 2048)
-		respTransport, err := tpt.WithSessionOptions(EarlyData(server))
+		respTransport, err := tpt.WithSessionOptions(EarlyData(nil, server))
 		require.NoError(t, err)
 
 		initConn, respConn := newConnPair(t)
@@ -545,7 +545,7 @@ func TestEarlyDataAcceptedWithNoHandler(t *testing.T) {
 	clientEDH := &earlyDataHandler{
 		send: func(ctx context.Context, conn net.Conn, id peer.ID) []byte { return []byte("foobar") },
 	}
-	initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(clientEDH))
+	initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(clientEDH, nil))
 	require.NoError(t, err)
 	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
 

--- a/p2p/transport/webtransport/listener.go
+++ b/p2p/transport/webtransport/listener.go
@@ -190,7 +190,7 @@ func (l *listener) handshake(ctx context.Context, sess *webtransport.Session) (*
 	if err != nil {
 		return nil, err
 	}
-	n, err := l.noise.WithSessionOptions(noise.EarlyData(newEarlyDataReceiver(l.checkEarlyData)))
+	n, err := l.noise.WithSessionOptions(noise.EarlyData(nil, newEarlyDataReceiver(l.checkEarlyData)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Noise session: %w", err)
 	}

--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -208,7 +208,7 @@ func (t *transport) upgrade(ctx context.Context, sess *webtransport.Session, p p
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal WebTransport protobuf: %w", err)
 	}
-	n, err := t.noise.WithSessionOptions(noise.EarlyData(newEarlyDataSender(msgBytes)))
+	n, err := t.noise.WithSessionOptions(noise.EarlyData(newEarlyDataSender(msgBytes), nil))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Noise transport: %w", err)
 	}

--- a/p2p/transport/webtransport/transport_test.go
+++ b/p2p/transport/webtransport/transport_test.go
@@ -162,8 +162,11 @@ func TestHashVerification(t *testing.T) {
 	})
 
 	t.Run("fails when adding a wrong hash", func(t *testing.T) {
-		_, err := tr2.Dial(context.Background(), ln.Multiaddr().Encapsulate(foobarHash), serverID)
-		require.Error(t, err)
+		conn, err := tr2.Dial(context.Background(), ln.Multiaddr().Encapsulate(foobarHash), serverID)
+		if err != nil {
+			_, err = conn.AcceptStream()
+			require.Error(t, err)
+		}
 	})
 
 	require.NoError(t, ln.Close())


### PR DESCRIPTION
So far, only the client could send early data in its first handshake message, which the server would then receive.

This PR extends the logic, such that the server can now also send early data in its first handshake message.

Needed for https://github.com/libp2p/specs/pull/404#discussion_r968836367. Also needed for https://github.com/libp2p/specs/pull/446, if I understand correctly.