### PR TITLE
webtransport: disable HTTP origin check

### DIFF
--- a/p2p/transport/webtransport/listener.go
+++ b/p2p/transport/webtransport/listener.go
@@ -87,7 +87,10 @@ func newListener(laddr ma.Multiaddr, transport tpt.Transport, noise *noise.Trans
 		serverClosed:    make(chan struct{}),
 		addr:            udpConn.LocalAddr(),
 		multiaddr:       localMultiaddr,
-		server:          webtransport.Server{H3: http3.Server{TLSConfig: tlsConf}},
+		server: webtransport.Server{
+			H3:          http3.Server{TLSConfig: tlsConf},
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
 	}
 	ln.ctx, ln.ctxCancel = context.WithCancel(context.Background())
 	mux := http.NewServeMux()


### PR DESCRIPTION
There's some discussion about the security properties of that check here: https://security.stackexchange.com/questions/115716/is-the-origin-header-really-useful-for-securing-a-websocket.

In the p2p world, we want to have cross-origin WebTransport sessions. In fact, that's the whole point of it!