### PR TITLE
webtransport: move certhash verification to the client

### DIFF
--- a/p2p/transport/webtransport/transport_test.go
+++ b/p2p/transport/webtransport/transport_test.go
@@ -162,11 +162,8 @@ func TestHashVerification(t *testing.T) {
 	})
 
 	t.Run("fails when adding a wrong hash", func(t *testing.T) {
-		conn, err := tr2.Dial(context.Background(), ln.Multiaddr().Encapsulate(foobarHash), serverID)
-		if err != nil {
-			_, err = conn.AcceptStream()
-			require.Error(t, err)
-		}
+		_, err := tr2.Dial(context.Background(), ln.Multiaddr().Encapsulate(foobarHash), serverID)
+		require.Error(t, err)
 	})
 
 	require.NoError(t, ln.Close())


### PR DESCRIPTION
As suggested in https://github.com/libp2p/specs/pull/455.

This PR builds on top #1750. **Please only review the last commit**. I'll rebase this PR once #1750 is merged.