### PR TITLE
Add ContentRoutingMany interface.

### DIFF
--- a/core/routing/routing.go
+++ b/core/routing/routing.go
@@ -7,6 +7,7 @@ import (
 
 	ci "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multihash"
 
 	cid "github.com/ipfs/go-cid"
 )
@@ -34,6 +35,16 @@ type ContentRouting interface {
 	// When count is 0, this method will return an unbounded number of
 	// results.
 	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.AddrInfo
+}
+
+// ContentRoutingMany complements ContentRouting intetface allowing providing several keys at
+// the same time, improving performance.
+type ContentRoutingMany interface {
+	// ProvideMany adds the given keys to the content routing system.
+	ProvideMany(ctx context.Context, keys []multihash.Multihash) error
+
+	// Ready checks if the router is ready to start providing keys.
+	Ready() bool
 }
 
 // PeerRouting is a way to find address information about certain peers.


### PR DESCRIPTION
We had been using the ProvideMany method in some Routing implementations to improve performance.

We had several places where we needed to create this same interface to cast Routers to check if they support the ProvideMany method. To avoid that, and to have a common source of truth we think we should make this interface live with the other Routing ones.