### PR TITLE
websocket: fix nil pointer in tlsClientConf

### DIFF
--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -95,8 +95,9 @@ func New(u transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*
 		rcmgr = network.NullResourceManager
 	}
 	t := &WebsocketTransport{
-		upgrader: u,
-		rcmgr:    rcmgr,
+		upgrader:      u,
+		rcmgr:         rcmgr,
+		tlsClientConf: &tls.Config{},
 	}
 	for _, opt := range opts {
 		if err := opt(t); err != nil {


### PR DESCRIPTION
It's possible (and common) to have a WebSocket transport without a tls client config. This leads to a nil pointer deref error when we set the ServerName.

This sets a default empty `tlsClientConf` and adds a test case.

Fixes https://github.com/libp2p/go-libp2p/issues/1769