### PR TITLE
add a roadmap for the next 6 months

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 # Table of Contents
 
 - [Background](#background)
+- [Roadmap](#roadmap)
 - [Usage](#usage)
   - [Examples](#examples)
 - [Development](#development)
@@ -36,6 +37,11 @@ To learn more, check out the following resources:
 - [**The libp2p Specification**](https://github.com/libp2p/specs)
 - [**js-libp2p implementation**](https://github.com/libp2p/js-libp2p)
 - [**rust-libp2p implementation**](https://github.com/libp2p/rust-libp2p)
+
+## Roadmap
+
+Our roadmap for go-libp2p can be found here: https://github.com/libp2p/go-libp2p/blob/master/ROADMAP.md
+This document represents current projects the go-libp2p team is focused on and provides an estimation of completion targets. It is a completementary roadmap to the overarching libp2p project roadmap: https://github.com/libp2p/specs/blob/master/ROADMAP.md
 
 ## Usage
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,4 @@
 
-
 # go-libp2p roadmap Q4’22/Q1’23
 
 ```
@@ -8,6 +7,28 @@ Status: In Progress
 Notes: This document is still in review will may be heavily modified based on stakeholder feedback. Please add any feedback or questions in:
 https://github.com/libp2p/go-libp2p/issues/1806
 ```
+
+## About the Roadmap
+### Sections
+This document consists of two sections: [Milestones](#Milestones) and the [Roadmap Appendix](#Roadmap-Appendix)
+
+[Milestones](#Milestones) is our best educated guess (not a hard commitment) around when we plan to ship the key features.
+Where possible we've broken down a project into discrete sub-projects e.g. project "A" (⚡Handshakes at the Speed of Light) contains three sub-projects and consists of A.1, A.2, and A.3
+A project is signified as "complete" once all of it's sub-projects are shipped.
+
+The [Roadmap Appendix](#Roadmap-Appendix) section describes each project in detail and lists its sub-projects (if applicable.) Here you can find the motivation for each project and goals.
+
+We've deep-linked each section header to it's corresponding GitHub Epic. Latest information on the progress of each project there can be found in the Epics and their child issues (as we will make regular updates.)
+
+### Done criteria
+Our "Definition of Done" for projects/sub-projects that involve writing new protocols or modifications to existing ones will usually consist of the following:
+- [ ] Spec is merged and classified as "Candidate Recommendation"
+- [ ] (by virtue of the above) At least one major reference implementation exists
+- [ ] A well established testing criteria (defined at the outset of the project) is met (testing via Testground or otherwise)
+- [ ] Public documentation (on docs.libp2p) exists
+
+Others supporting projects (like testing or benchmarking) will have different criteria.
+
 
 ## 🛣️ Milestones
 ### 2022

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,58 @@
+# go-libp2p roadmap Q4’22/Q1’23
+
+## 📊 Comprehensive Metrics
+
+Why: For far too long, go-libp2p has been a black box. This has hurt us many times, by allowing trivial bugs to go undetected for a long time ([example](https://github.com/ipfs/kubo/pull/8750)). Having metrics will allow us to track the impact of performance improvements we make over time.
+
+Goal: go-libp2p ships with Grafana dashboards that allow node operators to monitor their nodes in production.
+
+How: This will look similar to how we already expose resource manager metrics. Metrics can be added incrementally for libp2p’s components. First milestone is having metrics for the swarm.
+
+Tracking issue: [https://github.com/libp2p/go-libp2p/issues/1356](https://github.com/libp2p/go-libp2p/issues/1356)
+
+## 📺 Universal Browser Connectivity
+
+Why: A huge part of “the Web” is happening inside the browser. As a universal p2p networking stack, libp2p needs to be able to offer solutions for browser users.
+
+Goal: go-libp2p ships with up-to-date WebTransport and (libp2p-) WebRTC implementations, enabled by default. This allows connections between browsers and public nodes, browsers and non-public nodes as well as two browsers.
+
+1. WebTransport: as the protocol is still under development by IETF and W3C, our implementation needs to follow. To stay up to date, we will have to move as soon as Chrome ships support for a new draft version
+2. WebRTC: while browser to public node is getting close to finalized, there’ll be a push to make the other combinations work as well
+
+## ⚡️Handshakes at the Speed of Light
+
+Why: Historically, libp2p has been very wasteful when it comes to round trips spent during connection establishment. This is slowing down our users, especially their TTFB (time to first byte) metrics.
+
+Goal: go-libp2p optimizes its handshake latency up to the point where only increasing the speed of light would lead to further speedups. In particular, this means (in chronological order of a handshake):
+
+1. cutting off the 1 RTT wasted on security protocol negotiation by including the security protocol in the multiaddr: [https://github.com/libp2p/specs/pull/353](https://github.com/libp2p/specs/pull/353)
+2. cutting off the 1 RTT wasted on muxer negotiation: [https://github.com/libp2p/specs/issues/426](https://github.com/libp2p/specs/issues/426)
+3. using 0.5-RTT data (for TLS) / a Noise Extension to ship the list of Identify protocols, cutting of 1 RTT that many protocols spend waiting on `IdentifyWait`
+
+## 🧠 Smart Dialing
+
+Why: Having a large list of transports to pick from is great. Having an advanced stack that can dial all of them is even greater. But dialing all of them at the same time wastes our, the network’s and the peer’s resources. 
+
+Goal: When given a list of multiaddrs of a peer, go-libp2p is smart enough to pick the address that results in the most performant connection (for example, preferring QUIC over TCP), while also picking the address such that maximizes the likelihood of a successful handshake.
+
+How:
+
+1. implement some kind of “Happy-Eyeballs” style prioritization among all supported transports
+2. estimation of the expected RTT of a connection based on two nodes’ IP addresses, so that Happy Eyeballs Timeouts can be set dynamically
+3. detection of blackholes, especially relevant to detect UDP (QUIC) blackholing
+
+## 🧪 Future-proof Testing
+
+Why: Having lots of transports is great, and shaving off RTTs is awesome. We need to stay backwards-compatible with legacy go-libp2p implementations, and less advanced libp2p stacks.
+
+Goal: We have cross-version and cross-implementation Testground coverage that makes sure that we are able to establish a libp2p connection between two nodes, in the expected number of RTTs. This makes sure that the optimizations don’t break compatibility, actually have the performance impact we expect them to have, and serves as a regression test in the future.
+
+## 📢 Judicious Address Advertisements
+
+Why: A node that advertises lots of addresses hurts itself. Other nodes will have to try dialing a lot of addresses before they find one that actually works, dramatically increasing handshake latencies.
+
+Goal: Nodes only advertise addresses that they are actually reachable at.
+
+How: Unfortunately, the AutoNAT protocol can’t be used to probe the reachability of any particular address (especially due to a bug in the go-libp2p implementation deployed years ago). Most likely, we need a second version of the AutoNAT protocol.
+
+Related discussion: [https://github.com/libp2p/go-libp2p/issues/1480](https://github.com/libp2p/go-libp2p/issues/1480)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 Why: For far too long, go-libp2p has been a black box. This has hurt us many times, by allowing trivial bugs to go undetected for a long time ([example](https://github.com/ipfs/kubo/pull/8750)). Having metrics will allow us to track the impact of performance improvements we make over time.
 
-Goal: go-libp2p ships with Grafana dashboards that allow node operators to monitor their nodes in production.
+Goal: Export a wider set of metrics across go-libp2p components and enable node operators to monitor their nodes in production. Optionally provide a sample Grafana dashboard similar to the resource manager dashboard.
 
 How: This will look similar to how we already expose resource manager metrics. Metrics can be added incrementally for libp2p’s components. First milestone is having metrics for the swarm.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,64 +1,118 @@
+
+
 # go-libp2p roadmap Q4’22/Q1’23
 
-## 📊 Comprehensive Metrics
+```
+Date: 2022-10-07
+Status: In Progress
+Notes: This document is still in review will may be heavily modified based on stakeholder feedback. Please add any feedback or questions in:
+https://github.com/libp2p/go-libp2p/issues/1806
+```
 
-Why: For far too long, go-libp2p has been a black box. This has hurt us many times, by allowing trivial bugs to go undetected for a long time ([example](https://github.com/ipfs/kubo/pull/8750)). Having metrics will allow us to track the impact of performance improvements we make over time.
+## 🛣️ Milestones
+### 2022
 
-Goal: Export a wider set of metrics across go-libp2p components and enable node operators to monitor their nodes in production. Optionally provide a sample Grafana dashboard similar to the resource manager dashboard.
+#### Early Q4 (October)
+-   A.1⚡Handshakes at the Speed of Light - **[Early Muxer Negotiation](https://github.com/libp2p/specs/issues/426)**
+- E.1 🧪 Future-proof testing - **RTT test for Early Muxer Negotiation**
 
-How: This will look similar to how we already expose resource manager metrics. Metrics can be added incrementally for libp2p’s components. First milestone is having metrics for the swarm.
+### Mid Q4 (November)
+-   F.1 ⏱ Future-proof Benchmarking - **[Using nix-builders](https://github.com/testground/testground/pull/1425)**
 
-Tracking issue: [https://github.com/libp2p/go-libp2p/issues/1356](https://github.com/libp2p/go-libp2p/issues/1356)
+#### End of Q4 (December)
+-   B.1 🧠 Smart Dialing - **Happy Eyeballs**
+-   C 📊 Comprehensive Metrics - **Swarm metrics**
+-   D.1 📺 Universal Browser Connectivity - **[WebRTC Browser -> Server](https://github.com/libp2p/go-libp2p/pull/1655)**
 
-## 📺 Universal Browser Connectivity
+### 2023
 
-Why: A huge part of “the Web” is happening inside the browser. As a universal p2p networking stack, libp2p needs to be able to offer solutions for browser users.
+#### Early Q1 (January)
+-   B.2 🧠 Smart Dialing - **QUIC Blackhole detector**
+-   A.2 ⚡ Handshakes at the Speed of Light - **[Adding security protocol](https://github.com/libp2p/specs/pull/353)**
 
-Goal: go-libp2p ships with up-to-date WebTransport and (libp2p-) WebRTC implementations, enabled by default. This allows connections between browsers and public nodes, browsers and non-public nodes as well as two browsers.
+#### Mid Q1 (February)
+-   B.3 🧠 Smart Dialing - **RTT estimation**
+    -   🎉 Estimated Project Completion
 
-1. WebTransport: as the protocol is still under development by IETF and W3C, our implementation needs to follow. To stay up to date, we will have to move as soon as Chrome ships support for a new draft version
-2. WebRTC: while browser to public node is getting close to finalized, there’ll be a push to make the other combinations work as well
+#### End of Q1 (March)
+-   F.2 ⏱️ Future-proof benchmarking - **Using first class support for remote runners in Testground**
+-   A.3 ⚡ Handshakes at the Speed of Light - **0.5 RTT data optimization** (for QUIC)
+    -   🎉 Estimated Project Completion
 
-## ⚡️Handshakes at the Speed of Light
+#### Up Next
+-   D.2 📺 Universal Browser Connectivity - **[WebTransport](https://github.com/libp2p/go-libp2p/issues/1717)** update to new draft versions
+    - Dependency on Chrome needs to support new draft version of WebTransport protocol (still under development by IETF and W3C)
+-  E.2 🧪 Future-proof testing - **Comprehensive testing for non-transport features**
+-  G 📢 Judicious Address Advertisements
 
-Why: Historically, libp2p has been very wasteful when it comes to round trips spent during connection establishment. This is slowing down our users, especially their TTFB (time to first byte) metrics.
+# Roadmap Appendix
+## [A.⚡️Handshakes at the Speed of Light](https://github.com/libp2p/go-libp2p/issues/1807)
 
-Goal: go-libp2p optimizes its handshake latency up to the point where only increasing the speed of light would lead to further speedups. In particular, this means (in chronological order of a handshake):
+**Why**: Historically, libp2p has been very wasteful when it comes to round trips spent during connection establishment. This is slowing down our users, especially their TTFB (time to first byte) metrics.
 
-1. cutting off the 1 RTT wasted on security protocol negotiation by including the security protocol in the multiaddr: [https://github.com/libp2p/specs/pull/353](https://github.com/libp2p/specs/pull/353)
-2. cutting off the 1 RTT wasted on muxer negotiation: [https://github.com/libp2p/specs/issues/426](https://github.com/libp2p/specs/issues/426)
-3. using 0.5-RTT data (for TLS) / a Noise Extension to ship the list of Identify protocols, cutting of 1 RTT that many protocols spend waiting on `IdentifyWait`
+**Goal**: go-libp2p optimizes its handshake latency up to the point where only increasing the speed of light would lead to further speedups. In particular, this means:
 
-## 🧠 Smart Dialing
+1. [Early Muxer Negotiation](https://github.com/libp2p/specs/issues/426): cutting off the 1 RTT wasted on muxer negotiation
+2. [Adding security protocol](https://github.com/libp2p/specs/pull/353): cutting off the 1 RTT wasted on security protocol negotiation by including the security protocol in the multiaddr
+3. 0.5 RTT data optimization: using 0.5-RTT data (for TLS) / a Noise Extension to ship the list of Identify protocols, cutting of 1 RTT that many protocols spend waiting on `IdentifyWait`
 
-Why: Having a large list of transports to pick from is great. Having an advanced stack that can dial all of them is even greater. But dialing all of them at the same time wastes our, the network’s and the peer’s resources. 
+## [B. 🧠 Smart Dialing](https://github.com/libp2p/go-libp2p/issues/1808)
 
-Goal: When given a list of multiaddrs of a peer, go-libp2p is smart enough to pick the address that results in the most performant connection (for example, preferring QUIC over TCP), while also picking the address such that maximizes the likelihood of a successful handshake.
+**Why**: Having a large list of transports to pick from is great. Having an advanced stack that can dial all of them is even greater. But dialing all of them at the same time wastes our, the network’s and the peer’s resources. 
+
+**Goal**: When given a list of multiaddrs of a peer, go-libp2p is smart enough to pick the address that results in the most performant connection (for example, preferring QUIC over TCP), while also picking the address such that maximizes the likelihood of a successful handshake.
 
 How:
 
-1. implement some kind of “Happy-Eyeballs” style prioritization among all supported transports
-2. estimation of the expected RTT of a connection based on two nodes’ IP addresses, so that Happy Eyeballs Timeouts can be set dynamically
-3. detection of blackholes, especially relevant to detect UDP (QUIC) blackholing
+1. Happy Eyeballs: implement some kind of “Happy-Eyeballs” style prioritization among all supported transports
+2. QUIC Blackhole detector: detection of blackholes, especially relevant to detect UDP (QUIC) blackholing
+3. RTT estimation: estimation of the expected RTT of a connection based on two nodes’ IP addresses, so that Happy Eyeballs Timeouts can be set dynamically
 
-## 🧪 Future-proof Testing
+## [C. 📊 Comprehensive Metrics](https://github.com/libp2p/go-libp2p/issues/1356)
 
-Why: Having lots of transports is great, and shaving off RTTs is awesome. We need to stay backwards-compatible with legacy go-libp2p implementations, and less advanced libp2p stacks.
+**Why**: For far too long, go-libp2p has been a black box. This has hurt us many times, by allowing trivial bugs to go undetected for a long time ([example](https://github.com/ipfs/kubo/pull/8750)). Having metrics will allow us to track the impact of performance improvements we make over time.
 
-Goal: We have cross-version and cross-implementation Testground coverage that makes sure that we are able to establish a libp2p connection between two nodes, in the expected number of RTTs. This makes sure that the optimizations don’t break compatibility, actually have the performance impact we expect them to have, and serves as a regression test in the future.
+**Goal**: Export a wider set of metrics across go-libp2p components and enable node operators to monitor their nodes in production. Optionally provide a sample Grafana dashboard similar to the resource manager dashboard.
 
-## ⏱ Future-proof Benchmarking
+**How**: This will look similar to how we already expose resource manager metrics. Metrics can be added incrementally for libp2p’s components. First milestone is having metrics for the swarm.
 
-Why: For libp2p to be competitive, it needs to delivers comparable performance to widely used protocols on the internet, namely HTTP/2 and HTTP/3.
+## [D. 📺 Universal Browser Connectivity](https://github.com/libp2p/go-libp2p/issues/1811)
 
-Goal: We have a test suite that runs libp2p transfers between nodes located at different locations all over the world, proving that libp2p is able to achieve performance on par with HTTP. The test suite is run on a continuous basis and results are published to a public performance dashboard.
+**Why**: A huge part of “the Web” is happening inside the browser. As a universal p2p networking stack, libp2p needs to be able to offer solutions for browser users.
 
-## 📢 Judicious Address Advertisements
+**Goal**: go-libp2p ships with up-to-date WebTransport and (libp2p-) WebRTC implementations, enabled by default. This allows connections between browsers and public nodes, browsers and non-public nodes as well as two browsers.
 
-Why: A node that advertises lots of addresses hurts itself. Other nodes will have to try dialing a lot of addresses before they find one that actually works, dramatically increasing handshake latencies.
+1. [WebRTC](https://github.com/libp2p/go-libp2p/pull/1655): while browser to public node is getting close to finalized, there’ll be a push to make the other combinations work as well
+2. [WebTransport](https://github.com/libp2p/go-libp2p/issues/1717): as the protocol is still under development by IETF and W3C, our implementation needs to follow. To stay up to date, we will have to move as soon as Chrome ships support for a new draft version
 
-Goal: Nodes only advertise addresses that they are actually reachable at.
+## [E. 🧪 Future-proof Testing](https://github.com/libp2p/go-libp2p/issues/1809)
 
-How: Unfortunately, the AutoNAT protocol can’t be used to probe the reachability of any particular address (especially due to a bug in the go-libp2p implementation deployed years ago). Most likely, we need a second version of the AutoNAT protocol.
+**Why**: Having lots of transports is great, and shaving off RTTs is awesome. We need to stay backwards-compatible with legacy go-libp2p implementations, and less advanced libp2p stacks.
+
+**Goal**: We have cross-version and cross-implementation Testground coverage that makes sure that we are able to establish a libp2p connection between two nodes, in the expected number of RTTs. This makes sure that the optimizations don’t break compatibility, actually have the performance impact we expect them to have, and serves as a regression test in the future.
+
+1. RTT test for Early Muxer Negotiation (A.1)
+2. Comprehensive testing for non-transport features (AutoNat, Hole punching, etc.)
+
+## [F. ⏱ Future-proof Benchmarking](https://github.com/libp2p/go-libp2p/issues/1810)
+
+**Why**: For libp2p to be competitive, it needs to delivers comparable performance to widely used protocols on the internet, namely HTTP/2 and HTTP/3.
+
+**Goal**: We have a test suite that runs libp2p transfers between nodes located at different locations all over the world, proving that libp2p is able to achieve performance on par with HTTP. The test suite is run on a continuous basis and results are published to a public performance dashboard.
+
+1. [Benchmarking using nix-builders](https://github.com/testground/testground/pull/1425)
+    - (Dependency: remote machines need Nix installed)
+2. Benchmarking using first class support for remote runners (using `remote:exec`) in Testground
+
+## [G. 📢 Judicious Address Advertisements](https://github.com/libp2p/go-libp2p/issues/1812)
+
+**Why**: A node that advertises lots of addresses hurts itself. Other nodes will have to try dialing a lot of addresses before they find one that actually works, dramatically increasing handshake latencies.
+
+**Goal**: Nodes only advertise addresses that they are actually reachable at.
+
+**How**: Unfortunately, the AutoNAT protocol can’t be used to probe the reachability of any particular address (especially due to a bug in the go-libp2p implementation deployed years ago). Most likely, we need a second version of the AutoNAT protocol.
 
 Related discussion: [https://github.com/libp2p/go-libp2p/issues/1480](https://github.com/libp2p/go-libp2p/issues/1480)
+
+## Libp2p Project Roadmap
+Roadmap items in this document were sourced from our the overarching libp2p project roadmap: https://github.com/libp2p/specs/blob/master/ROADMAP.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,7 +108,7 @@ How:
 
 ## [E. 🧪 Future-proof Testing](https://github.com/libp2p/go-libp2p/issues/1809)
 
-**Why**: Having lots of transports is great, and shaving off RTTs is awesome. We need to stay backwards-compatible with legacy go-libp2p implementations, and less advanced libp2p stacks.
+**Why**: Having lots of transports, encryption mechanism, and stream muxers is great, and shaving off RTTs is awesome. We need to stay backwards-compatible with legacy go-libp2p release, other libp2p implementations, and less advanced libp2p stacks.
 
 **Goal**: We have cross-version and cross-implementation Testground coverage that makes sure that we are able to establish a libp2p connection between two nodes, in the expected number of RTTs. This makes sure that the optimizations don’t break compatibility, actually have the performance impact we expect them to have, and serves as a regression test in the future.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,12 @@ Why: Having lots of transports is great, and shaving off RTTs is awesome. We nee
 
 Goal: We have cross-version and cross-implementation Testground coverage that makes sure that we are able to establish a libp2p connection between two nodes, in the expected number of RTTs. This makes sure that the optimizations don’t break compatibility, actually have the performance impact we expect them to have, and serves as a regression test in the future.
 
+## ⏱ Future-proof Benchmarking
+
+Why: For libp2p to be competitive, it needs to delivers comparable performance to widely used protocols on the internet, namely HTTP/2 and HTTP/3.
+
+Goal: We have a test suite that runs libp2p transfers between nodes located at different locations all over the world, proving that libp2p is able to achieve performance on par with HTTP. The test suite is run on a continuous basis and results are published to a public performance dashboard.
+
 ## 📢 Judicious Address Advertisements
 
 Why: A node that advertises lots of addresses hurts itself. Other nodes will have to try dialing a lot of addresses before they find one that actually works, dramatically increasing handshake latencies.


### PR DESCRIPTION
I took a first stab at our roadmap for the next half a year. This document contains that are specific to the go-libp2p stack. General libp2p project items are listed in the [roadmap in the specs repo](https://github.com/libp2p/specs/blob/master/ROADMAP.md). Sections are in no particular order.

**This document is intended as a conversation starter**. 
I intend to keep this PR open for at least a week to give plenty of time for feedback.