### PR TITLE
autorelay: not discarding static relays on connectivity failures

### DIFF
--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -45,7 +45,7 @@ func NewAutoRelay(bhost *basic.BasicHost, opts ...Option) (*AutoRelay, error) {
 	}
 	r.ctx, r.ctxCancel = context.WithCancel(context.Background())
 	r.conf = &conf
-	r.relayFinder = newRelayFinder(bhost, conf.peerSource, conf.staticRelaySource, &conf)
+	r.relayFinder = newRelayFinder(bhost, conf.peerSource, &conf)
 	bhost.AddrsFactory = r.hostAddrs
 
 	r.refCount.Add(1)

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -45,7 +45,7 @@ func NewAutoRelay(bhost *basic.BasicHost, opts ...Option) (*AutoRelay, error) {
 	}
 	r.ctx, r.ctxCancel = context.WithCancel(context.Background())
 	r.conf = &conf
-	r.relayFinder = newRelayFinder(bhost, conf.peerSource, &conf)
+	r.relayFinder = newRelayFinder(bhost, conf.peerSource, conf.staticRelaySource, &conf)
 	bhost.AddrsFactory = r.hostAddrs
 
 	r.refCount.Add(1)

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -28,8 +28,6 @@ type config struct {
 	backoff time.Duration
 	// Number of relays we strive to obtain a reservation with.
 	desiredRelays int
-	// staticRescan is the time we periodically rescan for disconnected static relays.
-	staticRescan time.Duration
 	// see WithMaxCandidateAge
 	maxCandidateAge  time.Duration
 	setMinCandidates bool
@@ -44,7 +42,6 @@ var defaultConfig = config{
 	backoff:         time.Hour,
 	desiredRelays:   2,
 	maxCandidateAge: 30 * time.Minute,
-	staticRescan:    10 * time.Minute,
 }
 
 var (
@@ -170,14 +167,6 @@ func WithBootDelay(d time.Duration) Option {
 func WithBackoff(d time.Duration) Option {
 	return func(c *config) error {
 		c.backoff = d
-		return nil
-	}
-}
-
-// WithStaticRescan sets the time we wait until initialize a new static relay scan.
-func WithStaticRescan(d time.Duration) Option {
-	return func(c *config) error {
-		c.staticRescan = d
 		return nil
 	}
 }

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -86,6 +86,15 @@ func WithStaticRelays(static []peer.AddrInfo) Option {
 		}
 		c.minCandidates = len(static)
 		c.staticRelays = static
+
+		c.peerSource = func(_ context.Context, num int) <-chan peer.AddrInfo {
+			peerChan := make(chan peer.AddrInfo, c.minCandidates)
+			for _, r := range c.staticRelays {
+				peerChan <- peer.AddrInfo{ID: r.ID, Addrs: r.Addrs}
+			}
+			close(peerChan)
+			return peerChan
+		}
 		return nil
 	}
 }

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -15,8 +16,10 @@ type config struct {
 	clock      clock.Clock
 	peerSource func(ctx context.Context, num int) <-chan peer.AddrInfo
 	// minimum interval used to call the peerSource callback
-	minInterval  time.Duration
-	staticRelays []peer.AddrInfo
+	peerMinInterval   time.Duration
+	staticRelaySource func(ctx context.Context, num int) <-chan peer.AddrInfo
+	// minimum interval used to call the staticRelaySource callback
+	staticRelayMinInterval time.Duration
 	// see WithMinCandidates
 	minCandidates int
 	// see WithMaxCandidates
@@ -44,11 +47,6 @@ var defaultConfig = config{
 	maxCandidateAge: 30 * time.Minute,
 }
 
-var (
-	errStaticRelaysMinCandidates = errors.New("cannot use WithMinCandidates and WithStaticRelays")
-	errStaticRelaysPeerSource    = errors.New("cannot use WithPeerSource and WithStaticRelays")
-)
-
 // DefaultRelays are the known PL-operated v1 relays; will be decommissioned in 2022.
 var DefaultRelays = []string{
 	"/ip4/147.75.80.110/tcp/4001/p2p/QmbFgm5zan8P6eWWmeyfncR5feYEMPbht5b1FW1C37aQ7y",
@@ -74,18 +72,27 @@ func init() {
 type Option func(*config) error
 
 func WithStaticRelays(static []peer.AddrInfo) Option {
+
+	staticRelayChan := make(chan peer.AddrInfo, len(static))
+
 	return func(c *config) error {
-		if c.setMinCandidates {
-			return errStaticRelaysMinCandidates
-		}
-		if c.peerSource != nil {
-			return errStaticRelaysPeerSource
-		}
-		if len(c.staticRelays) > 0 {
+		if c.staticRelaySource != nil {
 			return errors.New("can't set static relays, static relays already configured")
 		}
 		c.minCandidates = len(static)
-		c.staticRelays = static
+		c.staticRelaySource = func(ctx context.Context, num int) <-chan peer.AddrInfo {
+			c.staticRelayMinInterval = time.Hour
+			rand.Seed(time.Now().UnixNano())
+			var static_candidates = static
+			rand.Shuffle(len(static_candidates), func(i, j int) {
+				static_candidates[i], static_candidates[j] = static_candidates[j], static_candidates[i]
+			})
+			for i := 0; i < num%c.minCandidates; i++ {
+				staticRelayChan <- static_candidates[i]
+			}
+			return staticRelayChan
+		}
+
 		return nil
 	}
 }
@@ -107,11 +114,8 @@ func WithDefaultStaticRelays() Option {
 // If the channel is canceled you MUST close the output channel at some point.
 func WithPeerSource(f func(ctx context.Context, numPeers int) <-chan peer.AddrInfo, minInterval time.Duration) Option {
 	return func(c *config) error {
-		if len(c.staticRelays) > 0 {
-			return errStaticRelaysPeerSource
-		}
 		c.peerSource = f
-		c.minInterval = minInterval
+		c.peerMinInterval = minInterval
 		return nil
 	}
 }
@@ -140,9 +144,6 @@ func WithMaxCandidates(n int) Option {
 // This is to make sure that we don't just randomly connect to the first candidate that we discover.
 func WithMinCandidates(n int) Option {
 	return func(c *config) error {
-		if len(c.staticRelays) > 0 {
-			return errStaticRelaysMinCandidates
-		}
 		if n > c.maxCandidates {
 			n = c.maxCandidates
 		}

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -28,6 +28,8 @@ type config struct {
 	backoff time.Duration
 	// Number of relays we strive to obtain a reservation with.
 	desiredRelays int
+	// staticRescan is the time we periodically rescan for disconnected static relays.
+	staticRescan time.Duration
 	// see WithMaxCandidateAge
 	maxCandidateAge  time.Duration
 	setMinCandidates bool
@@ -42,6 +44,7 @@ var defaultConfig = config{
 	backoff:         time.Hour,
 	desiredRelays:   2,
 	maxCandidateAge: 30 * time.Minute,
+	staticRescan:    10 * time.Minute,
 }
 
 var (
@@ -167,6 +170,14 @@ func WithBootDelay(d time.Duration) Option {
 func WithBackoff(d time.Duration) Option {
 	return func(c *config) error {
 		c.backoff = d
+		return nil
+	}
+}
+
+// WithStaticRescan sets the time we wait until initialize a new static relay scan.
+func WithStaticRescan(d time.Duration) Option {
+	return func(c *config) error {
+		c.staticRescan = d
 		return nil
 	}
 }

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -59,7 +59,8 @@ type relayFinder struct {
 	ctxCancel   context.CancelFunc
 	ctxCancelMx sync.Mutex
 
-	peerSource func(context.Context, int) <-chan peer.AddrInfo
+	peerSource        func(context.Context, int) <-chan peer.AddrInfo
+	staticRelaySource func(context.Context, int) <-chan peer.AddrInfo
 
 	candidateFound             chan struct{} // receives every time we find a new relay candidate
 	candidateMx                sync.Mutex
@@ -82,12 +83,14 @@ type relayFinder struct {
 	cachedAddrsExpiry time.Time
 }
 
-func newRelayFinder(host *basic.BasicHost, peerSource func(context.Context, int) <-chan peer.AddrInfo, conf *config) *relayFinder {
+func newRelayFinder(host *basic.BasicHost, peerSource, staticRelaySource func(context.Context, int) <-chan peer.AddrInfo,
+	conf *config) *relayFinder {
 	return &relayFinder{
 		bootTime:                   conf.clock.Now(),
 		host:                       host,
 		conf:                       conf,
 		peerSource:                 peerSource,
+		staticRelaySource:          staticRelaySource,
 		candidates:                 make(map[peer.ID]*candidate),
 		backoff:                    make(map[peer.ID]time.Time),
 		candidateFound:             make(chan struct{}, 1),
@@ -99,19 +102,11 @@ func newRelayFinder(host *basic.BasicHost, peerSource func(context.Context, int)
 }
 
 func (rf *relayFinder) background(ctx context.Context) {
-	if rf.usesStaticRelay() {
-		rf.refCount.Add(1)
-		go func() {
-			defer rf.refCount.Done()
-			rf.handleStaticRelays(ctx)
-		}()
-	} else {
-		rf.refCount.Add(1)
-		go func() {
-			defer rf.refCount.Done()
-			rf.findNodes(ctx)
-		}()
-	}
+	rf.refCount.Add(1)
+	go func() {
+		defer rf.refCount.Done()
+		rf.findNodes(ctx)
+	}()
 
 	rf.refCount.Add(1)
 	go func() {
@@ -206,10 +201,18 @@ func (rf *relayFinder) background(ctx context.Context) {
 // It garbage collects old entries, so that nodes doesn't overflow.
 // This makes sure that as soon as we need to find relay candidates, we have them available.
 func (rf *relayFinder) findNodes(ctx context.Context) {
-	peerChan := rf.peerSource(ctx, rf.conf.maxCandidates)
+	var peerChan <-chan peer.AddrInfo = nil
+	//var staticRelayChan <-chan peer.AddrInfo = nil
+	if rf.peerSource != nil {
+		peerChan = rf.peerSource(ctx, rf.conf.maxCandidates)
+	}
+	//if rf.staticRelaySource != nil {
+	//	staticRelayChan = rf.staticRelaySource(ctx, rf.conf.maxCandidates)
+	//}
+
 	var wg sync.WaitGroup
 	lastCallToPeerSource := rf.conf.clock.Now()
-
+	//lastCallToStaticRelaySource := rf.conf.clock.Now()
 	timer := newTimer(rf.conf.clock)
 	for {
 		rf.candidateMx.Lock()
@@ -218,7 +221,7 @@ func (rf *relayFinder) findNodes(ctx context.Context) {
 
 		if peerChan == nil {
 			now := rf.conf.clock.Now()
-			nextAllowedCallToPeerSource := lastCallToPeerSource.Add(rf.conf.minInterval).Sub(now)
+			nextAllowedCallToPeerSource := lastCallToPeerSource.Add(rf.conf.peerMinInterval).Sub(now)
 			if numCandidates < rf.conf.minCandidates {
 				log.Debugw("not enough candidates. Resetting timer", "num", numCandidates, "desired", rf.conf.minCandidates)
 				timer.Reset(nextAllowedCallToPeerSource)
@@ -268,23 +271,6 @@ func (rf *relayFinder) findNodes(ctx context.Context) {
 			return
 		}
 	}
-}
-
-func (rf *relayFinder) handleStaticRelays(ctx context.Context) {
-	sem := make(chan struct{}, 4)
-	var wg sync.WaitGroup
-	wg.Add(len(rf.conf.staticRelays))
-	for _, pi := range rf.conf.staticRelays {
-		sem <- struct{}{}
-		go func(pi peer.AddrInfo) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			rf.handleNewNode(ctx, pi)
-		}(pi)
-	}
-	wg.Wait()
-	log.Debug("processed all static relays")
-	rf.notifyNewCandidate()
 }
 
 func (rf *relayFinder) notifyMaybeConnectToRelay() {
@@ -640,7 +626,7 @@ func (rf *relayFinder) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 }
 
 func (rf *relayFinder) usesStaticRelay() bool {
-	return len(rf.conf.staticRelays) > 0
+	return rf.conf.staticRelaySource != nil
 }
 
 func (rf *relayFinder) Start() error {

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -99,19 +99,11 @@ func newRelayFinder(host *basic.BasicHost, peerSource func(context.Context, int)
 }
 
 func (rf *relayFinder) background(ctx context.Context) {
-	if rf.usesStaticRelay() {
-		rf.refCount.Add(1)
-		go func() {
-			defer rf.refCount.Done()
-			rf.handleStaticRelays(ctx)
-		}()
-	} else {
-		rf.refCount.Add(1)
-		go func() {
-			defer rf.refCount.Done()
-			rf.findNodes(ctx)
-		}()
-	}
+	rf.refCount.Add(1)
+	go func() {
+		defer rf.refCount.Done()
+		rf.findNodes(ctx)
+	}()
 
 	rf.refCount.Add(1)
 	go func() {
@@ -268,23 +260,6 @@ func (rf *relayFinder) findNodes(ctx context.Context) {
 			return
 		}
 	}
-}
-
-func (rf *relayFinder) handleStaticRelays(ctx context.Context) {
-	sem := make(chan struct{}, 4)
-	var wg sync.WaitGroup
-	wg.Add(len(rf.conf.staticRelays))
-	for _, pi := range rf.conf.staticRelays {
-		sem <- struct{}{}
-		go func(pi peer.AddrInfo) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			rf.handleNewNode(ctx, pi)
-		}(pi)
-	}
-	wg.Wait()
-	log.Debug("processed all static relays")
-	rf.notifyNewCandidate()
 }
 
 func (rf *relayFinder) notifyMaybeConnectToRelay() {
@@ -446,7 +421,7 @@ func (rf *relayFinder) maybeConnectToRelay(ctx context.Context) {
 	}
 
 	rf.candidateMx.Lock()
-	if !rf.usesStaticRelay() && len(rf.relays) == 0 && len(rf.candidates) < rf.conf.minCandidates && rf.conf.clock.Since(rf.bootTime) < rf.conf.bootDelay {
+	if len(rf.relays) == 0 && len(rf.candidates) < rf.conf.minCandidates && rf.conf.clock.Since(rf.bootTime) < rf.conf.bootDelay {
 		// During the startup phase, we don't want to connect to the first candidate that we find.
 		// Instead, we wait until we've found at least minCandidates, and then select the best of those.
 		// However, if that takes too long (longer than bootDelay), we still go ahead.
@@ -637,10 +612,6 @@ func (rf *relayFinder) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	rf.cachedAddrsExpiry = rf.conf.clock.Now().Add(30 * time.Second)
 
 	return raddrs
-}
-
-func (rf *relayFinder) usesStaticRelay() bool {
-	return len(rf.conf.staticRelays) > 0
 }
 
 func (rf *relayFinder) Start() error {


### PR DESCRIPTION
Static relays are a special kind of relays, since the client has spent some time bootstrappin those relays. Thats why if the client (autorelay) looses connection with such a relays, it should not be treated like regular relays (e.g. discarding them) Two cases come to mind:
1. If a static relay goes down (for maintenance purposes), typically the client has more than one static relay, so autorelay will start making slots reservations on the ones online. However, once the first static relay is up again, it should be part again of the candidate list. Current implementation, [discard a failing static relay right away](https://github.com/libp2p/go-libp2p/blob/master/p2p/host/autorelay/relay_finder.go#L152-L158).
2. If the client switchs networks or simply the network gets down for a while (not restarting the client since that would imply static relays [being rescanned](https://github.com/libp2p/go-libp2p/blob/master/p2p/host/autorelay/relay_finder.go#L106)), then the client would discard all relays, and when back up again, it won't have any static relays available (unles autorelay gets resseted)

This can be solved in two ways, either not discarding a static relay on connection errors (and send it back to candidates) or implementing a timer to periodically call [handleStaticRelay](https://github.com/libp2p/go-libp2p/blob/master/p2p/host/autorelay/relay_finder.go#L273-L288). I have implemented both, since the former responses quicker in case no 1 and the latter periodically rescues forgotten static relays in case no 2

This PR solves #1782 