### PR TITLE
p2p/protocol: add ping timeout option

### DIFF
--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -144,6 +144,7 @@ func (hp *holePuncher) directConnect(rp peer.ID) error {
 		// wait for sync to reach the other peer and then punch a hole for it in our NAT
 		// by attempting a connect to it.
 		timer := time.NewTimer(synTime)
+		defer timer.Stop()
 		select {
 		case start := <-timer.C:
 			pi := peer.AddrInfo{
@@ -160,7 +161,6 @@ func (hp *holePuncher) directConnect(rp peer.ID) error {
 				return nil
 			}
 		case <-hp.ctx.Done():
-			timer.Stop()
 			return hp.ctx.Err()
 		}
 	}


### PR DESCRIPTION
Would be nice to be able to set a timeout to PingService. There are no changes to the existing interface.

This PR includes a small fix in holepuncher. 
- Coverage the case that doesn't call 'timer.Stop'.
https://github.com/libp2p/go-libp2p/blob/7828f3e0797e0a7b7033fa5e8be9b94f57a4c173/p2p/protocol/holepunch/holepuncher.go#L158-L160
