### PR TITLE
fix: try increasing timeouts if we're in CI for this test

### DIFF
--- a/p2p/transport/quic/reuse_test.go
+++ b/p2p/transport/quic/reuse_test.go
@@ -3,6 +3,7 @@ package libp2pquic
 import (
 	"bytes"
 	"net"
+	"os"
 	"runtime/pprof"
 	"strings"
 	"testing"
@@ -144,6 +145,11 @@ func TestReuseGarbageCollect(t *testing.T) {
 	})
 	garbageCollectInterval = 50 * time.Millisecond
 	maxUnusedDuration = 100 * time.Millisecond
+	if os.Getenv("CI") != "" {
+		// Increase these timeouts if in CI
+		garbageCollectInterval = 10 * garbageCollectInterval
+		maxUnusedDuration = 10 * maxUnusedDuration
+	}
 
 	reuse := newReuse()
 	cleanup(t, reuse)


### PR DESCRIPTION
Increases these timeouts 10x if in CI. We got two failures here were these failed because of the timeout:

* https://github.com/libp2p/go-libp2p/actions/runs/3114377990/jobs/5050146995#step:7:2541
* https://github.com/libp2p/go-libp2p/actions/runs/3114811283/jobs/5051064314#step:7:2541