### PR TITLE
examples: connect to all peers in example mdns chat app

### DIFF
--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -120,6 +120,7 @@ func main() {
 
 		if err := host.Connect(ctx, peer); err != nil {
 			fmt.Println("Connection failed:", err)
+			continue
 		}
 
 		// open a stream, this stream will be handled by handleStream other end

--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -114,26 +114,25 @@ func main() {
 	fmt.Printf("\n[*] Your Multiaddress Is: /ip4/%s/tcp/%v/p2p/%s\n", cfg.listenHost, cfg.listenPort, host.ID().Pretty())
 
 	peerChan := initMDNS(host, cfg.RendezvousString)
+	for { // allows multiple peers to join
+		peer := <-peerChan // will block untill we discover a peer
+		fmt.Println("Found peer:", peer, ", connecting")
 
-	peer := <-peerChan // will block untill we discover a peer
-	fmt.Println("Found peer:", peer, ", connecting")
+		if err := host.Connect(ctx, peer); err != nil {
+			fmt.Println("Connection failed:", err)
+		}
 
-	if err := host.Connect(ctx, peer); err != nil {
-		fmt.Println("Connection failed:", err)
+		// open a stream, this stream will be handled by handleStream other end
+		stream, err := host.NewStream(ctx, peer.ID, protocol.ID(cfg.ProtocolID))
+
+		if err != nil {
+			fmt.Println("Stream open failed", err)
+		} else {
+			rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
+
+			go writeData(rw)
+			go readData(rw)
+			fmt.Println("Connected to:", peer)
+		}
 	}
-
-	// open a stream, this stream will be handled by handleStream other end
-	stream, err := host.NewStream(ctx, peer.ID, protocol.ID(cfg.ProtocolID))
-
-	if err != nil {
-		fmt.Println("Stream open failed", err)
-	} else {
-		rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
-
-		go writeData(rw)
-		go readData(rw)
-		fmt.Println("Connected to:", peer)
-	}
-
-	select {} // wait here
 }


### PR DESCRIPTION
Fixes [#1797](https://github.com/libp2p/go-libp2p/issues/1797)

Added if condition to make sure it is not attempting self dial .

Added for loop so that multiple peers can join chat .