### PR TITLE
circuitv2: flaky: don't use rcmgr in this test

### DIFF
--- a/p2p/protocol/circuitv2/client/reservation_test.go
+++ b/p2p/protocol/circuitv2/client/reservation_test.go
@@ -89,7 +89,7 @@ func TestReservationFailures(t *testing.T) {
 				host.SetStreamHandler(proto.ProtoIDv2Hop, tc.streamHandler)
 			}
 
-			cl, err := libp2p.New()
+			cl, err := libp2p.New(libp2p.ResourceManager(network.NullResourceManager))
 			require.NoError(t, err)
 			defer cl.Close()
 			_, err = client.Reserve(context.Background(), cl, peer.AddrInfo{ID: host.ID(), Addrs: host.Addrs()})


### PR DESCRIPTION
I'm not sure why this causes flakiness. It's pretty rare (2 instances in the last 16 days). But we don't need the resource manager for this test. And the test is checking that there is a specific error condition. So it seems okay (but not ideal) to not use the resource manager here so that we are more likely to see the error we want. Another argument is that this test has nothing to do with the resource manager, and the only reason it was in there originally was for convenience.

Flaky runs:
* https://github.com/libp2p/go-libp2p/actions/runs/3094283154/jobs/5007493400
* https://github.com/libp2p/go-libp2p/actions/runs/3092850661/jobs/5004581612