### PR TITLE
identify: Surface error in IdentifyConn and flaky TestIdentifyPushOnAddrChange

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -330,13 +330,13 @@ func (ids *idService) IdentifyWait(c network.Conn) <-chan error {
 		// already, but that doesn't really matter. We'll fail to open a
 		// stream then forget the connection.
 		go func() {
-			defer close(wait)
 			if err := ids.identifyConn(c); err != nil {
 				log.Warnf("failed to identify %s: %s", c.RemotePeer(), err)
 				ids.emitters.evtPeerIdentificationFailed.Emit(event.EvtPeerIdentificationFailed{Peer: c.RemotePeer(), Reason: err})
 				wait <- err
 				return
 			}
+			wait <- nil
 			ids.emitters.evtPeerIdentificationCompleted.Emit(event.EvtPeerIdentificationCompleted{Peer: c.RemotePeer()})
 		}()
 	}

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -622,7 +622,8 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 
 	// h2 should now see the connection and we should wait for h1 to Identify itself to h2.
 	require.NotEmpty(t, h2.Network().ConnsToPeer(h1p))
-	ids2.IdentifyConn(h2.Network().ConnsToPeer(h1p)[0])
+	err = <-ids2.IdentifyWait(h2.Network().ConnsToPeer(h1p)[0])
+	require.NoError(t, err)
 
 	testKnowsAddrs(t, h1, h2p, h2.Peerstore().Addrs(h2p))
 	testKnowsAddrs(t, h2, h1p, h1.Peerstore().Addrs(h1p))


### PR DESCRIPTION
Changes `IdentifyWait` to return a `chan error` instead of a `chan struct{}`. This lets us surface errors to the caller.

This is technically a breaking api change, but I think it is safe because before users would ignore the return value, so they can still ignore the return value and get the same behavior. Callers who are interested if this identify failed can now use the returned error.

The first caller that cares is our flaky `TestIdentifyPushOnAddrChange`. This should tell us why this is failing and give us next steps to fix the flakiness.