### PR TITLE
ipfs /api/v0/id is post

### DIFF
--- a/examples/routed-echo/bootstrap.go
+++ b/examples/routed-echo/bootstrap.go
@@ -43,7 +43,7 @@ type IdOutput struct {
 
 // quick and dirty function to get the local ipfs daemons address for bootstrapping
 func getLocalPeerInfo() []peer.AddrInfo {
-	resp, err := http.Get(LOCAL_PEER_ENDPOINT)
+	resp, err := http.PostForm(LOCAL_PEER_ENDPOINT, nil)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
curl -X POST "http://127.0.0.1:5001/api/v0/id

https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-id