### PR TITLE
noise: add an option to allow unknown peer ID in SecureOutbound 

### DIFF
--- a/p2p/security/noise/crypto_test.go
+++ b/p2p/security/noise/crypto_test.go
@@ -93,7 +93,7 @@ func TestCryptoFailsIfHandshakeIncomplete(t *testing.T) {
 	init, resp := net.Pipe()
 	_ = resp.Close()
 
-	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", nil, nil, nil, true)
+	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", nil, nil, nil, true, true)
 	_, err := session.encrypt(nil, []byte("hi"))
 	if err == nil {
 		t.Error("expected encryption error when handshake incomplete")

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -272,12 +272,14 @@ func (s *secureSession) handleRemoteHandshakePayload(payload []byte, remoteStati
 		return nil, err
 	}
 
-	// check the peer ID for:
-	// * all connections, if we know the peer ID to which we want to connect.
-	if s.remoteID != "" && s.remoteID != id {
-		// use Pretty() as it produces the full b58-encoded string, rather than abbreviated forms.
+	// check the peer ID if enabled
+	if s.checkPeerID && s.remoteID != id {
 		return nil, fmt.Errorf("peer id mismatch: expected %s, but remote key matches %s", s.remoteID.Pretty(), id.Pretty())
 	}
+	// if (s.initiator && s.remoteID != id) || (!s.initiator && s.remoteID != "" && s.remoteID != id) {
+	// 	// use Pretty() as it produces the full b58-encoded string, rather than abbreviated forms.
+	// 	return nil, fmt.Errorf("peer id mismatch: expected %s, but remote key matches %s", s.remoteID.Pretty(), id.Pretty())
+	// }
 
 	// verify payload is signed by asserted remote libp2p key.
 	sig := nhp.GetIdentitySig()

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -276,10 +276,6 @@ func (s *secureSession) handleRemoteHandshakePayload(payload []byte, remoteStati
 	if s.checkPeerID && s.remoteID != id {
 		return nil, fmt.Errorf("peer id mismatch: expected %s, but remote key matches %s", s.remoteID.Pretty(), id.Pretty())
 	}
-	// if (s.initiator && s.remoteID != id) || (!s.initiator && s.remoteID != "" && s.remoteID != id) {
-	// 	// use Pretty() as it produces the full b58-encoded string, rather than abbreviated forms.
-	// 	return nil, fmt.Errorf("peer id mismatch: expected %s, but remote key matches %s", s.remoteID.Pretty(), id.Pretty())
-	// }
 
 	// verify payload is signed by asserted remote libp2p key.
 	sig := nhp.GetIdentitySig()

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -273,9 +273,8 @@ func (s *secureSession) handleRemoteHandshakePayload(payload []byte, remoteStati
 	}
 
 	// check the peer ID for:
-	// * all outbound connection
-	// * inbound connections, if we know which peer we want to connect to (SecureInbound called with a peer ID)
-	if (s.initiator && s.remoteID != id) || (!s.initiator && s.remoteID != "" && s.remoteID != id) {
+	// * all connections, if we know the peer ID to which we want to connect.
+	if s.remoteID != "" && s.remoteID != id {
 		// use Pretty() as it produces the full b58-encoded string, rather than abbreviated forms.
 		return nil, fmt.Errorf("peer id mismatch: expected %s, but remote key matches %s", s.remoteID.Pretty(), id.Pretty())
 	}

--- a/p2p/security/noise/session.go
+++ b/p2p/security/noise/session.go
@@ -15,7 +15,8 @@ import (
 )
 
 type secureSession struct {
-	initiator bool
+	initiator   bool
+	checkPeerID bool
 
 	localID   peer.ID
 	localKey  crypto.PrivKey
@@ -47,7 +48,7 @@ type secureSession struct {
 
 // newSecureSession creates a Noise session over the given insecureConn Conn, using
 // the libp2p identity keypair from the given Transport.
-func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, prologue []byte, initiatorEDH, responderEDH EarlyDataHandler, initiator bool) (*secureSession, error) {
+func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, remote peer.ID, prologue []byte, initiatorEDH, responderEDH EarlyDataHandler, initiator, checkPeerID bool) (*secureSession, error) {
 	s := &secureSession{
 		insecureConn:              insecure,
 		insecureReader:            bufio.NewReader(insecure),
@@ -58,6 +59,7 @@ func newSecureSession(tpt *Transport, ctx context.Context, insecure net.Conn, re
 		prologue:                  prologue,
 		initiatorEarlyDataHandler: initiatorEDH,
 		responderEarlyDataHandler: responderEDH,
+		checkPeerID:               checkPeerID,
 	}
 
 	// the go-routine we create to run the handshake will

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -77,7 +77,8 @@ type SessionTransport struct {
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (i *SessionTransport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	c, err := newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, false, p != "" || i.disablePeerIDCheck)
+	checkPeerID := !i.disablePeerIDCheck && p != ""
+	c, err := newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, false, checkPeerID)
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
 		if maErr == nil {

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -82,7 +82,8 @@ func (i *SessionTransport) SecureOutbound(ctx context.Context, insecure net.Conn
 
 // SecureOutboundForAnyPeerID runs the Noise handshake as the initiator but does not check
 // the remote's peer ID. This is the outbound equivalent of calling `SecureInbound` with an empty
-// peer ID.
+// peer ID. This is susceptible to MITM attacks since we do not verify the identity of the remote
+// peer.
 func (i *SessionTransport) SecureOutboundForAnyPeerID(ctx context.Context, insecure net.Conn) (sec.SecureConn, error) {
 	return newSecureSession(i.t, ctx, insecure, "", i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, true, false)
 }

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -56,7 +56,7 @@ func EarlyData(initiator, responder EarlyDataHandler) SessionOption {
 // peer.
 func DisablePeerIDCheck() SessionOption {
 	return func(s *SessionTransport) error {
-		s.disablePeerIdCheck = true
+		s.disablePeerIDCheck = true
 		return nil
 	}
 }
@@ -69,7 +69,7 @@ type SessionTransport struct {
 	t *Transport
 	// options
 	prologue           []byte
-	disablePeerIdCheck bool
+	disablePeerIDCheck bool
 
 	initiatorEarlyDataHandler, responderEarlyDataHandler EarlyDataHandler
 }
@@ -77,7 +77,7 @@ type SessionTransport struct {
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (i *SessionTransport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	c, err := newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, false, p != "" || i.disablePeerIdCheck)
+	c, err := newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, false, p != "" || i.disablePeerIDCheck)
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
 		if maErr == nil {
@@ -89,5 +89,5 @@ func (i *SessionTransport) SecureInbound(ctx context.Context, insecure net.Conn,
 
 // SecureOutbound runs the Noise handshake as the initiator.
 func (i *SessionTransport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	return newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, true, !i.disablePeerIdCheck)
+	return newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, true, !i.disablePeerIDCheck)
 }

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -51,7 +51,7 @@ func New(privkey crypto.PrivKey, muxers []protocol.ID) (*Transport, error) {
 }
 
 // SecureInbound runs the Noise handshake as the responder.
-// if p is empty accept any peer ID.
+// If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
 	responderEDH := newTransportEDH(t)
 	checkPeerID := true

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -76,7 +76,8 @@ func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p pee
 
 // SecureOutboundForAnyPeerID runs the Noise handshake as the initiator but does not check
 // the remote's peer ID. This is the outbound equivalent of calling `SecureInbound` with an empty
-// peer ID.
+// peer ID. This is susceptible to MITM attacks since we do not verify the identity of the remote
+// peer.
 func (t *Transport) SecureOutboundForAnyPeerID(ctx context.Context, insecure net.Conn) (sec.SecureConn, error) {
 	return newSecureSession(t, ctx, insecure, "", nil, nil, nil, true, false)
 }

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -54,11 +54,7 @@ func New(privkey crypto.PrivKey, muxers []protocol.ID) (*Transport, error) {
 // If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
 	responderEDH := newTransportEDH(t)
-	checkPeerID := true
-	if p == "" {
-		checkPeerID = false
-	}
-	c, err := newSecureSession(t, ctx, insecure, p, nil, nil, responderEDH, checkPeerID)
+	c, err := newSecureSession(t, ctx, insecure, p, nil, nil, responderEDH, false, p != "")
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
 		if maErr == nil {
@@ -71,7 +67,7 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer
 // SecureOutbound runs the Noise handshake as the initiator.
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
 	initiatorEDH := newTransportEDH(t)
-	c, err := newSecureSession(t, ctx, insecure, p, nil, initiatorEDH, nil, true)
+	c, err := newSecureSession(t, ctx, insecure, p, nil, initiatorEDH, nil, true, true)
 	if err != nil {
 		return c, err
 	}

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -74,16 +74,8 @@ func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p pee
 	return SessionWithConnState(c, initiatorEDH.MatchMuxers(true)), err
 }
 
-// SecureOutboundForAnyPeerID runs the Noise handshake as the initiator but does not check
-// the remote's peer ID. This is the outbound equivalent of calling `SecureInbound` with an empty
-// peer ID. This is susceptible to MITM attacks since we do not verify the identity of the remote
-// peer.
-func (t *Transport) SecureOutboundForAnyPeerID(ctx context.Context, insecure net.Conn) (sec.SecureConn, error) {
-	return newSecureSession(t, ctx, insecure, "", nil, nil, nil, true, false)
-}
-
 func (t *Transport) WithSessionOptions(opts ...SessionOption) (*SessionTransport, error) {
-	st := &SessionTransport{t: t}
+	st := &SessionTransport{t: t, disablePeerIdCheck: false}
 	for _, opt := range opts {
 		if err := opt(st); err != nil {
 			return nil, err

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -78,6 +78,13 @@ func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p pee
 	return SessionWithConnState(c, initiatorEDH.MatchMuxers(true)), err
 }
 
+// SecureOutboundForAnyPeerID runs the Noise handshake as the initiator but does not check
+// the remote's peer ID. This is the outbound equivalent of calling `SecureInbound` with an empty
+// peer ID.
+func (t *Transport) SecureOutboundForAnyPeerID(ctx context.Context, insecure net.Conn) (sec.SecureConn, error) {
+	return newSecureSession(t, ctx, insecure, "", nil, nil, nil, true, false)
+}
+
 func (t *Transport) WithSessionOptions(opts ...SessionOption) (*SessionTransport, error) {
 	st := &SessionTransport{t: t}
 	for _, opt := range opts {

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -75,7 +75,7 @@ func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p pee
 }
 
 func (t *Transport) WithSessionOptions(opts ...SessionOption) (*SessionTransport, error) {
-	st := &SessionTransport{t: t, disablePeerIdCheck: false}
+	st := &SessionTransport{t: t}
 	for _, opt := range opts {
 		if err := opt(st); err != nil {
 			return nil, err

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -237,13 +237,16 @@ func TestPeerIDOutboundNoCheck(t *testing.T) {
 	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
 	init, resp := newConnPair(t)
 
+	initSessionTransport, err := initTransport.WithSessionOptions(DisablePeerIDCheck())
+	require.NoError(t, err)
+
 	errChan := make(chan error)
 	go func() {
-		_, err := initTransport.SecureOutboundForAnyPeerID(context.Background(), init)
+		_, err := initSessionTransport.SecureOutbound(context.Background(), init, "test")
 		errChan <- err
 	}()
 
-	_, err := respTransport.SecureInbound(context.Background(), resp, "")
+	_, err = respTransport.SecureInbound(context.Background(), resp, "")
 	require.NoError(t, err)
 	initErr := <-errChan
 	require.NoError(t, initErr)

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -232,6 +232,24 @@ func TestPeerIDMismatchInboundFailsHandshake(t *testing.T) {
 	<-done
 }
 
+func TestPeerIDInboundCheckDisabled(t *testing.T) {
+	initTransport := newTestTransport(t, crypto.Ed25519, 2048)
+	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
+	init, resp := newConnPair(t)
+
+	initSessionTransport, err := initTransport.WithSessionOptions(DisablePeerIDCheck())
+	require.NoError(t, err)
+	errChan := make(chan error)
+	go func() {
+		_, err := initSessionTransport.SecureInbound(context.Background(), init, "test")
+		errChan <- err
+	}()
+	_, err = respTransport.SecureOutbound(context.Background(), resp, initTransport.localID)
+	require.NoError(t, err)
+	initErr := <-errChan
+	require.NoError(t, initErr)
+}
+
 func TestPeerIDOutboundNoCheck(t *testing.T) {
 	initTransport := newTestTransport(t, crypto.Ed25519, 2048)
 	respTransport := newTestTransport(t, crypto.Ed25519, 2048)

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -88,8 +88,7 @@ func connect(t *testing.T, initTransport, respTransport *Transport) (*secureSess
 		initConn, initErr = initTransport.SecureOutbound(context.Background(), init, respTransport.localID)
 	}()
 
-	receiverTpt, _ := respTransport.WithSessionOptions(CheckPeerID(false))
-	respConn, respErr := receiverTpt.SecureInbound(context.Background(), resp, "")
+	respConn, respErr := respTransport.SecureInbound(context.Background(), resp, "")
 	<-done
 
 	if initErr != nil {
@@ -197,7 +196,7 @@ func TestPeerIDMatch(t *testing.T) {
 
 func TestPeerIDMismatchOutboundFailsHandshake(t *testing.T) {
 	initTransport := newTestTransport(t, crypto.Ed25519, 2048)
-	respTransport, _ := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(CheckPeerID(false))
+	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
 	init, resp := newConnPair(t)
 
 	errChan := make(chan error)
@@ -234,18 +233,17 @@ func TestPeerIDMismatchInboundFailsHandshake(t *testing.T) {
 }
 
 func TestPeerIDOutboundNoCheck(t *testing.T) {
-	initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(CheckPeerID(false))
-	require.NoError(t, err, "could not initiate session transport")
+	initTransport := newTestTransport(t, crypto.Ed25519, 2048)
 	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
 	init, resp := newConnPair(t)
 
 	errChan := make(chan error)
 	go func() {
-		_, err := initTransport.SecureOutbound(context.Background(), init, "")
+		_, err := initTransport.SecureOutboundForAnyPeerID(context.Background(), init)
 		errChan <- err
 	}()
 
-	_, err = respTransport.SecureInbound(context.Background(), resp, "")
+	_, err := respTransport.SecureInbound(context.Background(), resp, "")
 	require.NoError(t, err)
 	initErr := <-errChan
 	require.NoError(t, initErr)
@@ -590,7 +588,7 @@ func TestEarlyfffDataAcceptedWithNoHandler(t *testing.T) {
 	}
 	initTransport, err := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(EarlyData(clientEDH, nil))
 	require.NoError(t, err)
-	respTransport, _ := newTestTransport(t, crypto.Ed25519, 2048).WithSessionOptions(CheckPeerID(false))
+	respTransport := newTestTransport(t, crypto.Ed25519, 2048)
 
 	initConn, respConn := newConnPair(t)
 
@@ -600,7 +598,7 @@ func TestEarlyfffDataAcceptedWithNoHandler(t *testing.T) {
 		errChan <- err
 	}()
 
-	conn, err := initTransport.SecureOutbound(context.Background(), respConn, respTransport.t.localID)
+	conn, err := initTransport.SecureOutbound(context.Background(), respConn, respTransport.localID)
 	require.NoError(t, err)
 	defer conn.Close()
 


### PR DESCRIPTION
Allows the `SecureOutbound` call to be called with an unknown peer ID (empty string). This is required for https://github.com/libp2p/specs/pull/412#discussion_r977698490