### PR TITLE
fix: websocket transport should send host header

### DIFF
--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -20,18 +20,6 @@ type listener struct {
 	incoming chan *Conn
 }
 
-func (pwma *parsedWebsocketMultiaddr) toMultiaddr() ma.Multiaddr {
-	if !pwma.isWSS {
-		return pwma.restMultiaddr.Encapsulate(wsComponent)
-	}
-
-	if pwma.sni == nil {
-		return pwma.restMultiaddr.Encapsulate(tlsComponent).Encapsulate(wsComponent)
-	}
-
-	return pwma.restMultiaddr.Encapsulate(tlsComponent).Encapsulate(pwma.sni).Encapsulate(wsComponent)
-}
-
 // newListener creates a new listener from a raw net.Listener.
 // tlsConf may be nil (for unencrypted websockets).
 func newListener(a ma.Multiaddr, tlsConf *tls.Config) (*listener, error) {

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -479,6 +479,8 @@ func TestWriteZero(t *testing.T) {
 func TestResolveMultiaddr(t *testing.T) {
 	// map[unresolved]resolved
 	testCases := map[string]string{
+		"/ip4/1.2.3.4/tcp/1234/ws":             "/ip4/1.2.3.4/tcp/1234/ws",
+		"/dns4/example.com/tcp/1234/ws":        "/dns4/example.com/tcp/1234/sni/example.com/ws",
 		"/dns4/example.com/tcp/1234/wss":       "/dns4/example.com/tcp/1234/tls/sni/example.com/ws",
 		"/dns6/example.com/tcp/1234/wss":       "/dns6/example.com/tcp/1234/tls/sni/example.com/ws",
 		"/dnsaddr/example.com/tcp/1234/wss":    "/dnsaddr/example.com/tcp/1234/tls/sni/example.com/ws",


### PR DESCRIPTION
websocket transport resolve should make sure HTTP Host is preserved, even from dns resolution performed by swarm DNS resolver. This commit updates the resolve strategy to add an SNI for both WS and WSS, if a host is present. This SNI is used as the WS URL Host, while the resolved host is used to perform the underlying TCP dial.

This also moves `toMultiAddr()` method of `parsedWebsocketMultiaddr` in the file the object is declared, in an attempt to make reading simpler.

The issue this addresses is described in more length [in this comment](https://github.com/libp2p/go-libp2p-relay-daemon/issues/18#issuecomment-1276212041).