### PR TITLE
holepunch: add multiaddress filter

### DIFF
--- a/p2p/protocol/holepunch/filter.go
+++ b/p2p/protocol/holepunch/filter.go
@@ -5,8 +5,8 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// WithAddrFilter is a Service option that enables multi address filtering.
-// It allows to only allow a subset of observed addresses to the remote
+// WithAddrFilter is a Service option that enables multiaddress filtering.
+// It allows to only send a subset of observed addresses to the remote
 // peer. E.g., only announce TCP or QUIC multi addresses instead of both.
 // It also allows to only consider a subset of received multi addresses
 // that remote peers announced to us.
@@ -19,12 +19,10 @@ func WithAddrFilter(maf AddrFilter) Option {
 }
 
 // AddrFilter defines the interface for the multi address filtering.
-//   - FilterLocal is a function that filters the multi addresses that
-//     we send to the remote peer.
-//   - FilterRemote is a function that filters the multi addresses which
-//     we received from the remote peer.
 type AddrFilter interface {
+	// FilterLocal is a function that filters the multi addresses that we send to the remote peer.
 	FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
+	// FilterRemote is a function that filters the multi addresses which we received from the remote peer.
 	FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
 }
 

--- a/p2p/protocol/holepunch/filter.go
+++ b/p2p/protocol/holepunch/filter.go
@@ -1,0 +1,42 @@
+package holepunch
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// WithAddrFilter is a Service option that enables multi address filtering.
+// It allows to only allow a subset of observed addresses to the remote
+// peer. E.g., only announce TCP or QUIC multi addresses instead of both.
+// It also allows to only consider a subset of received multi addresses
+// that remote peers announced to us.
+// Theoretically, this API also allows to add multi addresses in both cases.
+func WithAddrFilter(maf AddrFilter) Option {
+	return func(hps *Service) error {
+		hps.filter = maf
+		return nil
+	}
+}
+
+// AddrFilter defines the interface for the multi address filtering.
+//   - FilterLocal is a function that filters the multi addresses that
+//     we send to the remote peer.
+//   - FilterRemote is a function that filters the multi addresses which
+//     we received from the remote peer.
+type AddrFilter interface {
+	FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
+	FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
+}
+
+// DefaultAddrFilter is the default address filtering logic. It strips
+// all relayed multi addresses from both the locally observed addresses
+// and received remote addresses.
+type DefaultAddrFilter struct{}
+
+func (d DefaultAddrFilter) FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
+	return removeRelayAddrs(maddrs)
+}
+
+func (d DefaultAddrFilter) FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
+	return removeRelayAddrs(maddrs)
+}

--- a/p2p/protocol/holepunch/filter.go
+++ b/p2p/protocol/holepunch/filter.go
@@ -11,9 +11,9 @@ import (
 // It also allows to only consider a subset of received multi addresses
 // that remote peers announced to us.
 // Theoretically, this API also allows to add multi addresses in both cases.
-func WithAddrFilter(maf AddrFilter) Option {
+func WithAddrFilter(f AddrFilter) Option {
 	return func(hps *Service) error {
-		hps.filter = maf
+		hps.filter = f
 		return nil
 	}
 }
@@ -24,17 +24,4 @@ type AddrFilter interface {
 	FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
 	// FilterRemote is a function that filters the multi addresses which we received from the remote peer.
 	FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
-}
-
-// DefaultAddrFilter is the default address filtering logic. It strips
-// all relayed multi addresses from both the locally observed addresses
-// and received remote addresses.
-type DefaultAddrFilter struct{}
-
-func (d DefaultAddrFilter) FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
-	return removeRelayAddrs(maddrs)
-}
-
-func (d DefaultAddrFilter) FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
-	return removeRelayAddrs(maddrs)
 }

--- a/p2p/protocol/holepunch/filter.go
+++ b/p2p/protocol/holepunch/filter.go
@@ -20,8 +20,8 @@ func WithAddrFilter(f AddrFilter) Option {
 
 // AddrFilter defines the interface for the multi address filtering.
 type AddrFilter interface {
-	// FilterLocal is a function that filters the multi addresses that we send to the remote peer.
+	// FilterLocal filters the multi addresses that are sent to the remote peer.
 	FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
-	// FilterRemote is a function that filters the multi addresses which we received from the remote peer.
+	// FilterRemote filters the multi addresses received from the remote peer.
 	FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
 }

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -192,7 +192,7 @@ func TestFailuresOnInitiator(t *testing.T) {
 			errMsg: "i/o deadline reached",
 		},
 		"no addrs after filtering": {
-			errMsg: "aborting hole punch initiation, as we have no public address after filtering",
+			errMsg: "aborting hole punch initiation as we have no public address",
 			filter: func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
 				return []ma.Multiaddr{}
 			},

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -223,6 +223,11 @@ func TestFailuresOnInitiator(t *testing.T) {
 			}
 
 			hps := addHolePunchService(t, h2, opts...)
+			// wait until the hole punching protocol has actually started
+			require.Eventually(t, func() bool {
+				protos, _ := h2.Peerstore().SupportsProtocols(h1.ID(), string(holepunch.Protocol))
+				return len(protos) > 0
+			}, 200*time.Millisecond, 10*time.Millisecond)
 
 			if tc.rhandler != nil {
 				h1.SetStreamHandler(holepunch.Protocol, tc.rhandler)

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -45,6 +45,21 @@ func (m *mockEventTracer) getEvents() []*holepunch.Event {
 
 var _ holepunch.EventTracer = &mockEventTracer{}
 
+type mockMaddrFilter struct {
+	filterLocal  func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
+	filterRemote func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
+}
+
+func (m mockMaddrFilter) FilterLocal(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
+	return m.filterLocal(remoteID, maddrs)
+}
+
+func (m mockMaddrFilter) FilterRemote(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
+	return m.filterRemote(remoteID, maddrs)
+}
+
+var _ holepunch.AddrFilter = &mockMaddrFilter{}
+
 type mockIDService struct {
 	identify.IDService
 }
@@ -110,7 +125,7 @@ func TestDirectDialWorks(t *testing.T) {
 func TestEndToEndSimConnect(t *testing.T) {
 	h1tr := &mockEventTracer{}
 	h2tr := &mockEventTracer{}
-	h1, h2, relay, _ := makeRelayedHosts(t, holepunch.WithTracer(h1tr), holepunch.WithTracer(h2tr), true)
+	h1, h2, relay, _ := makeRelayedHosts(t, []holepunch.Option{holepunch.WithTracer(h1tr)}, []holepunch.Option{holepunch.WithTracer(h2tr)}, true)
 	defer h1.Close()
 	defer h2.Close()
 	defer relay.Close()
@@ -151,6 +166,7 @@ func TestFailuresOnInitiator(t *testing.T) {
 		rhandler         func(s network.Stream)
 		errMsg           string
 		holePunchTimeout time.Duration
+		filter           func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
 	}{
 		"responder does NOT send a CONNECT message": {
 			rhandler: func(s network.Stream) {
@@ -175,6 +191,12 @@ func TestFailuresOnInitiator(t *testing.T) {
 			},
 			errMsg: "i/o deadline reached",
 		},
+		"no addrs after filtering": {
+			errMsg: "aborting hole punch initiation, as we have no public address after filtering",
+			filter: func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
+				return []ma.Multiaddr{}
+			},
+		},
 	}
 
 	for name, tc := range tcs {
@@ -190,7 +212,17 @@ func TestFailuresOnInitiator(t *testing.T) {
 			defer h1.Close()
 			defer h2.Close()
 			defer relay.Close()
-			hps := addHolePunchService(t, h2, holepunch.WithTracer(tr))
+
+			opts := []holepunch.Option{holepunch.WithTracer(tr)}
+			if tc.filter != nil {
+				f := mockMaddrFilter{
+					filterLocal:  tc.filter,
+					filterRemote: tc.filter,
+				}
+				opts = append(opts, holepunch.WithAddrFilter(f))
+			}
+
+			hps := addHolePunchService(t, h2, opts...)
 
 			if tc.rhandler != nil {
 				h1.SetStreamHandler(holepunch.Protocol, tc.rhandler)
@@ -221,6 +253,7 @@ func TestFailuresOnResponder(t *testing.T) {
 		initiator        func(s network.Stream)
 		errMsg           string
 		holePunchTimeout time.Duration
+		filter           func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr
 	}{
 		"initiator does NOT send a CONNECT message": {
 			initiator: func(s network.Stream) {
@@ -258,6 +291,19 @@ func TestFailuresOnResponder(t *testing.T) {
 			},
 			errMsg: "expected CONNECT message to contain at least one address",
 		},
+		"no addrs after filtering": {
+			errMsg: "rejecting hole punch request, as we don't have any public addresses",
+			initiator: func(s network.Stream) {
+				protoio.NewDelimitedWriter(s).WriteMsg(&holepunch_pb.HolePunch{
+					Type:     holepunch_pb.HolePunch_CONNECT.Enum(),
+					ObsAddrs: addrsToBytes([]ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/1234")}),
+				})
+				time.Sleep(10 * time.Second)
+			},
+			filter: func(remoteID peer.ID, maddrs []ma.Multiaddr) []ma.Multiaddr {
+				return []ma.Multiaddr{}
+			},
+		},
 	}
 
 	for name, tc := range tcs {
@@ -267,9 +313,18 @@ func TestFailuresOnResponder(t *testing.T) {
 				holepunch.StreamTimeout = tc.holePunchTimeout
 				defer func() { holepunch.StreamTimeout = cpy }()
 			}
-
 			tr := &mockEventTracer{}
-			h1, h2, relay, _ := makeRelayedHosts(t, holepunch.WithTracer(tr), nil, false)
+
+			opts := []holepunch.Option{holepunch.WithTracer(tr)}
+			if tc.filter != nil {
+				f := mockMaddrFilter{
+					filterLocal:  tc.filter,
+					filterRemote: tc.filter,
+				}
+				opts = append(opts, holepunch.WithAddrFilter(f))
+			}
+
+			h1, h2, relay, _ := makeRelayedHosts(t, opts, nil, false)
 			defer h1.Close()
 			defer h2.Close()
 			defer relay.Close()
@@ -377,13 +432,9 @@ func mkHostWithStaticAutoRelay(t *testing.T, relay host.Host) host.Host {
 	return h
 }
 
-func makeRelayedHosts(t *testing.T, h1opt, h2opt holepunch.Option, addHolePuncher bool) (h1, h2, relay host.Host, hps *holepunch.Service) {
+func makeRelayedHosts(t *testing.T, h1opt, h2opt []holepunch.Option, addHolePuncher bool) (h1, h2, relay host.Host, hps *holepunch.Service) {
 	t.Helper()
-	var h1opts []holepunch.Option
-	if h1opt != nil {
-		h1opts = append(h1opts, h1opt)
-	}
-	h1, _ = mkHostWithHolePunchSvc(t, h1opts...)
+	h1, _ = mkHostWithHolePunchSvc(t, h1opt...)
 	var err error
 	relay, err = libp2p.New(libp2p.ListenAddrs(ma.StringCast("/ip4/127.0.0.1/tcp/0")), libp2p.DisableRelay())
 	require.NoError(t, err)
@@ -393,7 +444,7 @@ func makeRelayedHosts(t *testing.T, h1opt, h2opt holepunch.Option, addHolePunche
 
 	h2 = mkHostWithStaticAutoRelay(t, relay)
 	if addHolePuncher {
-		hps = addHolePunchService(t, h2, h2opt)
+		hps = addHolePunchService(t, h2, h2opt...)
 	}
 
 	// h1 has a relay addr
@@ -413,12 +464,8 @@ func makeRelayedHosts(t *testing.T, h1opt, h2opt holepunch.Option, addHolePunche
 	return
 }
 
-func addHolePunchService(t *testing.T, h host.Host, opt holepunch.Option) *holepunch.Service {
+func addHolePunchService(t *testing.T, h host.Host, opts ...holepunch.Option) *holepunch.Service {
 	t.Helper()
-	var opts []holepunch.Option
-	if opt != nil {
-		opts = append(opts, opt)
-	}
 	hps, err := holepunch.NewService(h, newMockIDService(t, h), opts...)
 	require.NoError(t, err)
 	return hps

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -53,6 +53,7 @@ type Service struct {
 	hasPublicAddrsChan chan struct{}
 
 	tracer *tracer
+	filter AddrFilter
 
 	refCount sync.WaitGroup
 }
@@ -74,6 +75,7 @@ func NewService(h host.Host, ids identify.IDService, opts ...Option) (*Service, 
 		host:               h,
 		ids:                ids,
 		hasPublicAddrsChan: make(chan struct{}),
+		filter:             DefaultAddrFilter{},
 	}
 
 	for _, opt := range opts {
@@ -140,7 +142,7 @@ func (s *Service) watchForPublicAddr() {
 				continue
 			}
 			s.holePuncherMx.Lock()
-			s.holePuncher = newHolePuncher(s.host, s.ids, s.tracer)
+			s.holePuncher = newHolePuncher(s.host, s.ids, s.tracer, s.filter)
 			s.holePuncherMx.Unlock()
 			close(s.hasPublicAddrsChan)
 			return
@@ -168,7 +170,7 @@ func (s *Service) incomingHolePunch(str network.Stream) (rtt time.Duration, addr
 	if !isRelayAddress(str.Conn().RemoteMultiaddr()) {
 		return 0, nil, fmt.Errorf("received hole punch stream: %s", str.Conn().RemoteMultiaddr())
 	}
-	ownAddrs := removeRelayAddrs(s.ids.OwnObservedAddrs())
+	ownAddrs := s.filter.FilterLocal(str.Conn().RemotePeer(), s.ids.OwnObservedAddrs())
 	// If we can't tell the peer where to dial us, there's no point in starting the hole punching.
 	if len(ownAddrs) == 0 {
 		return 0, nil, errors.New("rejecting hole punch request, as we don't have any public addresses")
@@ -194,7 +196,7 @@ func (s *Service) incomingHolePunch(str network.Stream) (rtt time.Duration, addr
 	if t := msg.GetType(); t != pb.HolePunch_CONNECT {
 		return 0, nil, fmt.Errorf("expected CONNECT message from initiator but got %d", t)
 	}
-	obsDial := removeRelayAddrs(addrsFromBytes(msg.ObsAddrs))
+	obsDial := s.filter.FilterRemote(str.Conn().RemotePeer(), addrsFromBytes(msg.ObsAddrs))
 	log.Debugw("received hole punch request", "peer", str.Conn().RemotePeer(), "addrs", obsDial)
 	if len(obsDial) == 0 {
 		return 0, nil, errors.New("expected CONNECT message to contain at least one address")


### PR DESCRIPTION
This PR adds a new option to the holepunch service that allows filtering of multi addresses during the DCUtR protocol.