### PR TITLE
Populate the ConnState field for connections

### DIFF
--- a/core/network/conn.go
+++ b/core/network/conn.go
@@ -59,6 +59,9 @@ type ConnSecurity interface {
 
 	// Connection state info of the secured connection.
 	ConnState() ConnectionState
+
+	// Set connection state of securied connection.
+	SetConnState(ConnectionState)
 }
 
 // ConnMultiaddrs is an interface mixin for connection types that provide multiaddr

--- a/core/network/mux.go
+++ b/core/network/mux.go
@@ -91,5 +91,5 @@ type MuxedConn interface {
 // multiple streams over the underlying net.Conn
 type Multiplexer interface {
 	// NewConn constructs a new connection
-	NewConn(c net.Conn, isServer bool, scope PeerScope) (MuxedConn, error)
+	NewConn(c net.Conn, isServer bool, scope PeerScope) (MuxedConn, string, error)
 }

--- a/core/sec/insecure/insecure.go
+++ b/core/sec/insecure/insecure.go
@@ -117,6 +117,7 @@ type Conn struct {
 
 	localPrivKey ci.PrivKey
 	remotePubKey ci.PubKey
+	connState    network.ConnectionState
 }
 
 func makeExchangeMessage(pubkey ci.PubKey) (*pb.Exchange, error) {
@@ -233,7 +234,12 @@ func (ic *Conn) LocalPrivateKey() ci.PrivKey {
 
 // ConnState returns the security connection's state information.
 func (ic *Conn) ConnState() network.ConnectionState {
-	return network.ConnectionState{}
+	return ic.connState
+}
+
+// ConnState returns the security connection's state information.
+func (ic *Conn) SetConnState(connState network.ConnectionState) {
+	ic.connState = connState
 }
 
 var _ sec.SecureTransport = (*Transport)(nil)

--- a/p2p/muxer/mplex/transport.go
+++ b/p2p/muxer/mplex/transport.go
@@ -17,10 +17,10 @@ var _ network.Multiplexer = &Transport{}
 // mplex-backed muxed connections.
 type Transport struct{}
 
-func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope) (network.MuxedConn, error) {
+func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope) (network.MuxedConn, string, error) {
 	m, err := mp.NewMultiplex(nc, isServer, scope)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return NewMuxedConn(m), nil
+	return NewMuxedConn(m), "", nil
 }

--- a/p2p/muxer/mplex/transport_test.go
+++ b/p2p/muxer/mplex/transport_test.go
@@ -38,7 +38,7 @@ type memoryLimitedTransport struct {
 	Transport
 }
 
-func (t *memoryLimitedTransport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope) (network.MuxedConn, error) {
+func (t *memoryLimitedTransport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope) (network.MuxedConn, string, error) {
 	return t.Transport.NewConn(nc, isServer, &memoryScope{
 		limit:     3 * 1 << 20,
 		PeerScope: scope,

--- a/p2p/muxer/muxer-multistream/multistream.go
+++ b/p2p/muxer/muxer-multistream/multistream.go
@@ -22,6 +22,7 @@ type Transport struct {
 	NegotiateTimeout time.Duration
 
 	OrderPreference []string
+	selectedProto   string
 }
 
 func NewBlankTransport() *Transport {
@@ -71,10 +72,15 @@ func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope)
 		return nil, fmt.Errorf("selected protocol we don't have a transport for")
 	}
 
+	t.selectedProto = proto
 	return tpt.NewConn(nc, isServer, scope)
 }
 
 func (t *Transport) GetTransportByKey(key string) (network.Multiplexer, bool) {
 	val, ok := t.tpts[key]
 	return val, ok
+}
+
+func (t *Transport) GetSelectedProto() string {
+	return t.selectedProto
 }

--- a/p2p/muxer/muxer-multistream/multistream.go
+++ b/p2p/muxer/muxer-multistream/multistream.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/sec"
 
 	mss "github.com/multiformats/go-multistream"
 )
@@ -72,6 +73,10 @@ func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope)
 		return nil, fmt.Errorf("selected protocol we don't have a transport for")
 	}
 
+	secConn, ok := nc.(sec.SecureConn)
+	if ok {
+		secConn.SetConnState(network.ConnectionState{NextProto: proto})
+	}
 	t.selectedProto = proto
 	return tpt.NewConn(nc, isServer, scope)
 }

--- a/p2p/muxer/testsuite/mux.go
+++ b/p2p/muxer/testsuite/mux.go
@@ -133,7 +133,7 @@ func GoServe(t *testing.T, tr network.Multiplexer, l net.Listener) (done func())
 				}
 			}
 
-			sc1, err := tr.NewConn(c1, true, nil)
+			sc1, _, err := tr.NewConn(c1, true, nil)
 			checkErr(t, err)
 			go func() {
 				for {
@@ -163,7 +163,7 @@ func SubtestSimpleWrite(t *testing.T, tr network.Multiplexer) {
 	defer nc1.Close()
 
 	scope := &peerScope{}
-	c1, err := tr.NewConn(nc1, false, scope)
+	c1, _, err := tr.NewConn(nc1, false, scope)
 	checkErr(t, err)
 	defer func() {
 		c1.Close()
@@ -261,7 +261,7 @@ func SubtestStress(t *testing.T, opt Options) {
 		}
 
 		scope := &peerScope{}
-		c, err := opt.tr.NewConn(nc, false, scope)
+		c, _, err := opt.tr.NewConn(nc, false, scope)
 		if err != nil {
 			t.Fatal(fmt.Errorf("a.AddConn(%s <--> %s): %s", nc.LocalAddr(), nc.RemoteAddr(), err))
 			return
@@ -348,7 +348,7 @@ func SubtestStreamOpenStress(t *testing.T, tr network.Multiplexer) {
 	workers := 5
 	go func() {
 		defer wg.Done()
-		muxa, err := tr.NewConn(a, true, nil)
+		muxa, _, err := tr.NewConn(a, true, nil)
 		if err != nil {
 			t.Error(err)
 			return
@@ -382,7 +382,7 @@ func SubtestStreamOpenStress(t *testing.T, tr network.Multiplexer) {
 	}()
 
 	scope := &peerScope{}
-	muxb, err := tr.NewConn(b, false, scope)
+	muxb, _, err := tr.NewConn(b, false, scope)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func SubtestStreamReset(t *testing.T, tr network.Multiplexer) {
 
 	wg.Add(1)
 	scopea := &peerScope{}
-	muxa, err := tr.NewConn(a, true, scopea)
+	muxa, _, err := tr.NewConn(a, true, scopea)
 	if err != nil {
 		t.Error(err)
 		return
@@ -469,7 +469,7 @@ func SubtestStreamReset(t *testing.T, tr network.Multiplexer) {
 	}()
 
 	scopeb := &peerScope{}
-	muxb, err := tr.NewConn(b, false, scopeb)
+	muxb, _, err := tr.NewConn(b, false, scopeb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,11 +490,11 @@ func SubtestWriteAfterClose(t *testing.T, tr network.Multiplexer) {
 	a, b := tcpPipe(t)
 
 	scopea := &peerScope{}
-	muxa, err := tr.NewConn(a, true, scopea)
+	muxa, _, err := tr.NewConn(a, true, scopea)
 	checkErr(t, err)
 
 	scopeb := &peerScope{}
-	muxb, err := tr.NewConn(b, false, scopeb)
+	muxb, _, err := tr.NewConn(b, false, scopeb)
 	checkErr(t, err)
 
 	checkErr(t, muxa.Close())
@@ -518,11 +518,11 @@ func SubtestStreamLeftOpen(t *testing.T, tr network.Multiplexer) {
 	const dataLen = 50 * 1024
 
 	scopea := &peerScope{}
-	muxa, err := tr.NewConn(a, true, scopea)
+	muxa, _, err := tr.NewConn(a, true, scopea)
 	checkErr(t, err)
 
 	scopeb := &peerScope{}
-	muxb, err := tr.NewConn(b, false, scopeb)
+	muxb, _, err := tr.NewConn(b, false, scopeb)
 	checkErr(t, err)
 
 	var wg sync.WaitGroup

--- a/p2p/muxer/yamux/transport.go
+++ b/p2p/muxer/yamux/transport.go
@@ -37,7 +37,7 @@ type Transport yamux.Config
 
 var _ network.Multiplexer = &Transport{}
 
-func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope) (network.MuxedConn, error) {
+func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope) (network.MuxedConn, string, error) {
 	var newSpan func() (yamux.MemoryManager, error)
 	if scope != nil {
 		newSpan = func() (yamux.MemoryManager, error) { return scope.BeginSpan() }
@@ -51,9 +51,9 @@ func (t *Transport) NewConn(nc net.Conn, isServer bool, scope network.PeerScope)
 		s, err = yamux.Client(nc, t.Config(), newSpan)
 	}
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return NewMuxedConn(s), nil
+	return NewMuxedConn(s), "", nil
 }
 
 func (t *Transport) Config() *yamux.Config {

--- a/p2p/net/connmgr/connmgr_test.go
+++ b/p2p/net/connmgr/connmgr_test.go
@@ -807,6 +807,7 @@ func (m mockConn) NewStream(ctx context.Context) (network.Stream, error) { panic
 func (m mockConn) GetStreams() []network.Stream                          { panic("implement me") }
 func (m mockConn) Scope() network.ConnScope                              { panic("implement me") }
 func (m mockConn) ConnState() network.ConnectionState                    { return network.ConnectionState{} }
+func (m mockConn) SetConnState(_ network.ConnectionState)                {}
 
 func TestPeerInfoSorting(t *testing.T) {
 	t.Run("starts with temporary connections", func(t *testing.T) {

--- a/p2p/net/mock/mock_conn.go
+++ b/p2p/net/mock/mock_conn.go
@@ -183,6 +183,9 @@ func (c *conn) ConnState() network.ConnectionState {
 	return network.ConnectionState{}
 }
 
+// SetConnState of security connection.
+func (c *conn) SetConnState(_ network.ConnectionState) {}
+
 // Stat returns metadata about the connection
 func (c *conn) Stat() network.ConnStats {
 	return c.stat

--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -184,6 +184,11 @@ func (c *Conn) ConnState() network.ConnectionState {
 	return c.conn.ConnState()
 }
 
+// SetConnState assigns the security connection state.
+func (c *Conn) SetConnState(state network.ConnectionState) {
+	c.conn.SetConnState(state)
+}
+
 // Stat returns metadata pertaining to this connection
 func (c *Conn) Stat() network.ConnStats {
 	c.streams.Lock()

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	ipnet "github.com/libp2p/go-libp2p/core/pnet"
 	"github.com/libp2p/go-libp2p/core/sec"
-	"github.com/libp2p/go-libp2p/core/sec/insecure"
 	"github.com/libp2p/go-libp2p/core/transport"
 	msmux "github.com/libp2p/go-libp2p/p2p/muxer/muxer-multistream"
 	"github.com/libp2p/go-libp2p/p2p/net/pnet"
@@ -221,12 +220,6 @@ func (u *upgrader) setupMuxer(ctx context.Context, conn sec.SecureConn, server b
 
 	select {
 	case <-done:
-		// Update connectionState for insecure connections.
-		insecConn, isInsec := conn.(*insecure.Conn)
-		if isInsec && ok {
-			selected := msmuxer.GetSelectedProto()
-			insecConn.SetConnState(network.ConnectionState{NextProto: selected})
-		}
 		return smconn, err
 	case <-ctx.Done():
 		// interrupt this process

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	ipnet "github.com/libp2p/go-libp2p/core/pnet"
 	"github.com/libp2p/go-libp2p/core/sec"
+	"github.com/libp2p/go-libp2p/core/sec/insecure"
 	"github.com/libp2p/go-libp2p/core/transport"
 	msmux "github.com/libp2p/go-libp2p/p2p/muxer/muxer-multistream"
 	"github.com/libp2p/go-libp2p/p2p/net/pnet"
@@ -220,6 +221,12 @@ func (u *upgrader) setupMuxer(ctx context.Context, conn sec.SecureConn, server b
 
 	select {
 	case <-done:
+		// Update connectionState for insecure connections.
+		insecConn, isInsec := conn.(*insecure.Conn)
+		if isInsec && ok {
+			selected := msmuxer.GetSelectedProto()
+			insecConn.SetConnState(network.ConnectionState{NextProto: selected})
+		}
 		return smconn, err
 	case <-ctx.Done():
 		// interrupt this process

--- a/p2p/net/upgrader/upgrader_test.go
+++ b/p2p/net/upgrader/upgrader_test.go
@@ -3,7 +3,6 @@ package upgrader_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"testing"
 
@@ -124,7 +123,6 @@ func TestOutboundConnectionGating(t *testing.T) {
 	testGater := &testGater{}
 	_, dialUpgrader := createUpgrader(t, upgrader.WithConnectionGater(testGater))
 	conn, err := dial(t, dialUpgrader, ln.Multiaddr(), id, &network.NullScope{})
-	fmt.Println(">>>> next proto: ", conn.ConnState().NextProto)
 	require.NoError(err)
 	require.NotNil(conn)
 	_ = conn.Close()

--- a/p2p/security/noise/session.go
+++ b/p2p/security/noise/session.go
@@ -116,6 +116,10 @@ func (s *secureSession) ConnState() network.ConnectionState {
 	return s.connectionState
 }
 
+func (s *secureSession) SetConnState(state network.ConnectionState) {
+	s.connectionState = state
+}
+
 func (s *secureSession) SetDeadline(t time.Time) error {
 	return s.insecureConn.SetDeadline(t)
 }

--- a/p2p/security/tls/conn.go
+++ b/p2p/security/tls/conn.go
@@ -41,3 +41,7 @@ func (c *conn) RemotePublicKey() ci.PubKey {
 func (c *conn) ConnState() network.ConnectionState {
 	return c.connectionState
 }
+
+func (c *conn) SetConnState(state network.ConnectionState) {
+	c.connectionState = state
+}

--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -96,6 +96,9 @@ func (c *conn) ConnState() network.ConnectionState {
 	return network.ConnectionState{}
 }
 
+// SetConnState sets the ConnState of security connection.
+func (c *conn) SetConnState(_ network.ConnectionState) {}
+
 // LocalMultiaddr returns the local Multiaddr associated
 func (c *conn) LocalMultiaddr() ma.Multiaddr {
 	return c.localMultiaddr


### PR DESCRIPTION
Populate the NextProto / ConnState field in the case of Insecure transport.
This simplifies testing