### PR TITLE
protocol/ping: close ping stream when we exit the loop

### DIFF
--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -71,7 +71,7 @@ func (p *PingService) PingHandler(s network.Stream) {
 				log.Error("ping loop failed without error")
 			}
 		}
-		s.Reset()
+		s.Close()
 	}()
 
 	for {


### PR DESCRIPTION
Changes the ping protocol to close the stream instead of reset the stream when we exit the read/write loop (happens if the peer closes their stream).

This is needed to better interop with the JS client ping implementation. That implementation will write the 32 bytes, then close the write stream, then wait for the response to be read. This is racey since the Go side will reset the stream, so the echoed bytes may have been dropped and will never be received by the JS side. Instead the JS side will see a stream reset and the ping will fail.

Came up after I made js-libp2p-webtransport close its stream after calling `sink`: https://github.com/libp2p/js-libp2p-webtransport/pull/23#discussion_r1012228549 Since I'm using ping as a test this behavior made the ping test flaky.

Afaik there's no way other way to make sure data has been written to the wire besides closing the stream.