### PR TITLE
swarm: return filtered addrs in addrsForDial

### DIFF
--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -334,7 +334,7 @@ func (s *Swarm) addrsForDial(ctx context.Context, p peer.ID) ([]ma.Multiaddr, er
 
 	s.peers.AddAddrs(p, goodAddrs, peerstore.TempAddrTTL)
 
-	return resolved, nil
+	return goodAddrs, nil
 }
 
 func (s *Swarm) resolveAddrs(ctx context.Context, pi peer.AddrInfo) ([]ma.Multiaddr, error) {


### PR DESCRIPTION
Commit [`f654b4b`](https://github.com/libp2p/go-libp2p/commit/f654b4bd6970d41737b2098fa0998ca686916118) introduced multiaddress resultion by transport and changed the return value from `goodAddrs` to `resolved`. I guess this should be `goodAddrs` again?

cc @MarcoPolo