### PR TITLE
remove deprecated StaticRelays option

### DIFF
--- a/options.go
+++ b/options.go
@@ -16,7 +16,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/pnet"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -299,17 +298,6 @@ func EnableAutoRelay(opts ...autorelay.Option) Option {
 	return func(cfg *Config) error {
 		cfg.EnableAutoRelay = true
 		cfg.AutoRelayOpts = opts
-		return nil
-	}
-}
-
-// StaticRelays configures known relays for autorelay; when this option is enabled
-// then the system will use the configured relays instead of querying the DHT to
-// discover relays.
-// Deprecated: pass an autorelay.WithStaticRelays option to EnableAutoRelay.
-func StaticRelays(relays []peer.AddrInfo) Option {
-	return func(cfg *Config) error {
-		cfg.AutoRelayOpts = append(cfg.AutoRelayOpts, autorelay.WithStaticRelays(relays))
 		return nil
 	}
 }

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -359,9 +359,11 @@ func mkHostWithStaticAutoRelay(t *testing.T, relay host.Host) host.Host {
 	h, err := libp2p.New(
 		libp2p.ListenAddrs(ma.StringCast("/ip4/127.0.0.1/tcp/0")),
 		libp2p.EnableRelay(),
-		libp2p.EnableAutoRelay(autorelay.WithCircuitV1Support()),
+		libp2p.EnableAutoRelay(
+			autorelay.WithCircuitV1Support(),
+			autorelay.WithStaticRelays([]peer.AddrInfo{pi}),
+		),
 		libp2p.ForceReachabilityPrivate(),
-		libp2p.StaticRelays([]peer.AddrInfo{pi}),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This option was deprecated in Nov last year. One year should be plenty of time to stop using it.