### PR TITLE
libp2p + HTTP

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,8 @@ type Config struct {
 
 	EnableHolePunching  bool
 	HolePunchingOptions []holepunch.Option
+
+	HTTPConfig bhost.HTTPConfig
 }
 
 func (cfg *Config) makeSwarm() (*swarm.Swarm, error) {
@@ -236,6 +238,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 		HolePunchingOptions: cfg.HolePunchingOptions,
 		EnableRelayService:  cfg.EnableRelayService,
 		RelayServiceOpts:    cfg.RelayServiceOpts,
+		HTTPConfig:          cfg.HTTPConfig,
 	})
 	if err != nil {
 		swrm.Close()

--- a/options.go
+++ b/options.go
@@ -489,3 +489,10 @@ func WithDialTimeout(t time.Duration) Option {
 		return nil
 	}
 }
+
+func WithHTTP(hcfg bhost.HTTPConfig) Option {
+	return func(cfg *Config) error {
+		cfg.HTTPConfig = hcfg
+		return nil
+	}
+}

--- a/p2p/host/basic/http.go
+++ b/p2p/host/basic/http.go
@@ -1,0 +1,260 @@
+package basichost
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/binary"
+	"net"
+	"net/http"
+	"net/url"
+	"runtime"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/gostream"
+	libp2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
+	"github.com/multiformats/go-multiaddr"
+	ma "github.com/multiformats/go-multiaddr"
+	multiaddrnet "github.com/multiformats/go-multiaddr/net"
+)
+
+type HTTPConfig struct {
+	// Whether to enable http request response style protocols
+	EnableHTTP bool
+	// The multiaddr to use to serve a standard TCP+TLS HTTP server, may be nil
+	HTTPServerAddr ma.Multiaddr
+}
+
+type addrState interface {
+	Addrs(p peer.ID) []ma.Multiaddr
+}
+
+type peerConnState interface {
+	Connectedness(peer.ID) network.Connectedness
+}
+
+type httpHost struct {
+	privKey crypto.PrivKey
+	ps      addrState
+	c       peerConnState
+	s       gostream.Streamer
+
+	listenAddrsMu sync.Mutex
+	listenAddrs   []ma.Multiaddr
+
+	handler       http.ServeMux
+	streamHandler http.ServeMux
+	clientsMu     sync.Mutex
+	clients       map[peer.ID]*http.Client
+	server        http.Server
+	streamServer  http.Server
+	certToPeer    memoizedCertToPeer
+}
+
+func (h *httpHost) NewHTTPClient(p peer.ID) (*http.Client, error) {
+	h.clientsMu.Lock()
+	defer h.clientsMu.Unlock()
+
+	// If we don't have any connections, prefer creating an http connection over a libp2p stream connection.
+
+	// TODO If we know this is a basic http connection, should we reuse the client across peers?
+	c, ok := h.clients[p]
+	if !ok {
+		if h.c.Connectedness(p) == network.Connected {
+			// We are connected over some existing libp2p transport, let's do http over streams
+			var err error
+			c, err = newHTTPClientViaStreams(h.s, p)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			availAddrs := h.ps.Addrs(p)
+			var addrToUse multiaddr.Multiaddr
+			var foundAddr bool
+			for _, a := range availAddrs {
+				multiaddr.ForEach(a, func(c multiaddr.Component) bool {
+					proto := c.Protocol().Code
+					if proto == multiaddr.P_HTTP || proto == multiaddr.P_HTTPS {
+						foundAddr = true
+						return false
+					}
+					return true
+				})
+				if foundAddr {
+					addrToUse = a
+					break
+				}
+			}
+
+			var err error
+			if !foundAddr {
+				// Fallback to libp2p
+				c, err = newHTTPClientViaStreams(h.s, p)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				id, err := libp2ptls.NewIdentity(h.privKey)
+				if err != nil {
+					return nil, err
+				}
+				tlsConf := id.ConfigWithVerify()
+				tlsConf.NextProtos = []string{"h2"}
+
+				httpT := http.Transport{
+					TLSClientConfig:   tlsConf,
+					ForceAttemptHTTP2: true,
+				}
+
+				addrToUse = addrToUse.Decapsulate(multiaddr.StringCast("/tls"))
+				addr, err := multiaddrnet.ToNetAddr(addrToUse)
+				if err != nil {
+					return nil, err
+				}
+
+				u, err := url.Parse("https://" + addr.String())
+				if err != nil {
+					return nil, err
+				}
+				c = &http.Client{
+					Transport: roundTripperWithBaseURL{&httpT, u},
+				}
+			}
+		}
+
+		h.clients[p] = c
+	}
+	return c, nil
+}
+
+func (h *httpHost) SetHTTPHandler(pattern string, handler func(peer.ID, http.ResponseWriter, *http.Request)) {
+	h.handler.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		peer, err := h.certToPeer.get(r.TLS.PeerCertificates[0].Raw, r.TLS)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		handler(peer, w, r)
+	})
+
+	h.streamHandler.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		peer, err := peer.Decode(r.RemoteAddr)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		handler(peer, w, r)
+	})
+}
+
+func (h *httpHost) ListenHTTPOverLibp2p() error {
+	// Listen on streams as well
+	streamListener, err := gostream.Listen(h.s, gostream.DefaultP2PProtocol)
+	if err != nil {
+		return err
+	}
+	defer streamListener.Close()
+	h.streamServer.Handler = &h.streamHandler
+
+	return h.streamServer.Serve(streamListener)
+}
+
+func (h *httpHost) ListenHTTP(ma multiaddr.Multiaddr) error {
+	id, err := libp2ptls.NewIdentity(h.privKey)
+	if err != nil {
+		return err
+	}
+	tlsConf := id.ConfigWithVerify()
+	tlsConf.NextProtos = []string{"h2", "http/1.1"}
+
+	addr, err := multiaddrnet.ToNetAddr(ma.Decapsulate(multiaddr.StringCast("/tls")))
+	if err != nil {
+		return err
+	}
+	ln, err := net.Listen("tcp", addr.String())
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	// Set listen addr
+	listenMa, err := multiaddrnet.FromNetAddr(ln.Addr())
+	if err != nil {
+		return err
+	}
+	listenMa = listenMa.Encapsulate(multiaddr.StringCast("/tls/http"))
+	h.listenAddrsMu.Lock()
+	h.listenAddrs = append(h.listenAddrs, listenMa)
+	h.listenAddrsMu.Unlock()
+
+	h.server.TLSConfig = tlsConf
+	h.server.Handler = &h.handler
+
+	return h.server.ServeTLS(ln, "", "")
+}
+
+func (h *httpHost) ListenAddrs() []multiaddr.Multiaddr {
+	h.listenAddrsMu.Lock()
+	defer h.listenAddrsMu.Unlock()
+	out := make([]multiaddr.Multiaddr, 0, len(h.listenAddrs))
+	out = append(out, h.listenAddrs...)
+	return out
+}
+
+// Cached cert to peer id
+
+type memoizedCertToPeer struct {
+	mu sync.RWMutex
+	m  map[uint64]peer.ID
+}
+
+func (m *memoizedCertToPeer) get(cert []byte, owningObj any) (peer.ID, error) {
+	h := sha256.New()
+	_, err := h.Write(cert)
+	if err != nil {
+		return "", err
+	}
+
+	// Avoid allocating
+	b := [32]byte{}
+	h.Sum(b[:0])
+
+	k := binary.LittleEndian.Uint64(b[0:8])
+
+	m.mu.RLock()
+	val, ok := m.m[k]
+	m.mu.RUnlock()
+	if !ok {
+
+		cert, err := x509.ParseCertificate(cert)
+		if err != nil {
+			return "", err
+		}
+		certs := []*x509.Certificate{cert}
+		pubkey, err := libp2ptls.PubKeyFromCertChain(certs)
+		if err != nil {
+			return "", err
+		}
+
+		val, err = peer.IDFromPublicKey(pubkey)
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.m[k] = val
+		m.mu.Unlock()
+
+		runtime.SetFinalizer(owningObj, func(owningObj any) {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			delete(m.m, k)
+		})
+
+	}
+
+	return val, nil
+}

--- a/p2p/host/basic/http_test.go
+++ b/p2p/host/basic/http_test.go
@@ -1,0 +1,150 @@
+package basichost
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	coretest "github.com/libp2p/go-libp2p/core/test"
+	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
+	libp2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPRoundTripOverHTTP(t *testing.T) {
+	ma := multiaddr.StringCast("/ip4/127.0.0.1/tcp/9561/tls/http")
+	h1, err := NewHost(swarmt.GenSwarm(t), &HostOpts{
+		HTTPConfig: HTTPConfig{
+			EnableHTTP:     true,
+			HTTPServerAddr: ma,
+		},
+	})
+	require.NoError(t, err)
+	defer h1.Close()
+	h2, err := NewHost(swarmt.GenSwarm(t), nil)
+	require.NoError(t, err)
+	defer h2.Close()
+
+	recvdPeer := make(chan peer.ID, 1)
+	h1.SetHTTPHandler("/echo", func(peer peer.ID, w http.ResponseWriter, r *http.Request) {
+		// Select so we never block this handler. Useful if you want to keep this server up and use it directly with curl
+		select {
+		case recvdPeer <- peer:
+		default:
+		}
+		w.WriteHeader(200)
+		io.Copy(w, r.Body)
+	})
+
+	// We could use h1.Addrs, but we want to test that we are indeed listening over TCP+TLS HTTP
+	h2.Peerstore().AddAddrs(h1.ID(), h1.httpHost.ListenAddrs(), time.Hour)
+	client, err := h2.NewHTTPClient(h1.ID())
+	require.NoError(t, err)
+
+	resp, err := client.Post("/echo", "application/octet-stream", bytes.NewReader([]byte("Hello World")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, string(respBytes), "Hello World")
+	require.Equal(t, h2.ID(), <-recvdPeer)
+}
+
+func TestHTTPRoundTripOverLibp2pTransport(t *testing.T) {
+	ma := multiaddr.StringCast("/ip4/127.0.0.1/tcp/9561/tls/http")
+	h1, err := NewHost(swarmt.GenSwarm(t), &HostOpts{
+		HTTPConfig: HTTPConfig{
+			EnableHTTP:     true,
+			HTTPServerAddr: ma,
+		},
+	})
+	require.NoError(t, err)
+	defer h1.Close()
+	h2, err := NewHost(swarmt.GenSwarm(t), nil)
+	require.NoError(t, err)
+	defer h2.Close()
+
+	recvdPeer := make(chan peer.ID, 1)
+	h1.SetHTTPHandler("/echo", func(peer peer.ID, w http.ResponseWriter, r *http.Request) {
+		// Select so we never block this handler. Useful if you want to keep this server up and use it directly with curl
+		select {
+		case recvdPeer <- peer:
+		default:
+		}
+		w.WriteHeader(200)
+		io.Copy(w, r.Body)
+	})
+
+	ctx := context.Background()
+	h2.Connect(ctx, peer.AddrInfo{
+		ID: h1.ID(),
+		// TODO filter out http addrs here
+		Addrs: h1.Addrs(),
+	})
+
+	client, err := h2.NewHTTPClient(h1.ID())
+	require.NoError(t, err)
+
+	resp, err := client.Post("/echo", "application/octet-stream", bytes.NewReader([]byte("Hello World")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, string(respBytes), "Hello World")
+	require.Equal(t, h2.ID(), <-recvdPeer)
+}
+
+func BenchmarkReadingPeerFromCert(b *testing.B) {
+	priv, _, err := coretest.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(b, err)
+	id, err := libp2ptls.NewIdentity(priv)
+	require.NoError(b, err)
+
+	tlsConf, _ := id.ConfigForPeer("")
+	cert, err := x509.ParseCertificate(tlsConf.Certificates[0].Certificate[0])
+	require.NoError(b, err)
+	certs := []*x509.Certificate{cert}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// This is the easiest way we would get the peer id from an http request, we read it from the tls cert every time.
+		pubkey, err := libp2ptls.PubKeyFromCertChain(certs)
+		require.NoError(b, err)
+		_, err = peer.IDFromPublicKey(pubkey)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkReadingPeerFromCertMemoized(b *testing.B) {
+	priv, _, err := coretest.RandTestKeyPair(crypto.Ed25519, 256)
+	require.NoError(b, err)
+	id, err := libp2ptls.NewIdentity(priv)
+	require.NoError(b, err)
+
+	tlsConf, _ := id.ConfigForPeer("")
+	cert := tlsConf.Certificates[0].Certificate[0]
+	require.NoError(b, err)
+	m := memoizedCertToPeer{
+		m: map[uint64]peer.ID{},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// This is the fastest way we would get the peer id from an http
+		// request, we memoize the peer id from the hash of the cert. Then we
+		// add a finalizer to some owning object (here it's a tlsConf, but
+		// normally it would be a pointer to the tls cert) so that the memoized
+		// map gets cleared.
+		_, err := m.get(cert, tlsConf)
+		require.NoError(b, err)
+	}
+}

--- a/p2p/host/basic/httpclient.go
+++ b/p2p/host/basic/httpclient.go
@@ -1,0 +1,32 @@
+package basichost
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/gostream"
+)
+
+func newHTTPClientViaStreams(s gostream.Streamer, p peer.ID) (*http.Client, error) {
+	transport := gostream.NewTransport(s)
+	u, err := url.Parse("libp2p://" + p.String())
+	if err != nil {
+		return nil, err
+	}
+	rt := roundTripperWithBaseURL{transport, u}
+
+	return &http.Client{Transport: rt}, nil
+}
+
+type roundTripperWithBaseURL struct {
+	rt      http.RoundTripper
+	baseURL *url.URL
+}
+
+func (rt roundTripperWithBaseURL) RoundTrip(req *http.Request) (*http.Response, error) {
+	newURL := rt.baseURL.JoinPath(req.URL.Path)
+	newURL.RawQuery = req.URL.RawQuery
+	req.URL = newURL
+	return rt.rt.RoundTrip(req)
+}

--- a/p2p/net/gostream/addr.go
+++ b/p2p/net/gostream/addr.go
@@ -1,0 +1,14 @@
+package gostream
+
+import "github.com/libp2p/go-libp2p/core/peer"
+
+// addr implements net.Addr and holds a libp2p peer ID.
+type addr struct{ id peer.ID }
+
+// Network returns the name of the network that this address belongs to
+// (libp2p).
+func (a *addr) Network() string { return Network }
+
+// String returns the peer ID of this address in string form
+// (B58-encoded).
+func (a *addr) String() string { return a.id.String() }

--- a/p2p/net/gostream/conn.go
+++ b/p2p/net/gostream/conn.go
@@ -1,0 +1,42 @@
+package gostream
+
+import (
+	"context"
+	"net"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+// conn is an implementation of net.Conn which wraps
+// libp2p streams.
+type conn struct {
+	network.Stream
+}
+
+// newConn creates a conn given a libp2p stream
+func newConn(s network.Stream) net.Conn {
+	return &conn{s}
+}
+
+// LocalAddr returns the local network address.
+func (c *conn) LocalAddr() net.Addr {
+	return &addr{c.Stream.Conn().LocalPeer()}
+}
+
+// RemoteAddr returns the remote network address.
+func (c *conn) RemoteAddr() net.Addr {
+	return &addr{c.Stream.Conn().RemotePeer()}
+}
+
+// Dial opens a stream to the destination address
+// (which should parseable to a peer ID) using the given
+// host and returns it as a standard net.Conn.
+func Dial(ctx context.Context, h Streamer, pid peer.ID, tag protocol.ID) (net.Conn, error) {
+	s, err := h.NewStream(ctx, pid, tag)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(s), nil
+}

--- a/p2p/net/gostream/gostream.go
+++ b/p2p/net/gostream/gostream.go
@@ -1,0 +1,34 @@
+// Package gostream allows to replace the standard net stack in Go
+// with [LibP2P](https://github.com/libp2p/libp2p) streams.
+//
+// Given a libp2p.Host, gostream provides Dial() and Listen() methods which
+// return implementations of net.Conn and net.Listener.
+//
+// Instead of the regular "host:port" addressing, `gostream` uses a Peer ID,
+// and rather than a raw TCP connection, gostream will use libp2p's net.Stream.
+// This means your connections will take advantage of  LibP2P's multi-routes,
+// NAT transversal and stream multiplexing.
+//
+// Note that LibP2P hosts cannot dial to themselves, so there is no possibility
+// of using the same Host as server and as client.
+package gostream
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+// Network is the "net.Addr.Network()" name returned by
+// addresses used by gostream connections. In turn, the "net.Addr.String()" will
+// be a peer ID.
+var Network = "libp2p"
+
+type Streamer interface {
+	ID() peer.ID
+	SetStreamHandler(pid protocol.ID, handler network.StreamHandler)
+	RemoveStreamHandler(pid protocol.ID)
+	NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (network.Stream, error)
+}

--- a/p2p/net/gostream/gostream_test.go
+++ b/p2p/net/gostream/gostream_test.go
@@ -1,0 +1,141 @@
+package gostream_test
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// newHost illustrates how to build a libp2p host with secio using
+// a randomly generated key-pair
+func newHost(t *testing.T, listen multiaddr.Multiaddr) host.Host {
+	h, err := libp2p.New(
+		libp2p.ListenAddrs(listen),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestServerClient(t *testing.T) {
+	m1, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/10000")
+	m2, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/10001")
+	srvHost := newHost(t, m1)
+	clientHost := newHost(t, m2)
+	defer srvHost.Close()
+	defer clientHost.Close()
+
+	srvHost.Peerstore().AddAddrs(clientHost.ID(), clientHost.Addrs(), peerstore.PermanentAddrTTL)
+	clientHost.Peerstore().AddAddrs(srvHost.ID(), srvHost.Addrs(), peerstore.PermanentAddrTTL)
+
+	var tag protocol.ID = "/testitytest"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		listener, err := Listen(srvHost, tag)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer listener.Close()
+
+		if listener.Addr().String() != srvHost.ID().Pretty() {
+			t.Error("bad listener address")
+			return
+		}
+
+		servConn, err := listener.Accept()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer servConn.Close()
+
+		reader := bufio.NewReader(servConn)
+		for {
+			msg, err := reader.ReadString('\n')
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if msg != "is libp2p awesome?\n" {
+				t.Errorf("Bad incoming message: %s", msg)
+				return
+			}
+
+			_, err = servConn.Write([]byte("yes it is\n"))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+
+	clientConn, err := Dial(ctx, clientHost, srvHost.ID(), tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clientConn.LocalAddr().String() != clientHost.ID().Pretty() {
+		t.Fatal("Bad LocalAddr")
+	}
+
+	if clientConn.RemoteAddr().String() != srvHost.ID().Pretty() {
+		t.Fatal("Bad RemoteAddr")
+	}
+
+	if clientConn.LocalAddr().Network() != Network {
+		t.Fatal("Bad Network()")
+	}
+
+	err = clientConn.SetDeadline(time.Now().Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = clientConn.SetReadDeadline(time.Now().Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = clientConn.SetWriteDeadline(time.Now().Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = clientConn.Write([]byte("is libp2p awesome?\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bufio.NewReader(clientConn)
+	resp, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(resp) != "yes it is\n" {
+		t.Errorf("Bad response: %s", resp)
+	}
+
+	err = clientConn.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-done
+}

--- a/p2p/net/gostream/listener.go
+++ b/p2p/net/gostream/listener.go
@@ -1,0 +1,70 @@
+package gostream
+
+import (
+	"context"
+	"net"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+// listener is an implementation of net.Listener which handles
+// http-tagged streams from a libp2p connection.
+// A listener can be built with Listen()
+type listener struct {
+	host     Streamer
+	ctx      context.Context
+	tag      protocol.ID
+	cancel   func()
+	streamCh chan network.Stream
+}
+
+// Accept returns the next a connection to this listener.
+// It blocks if there are no connections. Under the hood,
+// connections are libp2p streams.
+func (l *listener) Accept() (net.Conn, error) {
+	select {
+	case s := <-l.streamCh:
+		return newConn(s), nil
+	case <-l.ctx.Done():
+		return nil, l.ctx.Err()
+	}
+}
+
+// Close terminates this listener. It will no longer handle any
+// incoming streams
+func (l *listener) Close() error {
+	l.cancel()
+	l.host.RemoveStreamHandler(l.tag)
+	return nil
+}
+
+// Addr returns the address for this listener, which is its libp2p Peer ID.
+func (l *listener) Addr() net.Addr {
+	return &addr{l.host.ID()}
+}
+
+// Listen provides a standard net.Listener ready to accept "connections".
+// Under the hood, these connections are libp2p streams tagged with the
+// given protocol.ID.
+func Listen(h Streamer, tag protocol.ID) (net.Listener, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	l := &listener{
+		host:     h,
+		ctx:      ctx,
+		cancel:   cancel,
+		tag:      tag,
+		streamCh: make(chan network.Stream),
+	}
+
+	h.SetStreamHandler(tag, func(s network.Stream) {
+		select {
+		case l.streamCh <- s:
+		case <-ctx.Done():
+			s.Reset()
+		}
+	})
+
+	return l, nil
+}

--- a/p2p/net/gostream/p2phttp.go
+++ b/p2p/net/gostream/p2phttp.go
@@ -1,0 +1,162 @@
+// Package p2phttp allows to serve HTTP endpoints and make HTTP requests through
+// LibP2P (https://github.com/libp2p/libp2p) using Go's standard "http" and
+// "net" stacks.
+//
+// Instead of the regular "host:port" addressing, `p2phttp` uses a Peer ID
+// and lets LibP2P take care of the routing, thus taking advantage
+// of features like multi-routes,  NAT transversal and stream multiplexing
+// over a single connection.
+//
+// When already running a LibP2P facility, this package allows to expose
+// existing HTTP-based services (like REST APIs) through LibP2P and to
+// use those services with minimal changes to the code-base.
+//
+// For example, a simple http.Server on LibP2P works as:
+//
+//		listener, _ := gostream.Listen(host1, p2phttp.DefaultP2PProtocol)
+//		defer listener.Close()
+//		go func() {
+//			http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+//				w.Write([]byte("Hi!"))
+//			})
+//			server := &http.Server{}
+//			server.Serve(listener)
+//		}
+//	     ...
+//
+// As shown above, a Server only needs a
+// "github.com/libp2p/go-libp2p-gostream" listener. This listener will
+// use a libP2P host to watch for stream tagged with our Protocol.
+//
+// On the other side, a client just needs to be initialized with a custom
+// LibP2P host-based transport to perform requests to such server:
+//
+//	tr := &http.Transport{}
+//	tr.RegisterProtocol("libp2p", p2phttp.NewTransport(clientHost))
+//	client := &http.Client{Transport: tr}
+//	res, err := client.Get("libp2p://Qmaoi4isbcTbFfohQyn28EiYM5CDWQx9QRCjDh3CTeiY7P/hello")
+//	...
+//
+// In the example above, the client registers a "libp2p" protocol for which the
+// custom transport is used. It can still perform regular "http" requests. The
+// protocol name used is arbitraty and non standard.
+//
+// Note that LibP2P hosts cannot dial to themselves, so there is no possibility
+// of using the same host as server and as client.
+package gostream
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+// DefaultP2PProtocol is used to tag and identify streams
+// handled by go-libp2p-http
+var DefaultP2PProtocol protocol.ID = "/libp2p-http"
+
+// options holds configuration options for the transport.
+type options struct {
+	Protocol protocol.ID
+}
+
+// Option allows to set the libp2p transport options.
+type Option func(o *options)
+
+// ProtocolOption sets the Protocol Tag associated to the libp2p roundtripper.
+func ProtocolOption(p protocol.ID) Option {
+	return func(o *options) {
+		o.Protocol = p
+	}
+}
+
+// RoundTripper implemenets http.RoundTrip and can be used as
+// custom transport with Go http.Client.
+type RoundTripper struct {
+	h    Streamer
+	opts options
+}
+
+// NewTransport returns a new RoundTripper which uses the provided
+// libP2P host to perform an http request and obtain the response.
+//
+// The typical use case for NewTransport is to register the "libp2p"
+// protocol with a Transport, as in:
+//
+//	t := &http.Transport{}
+//	t.RegisterProtocol("libp2p", p2phttp.NewTransport(host, ProtocolOption(DefaultP2PProtocol)))
+//	c := &http.Client{Transport: t}
+//	res, err := c.Get("libp2p://Qmaoi4isbcTbFfohQyn28EiYM5CDWQx9QRCjDh3CTeiY7P/index.html")
+//	...
+func NewTransport(h Streamer, opts ...Option) *RoundTripper {
+	defOpts := options{
+		Protocol: DefaultP2PProtocol,
+	}
+	for _, o := range opts {
+		o(&defOpts)
+	}
+
+	return &RoundTripper{h, defOpts}
+}
+
+// we wrap the response body and close the stream
+// only when it's closed.
+type respBody struct {
+	io.ReadCloser
+	conn net.Conn
+}
+
+// Closes the response's body and the connection.
+func (rb *respBody) Close() error {
+	rb.conn.Close()
+	return rb.ReadCloser.Close()
+}
+
+// RoundTrip executes a single HTTP transaction, returning
+// a Response for the provided Request.
+func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	addr := r.Host
+	if addr == "" {
+		addr = r.URL.Host
+	}
+
+	pid, err := peer.Decode(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := Dial(r.Context(), rt.h, peer.ID(pid), rt.opts.Protocol)
+	if err != nil {
+		if r.Body != nil {
+			r.Body.Close()
+		}
+		return nil, err
+	}
+
+	// Write the request while reading the response
+	go func() {
+		err := r.Write(conn)
+		if err != nil {
+			conn.Close()
+		}
+		if r.Body != nil {
+			r.Body.Close()
+		}
+	}()
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), r)
+	if err != nil {
+		return resp, err
+	}
+
+	resp.Body = &respBody{
+		ReadCloser: resp.Body,
+		conn:       conn,
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
A draft PR that adds first class support for HTTP as a protocol in libp2p. This came out of various discussions around IPFS camp and 1:1 discussions.

This means:
* You can write a protocol using HTTP
* You can use HTTP over libp2p streams.
* You can use your HTTP protocol over a standard TCP + TLS HTTP connection (even curl works to communicate with a libp2p node, i.e. this works: `curl --insecure --cert ./client.cert --key ./client.key https://127.0.0.1:9561/echo -d "Hello World"`).
* This enables you to communicate with a peer over standard TCP + TLS HTTP, _even if that peer is a dumb static server_.

More details in the draft spec: <todo link>

---

Note: this is **not** in the roadmap. This came from seeing the desire when talking to various users around IPFS camp. This work for now will be prioritized below other items in the roadmap unless we agree otherwise.

---  

Do not merge this PR until:

- [ ] We discuss this in the libp2p spec
- [ ] Agree on a protocol ID
- [ ] Agree on the API shown off here
- [ ] Clean up the code. There are various TODOs left since the first pass here is a PoC.