### PR TITLE
fix: autorelay: treat static relays as just another peer source

### DIFF
--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -456,3 +456,38 @@ func TestIncorrectInit(t *testing.T) {
 	}()
 	_ = newPrivateNode(t)
 }
+
+func TestReconnectToStaticRelays(t *testing.T) {
+	cl := clock.NewMock()
+	var staticRelays []peer.AddrInfo
+	const numStaticRelays = 1
+	relays := make([]host.Host, 0, numStaticRelays)
+	for i := 0; i < numStaticRelays; i++ {
+		r := newRelay(t)
+		t.Cleanup(func() { r.Close() })
+		relays = append(relays, r)
+		staticRelays = append(staticRelays, peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()})
+	}
+
+	h := newPrivateNode(t,
+		autorelay.WithStaticRelays(staticRelays),
+		autorelay.WithMinCandidates(1),
+		autorelay.WithClock(cl),
+	)
+
+	defer h.Close()
+
+	cl.Add(time.Minute)
+	require.Eventually(t, func() bool { return numRelays(h) == 1 }, 3*time.Second, 50*time.Millisecond)
+
+	relaysInUse := usedRelays(h)
+	oldRelay := relaysInUse[0]
+	for _, r := range relays {
+		if r.ID() == oldRelay {
+			r.Network().ClosePeer(h.ID())
+		}
+	}
+
+	cl.Add(time.Hour)
+	require.Eventually(t, func() bool { return numRelays(h) == 1 }, 3*time.Second, 100*time.Millisecond)
+}


### PR DESCRIPTION
fixes https://github.com/libp2p/go-libp2p/issues/1782 by making static relays a specific type of peer source. Then re-using all the peersource logic. @marten-seemann  was there a reason you didn't do this originally?