### PR TITLE
rcmgr: fix missing service peer default in LimitConfig.Apply

### DIFF
--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -160,6 +160,7 @@ func (cfg *LimitConfig) Apply(c LimitConfig) {
 	cfg.AllowlistedSystem.Apply(c.AllowlistedSystem)
 	cfg.AllowlistedTransient.Apply(c.AllowlistedTransient)
 	cfg.ServiceDefault.Apply(c.ServiceDefault)
+	cfg.ServicePeerDefault.Apply(c.ServicePeerDefault)
 	cfg.ProtocolDefault.Apply(c.ProtocolDefault)
 	cfg.ProtocolPeerDefault.Apply(c.ProtocolPeerDefault)
 	cfg.PeerDefault.Apply(c.PeerDefault)


### PR DESCRIPTION
ServicePeerDefault wasn't being applied in the Apply method, which led to these limits being 0 instead of mirroring the limits from the Apply call in some usage patterns.
