### PR TITLE
feat: quic,webtransport: enable both quic-draft29 and quic-v1 addrs on quic. only quic-v1 on webtransport

### DIFF
--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -91,7 +91,7 @@ type Listener interface {
 	Accept() (CapableConn, error)
 	Close() error
 	Addr() net.Addr
-	Multiaddr() ma.Multiaddr
+	Multiaddrs() []ma.Multiaddr
 }
 
 // TransportNetwork is an inet.Network with methods for managing transports.

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-base32 v0.1.0
-	github.com/multiformats/go-multiaddr v0.7.0
+	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multibase v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ8
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
 github.com/multiformats/go-multiaddr v0.1.1/go.mod h1:aMKBKNEYmzmDmxfX88/vz+J5IU55txyt0p4aiWVohjo=
 github.com/multiformats/go-multiaddr v0.2.0/go.mod h1:0nO36NvPpyV4QzvTLi/lafl2y95ncPj0vFwVF6k6wJ4=
-github.com/multiformats/go-multiaddr v0.7.0 h1:gskHcdaCyPtp9XskVwtvEeQOG465sCohbQIirSyqxrc=
-github.com/multiformats/go-multiaddr v0.7.0/go.mod h1:Fs50eBDWvZu+l3/9S6xAE7ZYj6yhxlvaVZjakWN7xRs=
+github.com/multiformats/go-multiaddr v0.8.0 h1:aqjksEcqK+iD/Foe1RRFsGZh8+XFiGo7FgUCZlpv3LU=
+github.com/multiformats/go-multiaddr v0.8.0/go.mod h1:Fs50eBDWvZu+l3/9S6xAE7ZYj6yhxlvaVZjakWN7xRs=
 github.com/multiformats/go-multiaddr-dns v0.3.1 h1:QgQgR+LQVt3NPTjbrLLpsaT2ufAA2y0Mkk+QRVJbW3A=
 github.com/multiformats/go-multiaddr-dns v0.3.1/go.mod h1:G/245BRQ6FJGmryJCrOuTdB37AMA5AMOVuO6NY3JwTk=
 github.com/multiformats/go-multiaddr-fmt v0.1.0 h1:WLEFClPycPkp4fnIzoFoV9FVd49/eQsuaL3/CWe167E=

--- a/p2p/host/autonat/dialpolicy_test.go
+++ b/p2p/host/autonat/dialpolicy_test.go
@@ -47,9 +47,9 @@ func (l *mockL) Accept() (transport.CapableConn, error) {
 	<-l.ctx.Done()
 	return nil, errors.New("expected in mocked test")
 }
-func (l *mockL) Close() error                   { return nil }
-func (l *mockL) Addr() net.Addr                 { return nil }
-func (l *mockL) Multiaddr() multiaddr.Multiaddr { return l.addr }
+func (l *mockL) Close() error                      { return nil }
+func (l *mockL) Addr() net.Addr                    { return nil }
+func (l *mockL) Multiaddrs() []multiaddr.Multiaddr { return []multiaddr.Multiaddr{l.addr} }
 
 func TestSkipDial(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -237,8 +237,14 @@ func (s *Swarm) close() {
 	s.transports.m = nil
 	s.transports.Unlock()
 
-	var wg sync.WaitGroup
+	// Dedup transports that may be listening on multiple protocols
+	transportsToClose := make(map[transport.Transport]struct{}, len(transports))
 	for _, t := range transports {
+		transportsToClose[t] = struct{}{}
+	}
+
+	var wg sync.WaitGroup
+	for t := range transportsToClose {
 		if closer, ok := t.(io.Closer); ok {
 			wg.Add(1)
 			go func(c io.Closer) {

--- a/p2p/net/swarm/swarm_addr.go
+++ b/p2p/net/swarm/swarm_addr.go
@@ -18,7 +18,7 @@ func (s *Swarm) ListenAddresses() []ma.Multiaddr {
 func (s *Swarm) listenAddressesNoLock() []ma.Multiaddr {
 	addrs := make([]ma.Multiaddr, 0, len(s.listeners.m))
 	for l := range s.listeners.m {
-		addrs = append(addrs, l.Multiaddr())
+		addrs = append(addrs, l.Multiaddrs()...)
 	}
 	return addrs
 }

--- a/p2p/net/swarm/swarm_addr.go
+++ b/p2p/net/swarm/swarm_addr.go
@@ -16,7 +16,7 @@ func (s *Swarm) ListenAddresses() []ma.Multiaddr {
 }
 
 func (s *Swarm) listenAddressesNoLock() []ma.Multiaddr {
-	addrs := make([]ma.Multiaddr, 0, len(s.listeners.m))
+	addrs := make([]ma.Multiaddr, 0, len(s.listeners.m)+10) // A bit extra so we may avoid an extra allocation in the for loop below.
 	for l := range s.listeners.m {
 		addrs = append(addrs, l.Multiaddrs()...)
 	}

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -98,7 +98,7 @@ func TestDialAddressSelection(t *testing.T) {
 	require.Equal(t, tcpTr, s.TransportForDialing(ma.StringCast("/ip4/127.0.0.1/tcp/1234")))
 	require.Equal(t, quicTr, s.TransportForDialing(ma.StringCast("/ip4/127.0.0.1/udp/1234/quic")))
 	require.Equal(t, circuitTr, s.TransportForDialing(ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic/p2p-circuit/p2p/%s", id))))
-	require.Equal(t, webtransportTr, s.TransportForDialing(ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic/webtransport/certhash/%s", certHash))))
+	require.Equal(t, webtransportTr, s.TransportForDialing(ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/%s", certHash))))
 	require.Nil(t, s.TransportForDialing(ma.StringCast("/ip4/1.2.3.4")))
 	require.Nil(t, s.TransportForDialing(ma.StringCast("/ip4/1.2.3.4/tcp/443/ws")))
 }

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/transport"
+	"github.com/lucas-clemente/quic-go"
 
 	ma "github.com/multiformats/go-multiaddr"
 	madns "github.com/multiformats/go-multiaddr-dns"
@@ -439,15 +440,17 @@ func (s *Swarm) filterKnownUndialables(p peer.ID, addrs []ma.Multiaddr) []ma.Mul
 		}
 	}
 
-	return maybeRemoveWebTransportAddrs(ma.FilterAddrs(addrs,
-		func(addr ma.Multiaddr) bool { return !ma.Contains(ourAddrs, addr) },
-		s.canDial,
-		// TODO: Consider allowing link-local addresses
-		func(addr ma.Multiaddr) bool { return !manet.IsIP6LinkLocal(addr) },
-		func(addr ma.Multiaddr) bool {
-			return s.gater == nil || s.gater.InterceptAddrDial(p, addr)
-		},
-	))
+	return maybeRemoveWebTransportAddrs(
+		maybeRemoveQUICDraft29(
+			ma.FilterAddrs(addrs,
+				func(addr ma.Multiaddr) bool { return !ma.Contains(ourAddrs, addr) },
+				s.canDial,
+				// TODO: Consider allowing link-local addresses
+				func(addr ma.Multiaddr) bool { return !manet.IsIP6LinkLocal(addr) },
+				func(addr ma.Multiaddr) bool {
+					return s.gater == nil || s.gater.InterceptAddrDial(p, addr)
+				},
+			)))
 }
 
 // limitedDial will start a dial to the given peer when
@@ -536,9 +539,32 @@ func isWebTransport(addr ma.Multiaddr) bool {
 	return err == nil
 }
 
-func isQUIC(addr ma.Multiaddr) bool {
-	_, err := addr.ValueForProtocol(ma.P_QUIC)
-	return err == nil && !isWebTransport(addr)
+func quicVersion(addr ma.Multiaddr) (quic.VersionNumber, bool) {
+	found := false
+	foundWebTransport := false
+	var version quic.VersionNumber
+	ma.ForEach(addr, func(c ma.Component) bool {
+		switch c.Protocol().Code {
+		case ma.P_QUIC:
+			version = quic.VersionDraft29
+			found = true
+			return true
+		case ma.P_QUIC_V1:
+			version = quic.Version1
+			found = true
+			return true
+		case ma.P_WEBTRANSPORT:
+			version = quic.Version1
+			foundWebTransport = true
+			return false
+		default:
+			return true
+		}
+	})
+	if foundWebTransport {
+		return 0, false
+	}
+	return version, found
 }
 
 // If we have QUIC addresses, we don't want to dial WebTransport addresses.
@@ -548,7 +574,7 @@ func isQUIC(addr ma.Multiaddr) bool {
 func maybeRemoveWebTransportAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	var hasQuic, hasWebTransport bool
 	for _, addr := range addrs {
-		if isQUIC(addr) {
+		if _, isQuic := quicVersion(addr); isQuic {
 			hasQuic = true
 		}
 		if isWebTransport(addr) {
@@ -561,6 +587,41 @@ func maybeRemoveWebTransportAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	var c int
 	for _, addr := range addrs {
 		if isWebTransport(addr) {
+			continue
+		}
+		addrs[c] = addr
+		c++
+	}
+	return addrs[:c]
+}
+
+// If we have QUIC V1 addresses, we don't want to dial QUIC draft29 addresses.
+// This is a similar hack to the above. If we add one more hack like this, let's
+// define a `Filterer` interface like the `Resolver` interface that transports
+// can optionally implement if they want to filter the multiaddrs.
+//
+// This mutates the input
+func maybeRemoveQUICDraft29(addrs []ma.Multiaddr) []ma.Multiaddr {
+	var hasQuicV1, hasQuicDraft29 bool
+	for _, addr := range addrs {
+		v, isQuic := quicVersion(addr)
+		if !isQuic {
+			continue
+		}
+
+		if v == quic.Version1 {
+			hasQuicV1 = true
+		}
+		if v == quic.VersionDraft29 {
+			hasQuicDraft29 = true
+		}
+	}
+	if !hasQuicDraft29 || !hasQuicV1 {
+		return addrs
+	}
+	var c int
+	for _, addr := range addrs {
+		if v, isQuic := quicVersion(addr); isQuic && v == quic.VersionDraft29 {
 			continue
 		}
 		addrs[c] = addr

--- a/p2p/net/swarm/swarm_dial_test.go
+++ b/p2p/net/swarm/swarm_dial_test.go
@@ -204,3 +204,15 @@ func TestRemoveWebTransportAddrs(t *testing.T) {
 	require.Equal(t, []ma.Multiaddr{quicAddr}, maybeRemoveWebTransportAddrs([]ma.Multiaddr{quicAddr, webtransportAddr}))
 	require.Equal(t, []ma.Multiaddr{webtransportAddr}, maybeRemoveWebTransportAddrs([]ma.Multiaddr{webtransportAddr}))
 }
+
+func TestRemoveQuicDraft29(t *testing.T) {
+	tcpAddr := ma.StringCast("/ip4/9.5.6.4/tcp/1234")
+	quicDraft29Addr := ma.StringCast("/ip4/1.2.3.4/udp/443/quic")
+	quicV1Addr := ma.StringCast("/ip4/1.2.3.4/udp/443/quic-v1")
+
+	require.Equal(t, []ma.Multiaddr{tcpAddr, quicV1Addr}, maybeRemoveQUICDraft29([]ma.Multiaddr{tcpAddr, quicV1Addr}))
+	require.Equal(t, []ma.Multiaddr{tcpAddr, quicDraft29Addr}, maybeRemoveQUICDraft29([]ma.Multiaddr{tcpAddr, quicDraft29Addr}))
+	require.Equal(t, []ma.Multiaddr{tcpAddr, quicV1Addr}, maybeRemoveQUICDraft29([]ma.Multiaddr{tcpAddr, quicDraft29Addr, quicV1Addr}))
+	require.Equal(t, []ma.Multiaddr{quicV1Addr}, maybeRemoveQUICDraft29([]ma.Multiaddr{quicV1Addr, quicDraft29Addr}))
+	require.Equal(t, []ma.Multiaddr{quicDraft29Addr}, maybeRemoveQUICDraft29([]ma.Multiaddr{quicDraft29Addr}))
+}

--- a/p2p/net/swarm/swarm_dial_test.go
+++ b/p2p/net/swarm/swarm_dial_test.go
@@ -196,7 +196,7 @@ func TestAddrResolutionRecursive(t *testing.T) {
 func TestRemoveWebTransportAddrs(t *testing.T) {
 	tcpAddr := ma.StringCast("/ip4/9.5.6.4/tcp/1234")
 	quicAddr := ma.StringCast("/ip4/1.2.3.4/udp/443/quic")
-	webtransportAddr := ma.StringCast("/ip4/1.2.3.4/udp/443/quic/webtransport")
+	webtransportAddr := ma.StringCast("/ip4/1.2.3.4/udp/443/quic-v1/webtransport")
 
 	require.Equal(t, []ma.Multiaddr{tcpAddr, quicAddr}, maybeRemoveWebTransportAddrs([]ma.Multiaddr{tcpAddr, quicAddr}))
 	require.Equal(t, []ma.Multiaddr{tcpAddr, webtransportAddr}, maybeRemoveWebTransportAddrs([]ma.Multiaddr{tcpAddr, webtransportAddr}))

--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -37,7 +37,11 @@ func (s *Swarm) Listen(addrs ...ma.Multiaddr) error {
 	return nil
 }
 
-// ListenClose stop and delete listeners for all of the given addresses.
+// ListenClose stop and delete listeners for all of the given addresses. If an
+// any address belongs to one of the addreses a Listener provides, then the
+// Listener will close for *all* addresses it provides. For example if you close
+// and address with `/quic`, then the QUIC listener will close and also close
+// any `/quic-v1` address.
 func (s *Swarm) ListenClose(addrs ...ma.Multiaddr) {
 	var listenersToClose []transport.Listener
 

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -552,7 +552,7 @@ func TestListenCloseCount(t *testing.T) {
 		t.Fatal(err)
 	}
 	listenedAddrs := s.ListenAddresses()
-	require.Equal(t, 2, len(listenedAddrs))
+	require.Equal(t, 3, len(listenedAddrs))
 
 	s.ListenClose(listenedAddrs...)
 

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -10,6 +10,7 @@ import (
 
 	logging "github.com/ipfs/go-log/v2"
 	tec "github.com/jbenet/go-temp-err-catcher"
+	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
@@ -173,6 +174,10 @@ func (l *listener) String() string {
 		return fmt.Sprintf("<stream.Listener[%s] %s>", s, l.Multiaddr())
 	}
 	return fmt.Sprintf("<stream.Listener %s>", l.Multiaddr())
+}
+
+func (l *listener) Multiaddrs() []multiaddr.Multiaddr {
+	return []multiaddr.Multiaddr{l.Multiaddr()}
 }
 
 var _ transport.Listener = (*listener)(nil)

--- a/p2p/net/upgrader/listener_test.go
+++ b/p2p/net/upgrader/listener_test.go
@@ -56,7 +56,7 @@ func TestAcceptSingleConn(t *testing.T) {
 	ln := createListener(t, u)
 	defer ln.Close()
 
-	cconn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+	cconn, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(err)
 
 	sconn, err := ln.Accept()
@@ -80,7 +80,7 @@ func TestAcceptMultipleConns(t *testing.T) {
 	}()
 
 	for i := 0; i < 10; i++ {
-		cconn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+		cconn, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 		require.NoError(err)
 		toClose = append(toClose, cconn)
 
@@ -104,7 +104,7 @@ func TestConnectionsClosedIfNotAccepted(t *testing.T) {
 	ln := createListener(t, u)
 	defer ln.Close()
 
-	conn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+	conn, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(err)
 
 	errCh := make(chan error)
@@ -143,7 +143,7 @@ func TestFailedUpgradeOnListen(t *testing.T) {
 		errCh <- err
 	}()
 
-	_, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+	_, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.Error(err)
 
 	// close the listener.
@@ -177,7 +177,7 @@ func TestListenerClose(t *testing.T) {
 	require.Contains(err.Error(), "use of closed network connection")
 
 	// doesn't accept new connections when it is closed
-	_, err = dial(t, u, ln.Multiaddr(), peer.ID("1"), &network.NullScope{})
+	_, err = dial(t, u, ln.Multiaddrs()[0], peer.ID("1"), &network.NullScope{})
 	require.Error(err)
 }
 
@@ -189,7 +189,7 @@ func TestListenerCloseClosesQueued(t *testing.T) {
 
 	var conns []transport.CapableConn
 	for i := 0; i < 10; i++ {
-		conn, err := dial(t, upgrader, ln.Multiaddr(), id, &network.NullScope{})
+		conn, err := dial(t, upgrader, ln.Multiaddrs()[0], id, &network.NullScope{})
 		require.NoError(err)
 		conns = append(conns, conn)
 	}
@@ -249,7 +249,7 @@ func TestConcurrentAccept(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			conn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+			conn, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 			if err != nil {
 				errCh <- err
 				return
@@ -279,7 +279,7 @@ func TestAcceptQueueBacklogged(t *testing.T) {
 	// setup AcceptQueueLength connections, but don't accept any of them
 	var counter int32 // to be used atomically
 	doDial := func() {
-		conn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+		conn, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 		require.NoError(err)
 		atomic.AddInt32(&counter, 1)
 		t.Cleanup(func() { conn.Close() })
@@ -315,7 +315,7 @@ func TestListenerConnectionGater(t *testing.T) {
 	defer ln.Close()
 
 	// no gating.
-	conn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+	conn, err := dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(err)
 	require.False(conn.IsClosed())
 	_ = conn.Close()
@@ -323,28 +323,28 @@ func TestListenerConnectionGater(t *testing.T) {
 	// rejecting after handshake.
 	testGater.BlockSecured(true)
 	testGater.BlockAccept(false)
-	conn, err = dial(t, u, ln.Multiaddr(), "invalid", &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddrs()[0], "invalid", &network.NullScope{})
 	require.Error(err)
 	require.Nil(conn)
 
 	// rejecting on accept will trigger firupgrader.
 	testGater.BlockSecured(true)
 	testGater.BlockAccept(true)
-	conn, err = dial(t, u, ln.Multiaddr(), "invalid", &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddrs()[0], "invalid", &network.NullScope{})
 	require.Error(err)
 	require.Nil(conn)
 
 	// rejecting only on acceptance.
 	testGater.BlockSecured(false)
 	testGater.BlockAccept(true)
-	conn, err = dial(t, u, ln.Multiaddr(), "invalid", &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddrs()[0], "invalid", &network.NullScope{})
 	require.Error(err)
 	require.Nil(conn)
 
 	// back to normal
 	testGater.BlockSecured(false)
 	testGater.BlockAccept(false)
-	conn, err = dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(err)
 	require.False(conn.IsClosed())
 	_ = conn.Close()
@@ -360,13 +360,13 @@ func TestListenerResourceManagement(t *testing.T) {
 
 	connScope := mocknetwork.NewMockConnManagementScope(ctrl)
 	gomock.InOrder(
-		rcmgr.EXPECT().OpenConnection(network.DirInbound, true, gomock.Not(ln.Multiaddr())).Return(connScope, nil),
+		rcmgr.EXPECT().OpenConnection(network.DirInbound, true, gomock.Not(ln.Multiaddrs()[0])).Return(connScope, nil),
 		connScope.EXPECT().PeerScope(),
 		connScope.EXPECT().SetPeer(id),
 		connScope.EXPECT().PeerScope(),
 	)
 
-	cconn, err := dial(t, upgrader, ln.Multiaddr(), id, &network.NullScope{})
+	cconn, err := dial(t, upgrader, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(t, err)
 	defer cconn.Close()
 
@@ -383,8 +383,8 @@ func TestListenerResourceManagementDenied(t *testing.T) {
 	id, upgrader := createUpgraderWithResourceManager(t, rcmgr)
 	ln := createListener(t, upgrader)
 
-	rcmgr.EXPECT().OpenConnection(network.DirInbound, true, gomock.Not(ln.Multiaddr())).Return(nil, errors.New("nope"))
-	_, err := dial(t, upgrader, ln.Multiaddr(), id, &network.NullScope{})
+	rcmgr.EXPECT().OpenConnection(network.DirInbound, true, gomock.Not(ln.Multiaddrs()[0])).Return(nil, errors.New("nope"))
+	_, err := dial(t, upgrader, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.Error(t, err)
 
 	done := make(chan struct{})

--- a/p2p/net/upgrader/upgrader_test.go
+++ b/p2p/net/upgrader/upgrader_test.go
@@ -134,21 +134,21 @@ func TestOutboundConnectionGating(t *testing.T) {
 
 	testGater := &testGater{}
 	_, dialUpgrader := createUpgraderWithConnGater(t, testGater)
-	conn, err := dial(t, dialUpgrader, ln.Multiaddr(), id, &network.NullScope{})
+	conn, err := dial(t, dialUpgrader, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(err)
 	require.NotNil(conn)
 	_ = conn.Close()
 
 	// blocking accepts doesn't affect the dialling side, only the listener.
 	testGater.BlockAccept(true)
-	conn, err = dial(t, dialUpgrader, ln.Multiaddr(), id, &network.NullScope{})
+	conn, err = dial(t, dialUpgrader, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.NoError(err)
 	require.NotNil(conn)
 	_ = conn.Close()
 
 	// now let's block all connections after being secured.
 	testGater.BlockSecured(true)
-	conn, err = dial(t, dialUpgrader, ln.Multiaddr(), id, &network.NullScope{})
+	conn, err = dial(t, dialUpgrader, ln.Multiaddrs()[0], id, &network.NullScope{})
 	require.Error(err)
 	require.Contains(err.Error(), "gater rejected connection")
 	require.Nil(conn)
@@ -169,7 +169,7 @@ func TestOutboundResourceManagement(t *testing.T) {
 			connScope.EXPECT().PeerScope().Return(&network.NullScope{}),
 		)
 		_, dialUpgrader := createUpgrader(t)
-		conn, err := dial(t, dialUpgrader, ln.Multiaddr(), id, connScope)
+		conn, err := dial(t, dialUpgrader, ln.Multiaddrs()[0], id, connScope)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 		connScope.EXPECT().Done()
@@ -191,7 +191,7 @@ func TestOutboundResourceManagement(t *testing.T) {
 			connScope.EXPECT().Done(),
 		)
 		_, dialUpgrader := createUpgrader(t)
-		_, err := dial(t, dialUpgrader, ln.Multiaddr(), id, connScope)
+		_, err := dial(t, dialUpgrader, ln.Multiaddrs()[0], id, connScope)
 		require.Error(t, err)
 	})
 

--- a/p2p/test/webtransport/webtransport_test.go
+++ b/p2p/test/webtransport/webtransport_test.go
@@ -33,7 +33,7 @@ func TestDeterministicCertsAfterReboot(t *testing.T) {
 	cl.Add(time.Hour * 24 * 365)
 	h, err := libp2p.New(libp2p.NoTransports, libp2p.Transport(libp2pwebtransport.New, libp2pwebtransport.WithClock(cl)), libp2p.Identity(priv))
 	require.NoError(t, err)
-	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 
 	prevCerthashes := extractCertHashes(h.Addrs()[0])
@@ -42,7 +42,7 @@ func TestDeterministicCertsAfterReboot(t *testing.T) {
 	h, err = libp2p.New(libp2p.NoTransports, libp2p.Transport(libp2pwebtransport.New, libp2pwebtransport.WithClock(cl)), libp2p.Identity(priv))
 	require.NoError(t, err)
 	defer h.Close()
-	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 
 	nextCertHashes := extractCertHashes(h.Addrs()[0])

--- a/p2p/transport/quic/cmd/server/main.go
+++ b/p2p/transport/quic/cmd/server/main.go
@@ -48,7 +48,7 @@ func run(port string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Listening. Now run: go run cmd/client/main.go %s %s\n", ln.Multiaddr(), peerID)
+	fmt.Printf("Listening. Now run: go run cmd/client/main.go %s %s\n", ln.Multiaddrs()[0], peerID)
 	for {
 		conn, err := ln.Accept()
 		if err != nil {

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -3,6 +3,7 @@ package libp2pquic
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
@@ -19,18 +20,18 @@ var quicListen = quic.Listen // so we can mock it in tests
 
 // A listener listens for QUIC connections.
 type listener struct {
-	quicListener   quic.Listener
-	conn           pConn
-	transport      *transport
-	rcmgr          network.ResourceManager
-	privKey        ic.PrivKey
-	localPeer      peer.ID
-	localMultiaddr ma.Multiaddr
+	quicListener    quic.Listener
+	conn            pConn
+	transport       *transport
+	rcmgr           network.ResourceManager
+	privKey         ic.PrivKey
+	localPeer       peer.ID
+	localMultiaddrs map[quic.VersionNumber]ma.Multiaddr
 }
 
 var _ tpt.Listener = &listener{}
 
-func newListener(pconn pConn, t *transport, localPeer peer.ID, key ic.PrivKey, identity *p2ptls.Identity, rcmgr network.ResourceManager) (tpt.Listener, error) {
+func newListener(pconn pConn, t *transport, localPeer peer.ID, key ic.PrivKey, identity *p2ptls.Identity, rcmgr network.ResourceManager, enableDraft29 bool) (tpt.Listener, error) {
 	var tlsConf tls.Config
 	tlsConf.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
 		// return a tls.Config that verifies the peer's certificate chain.
@@ -44,18 +45,30 @@ func newListener(pconn pConn, t *transport, localPeer peer.ID, key ic.PrivKey, i
 	if err != nil {
 		return nil, err
 	}
-	localMultiaddr, err := toQuicMultiaddr(ln.Addr())
+	localMultiaddr, err := toQuicMultiaddr(ln.Addr(), quic.Version1)
 	if err != nil {
 		return nil, err
 	}
+
+	localMultiaddrs := map[quic.VersionNumber]ma.Multiaddr{}
+	localMultiaddrs[quic.Version1] = localMultiaddr
+
+	if enableDraft29 {
+		localMultiaddr, err := toQuicMultiaddr(ln.Addr(), quic.VersionDraft29)
+		if err != nil {
+			return nil, err
+		}
+		localMultiaddrs[quic.VersionDraft29] = localMultiaddr
+	}
+
 	return &listener{
-		conn:           pconn,
-		quicListener:   ln,
-		transport:      t,
-		rcmgr:          rcmgr,
-		privKey:        key,
-		localPeer:      localPeer,
-		localMultiaddr: localMultiaddr,
+		conn:            pconn,
+		quicListener:    ln,
+		transport:       t,
+		rcmgr:           rcmgr,
+		privKey:         key,
+		localPeer:       localPeer,
+		localMultiaddrs: localMultiaddrs,
 	}, nil
 }
 
@@ -97,7 +110,7 @@ func (l *listener) Accept() (tpt.CapableConn, error) {
 }
 
 func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
-	remoteMultiaddr, err := toQuicMultiaddr(qconn.RemoteAddr())
+	remoteMultiaddr, err := toQuicMultiaddr(qconn.RemoteAddr(), qconn.ConnectionState().Version)
 	if err != nil {
 		return nil, err
 	}
@@ -127,6 +140,11 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 		return nil, err
 	}
 
+	localMultiaddr, found := l.localMultiaddrs[qconn.ConnectionState().Version]
+	if !found {
+		return nil, errors.New("unknown quic version:" + qconn.ConnectionState().Version.String())
+	}
+
 	l.conn.IncreaseCount()
 	return &conn{
 		quicConn:        qconn,
@@ -134,7 +152,7 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 		transport:       l.transport,
 		scope:           connScope,
 		localPeer:       l.localPeer,
-		localMultiaddr:  l.localMultiaddr,
+		localMultiaddr:  localMultiaddr,
 		privKey:         l.privKey,
 		remoteMultiaddr: remoteMultiaddr,
 		remotePeerID:    remotePeerID,
@@ -165,5 +183,9 @@ func (l *listener) Addr() net.Addr {
 
 // Multiaddr returns the multiaddress of this listener.
 func (l *listener) Multiaddrs() []ma.Multiaddr {
-	return []ma.Multiaddr{l.localMultiaddr}
+	mas := make([]ma.Multiaddr, 0, len(l.localMultiaddrs))
+	for _, a := range l.localMultiaddrs {
+		mas = append(mas, a)
+	}
+	return mas
 }

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -164,6 +164,6 @@ func (l *listener) Addr() net.Addr {
 }
 
 // Multiaddr returns the multiaddress of this listener.
-func (l *listener) Multiaddr() ma.Multiaddr {
-	return l.localMultiaddr
+func (l *listener) Multiaddrs() []ma.Multiaddr {
+	return []ma.Multiaddr{l.localMultiaddr}
 }

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -142,7 +142,7 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 
 	localMultiaddr, found := l.localMultiaddrs[qconn.ConnectionState().Version]
 	if !found {
-		return nil, errors.New("unknown quic version:" + qconn.ConnectionState().Version.String())
+		return nil, errors.New("unknown QUIC version:" + qconn.ConnectionState().Version.String())
 	}
 
 	l.conn.IncreaseCount()

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -50,8 +50,7 @@ func newListener(pconn pConn, t *transport, localPeer peer.ID, key ic.PrivKey, i
 		return nil, err
 	}
 
-	localMultiaddrs := map[quic.VersionNumber]ma.Multiaddr{}
-	localMultiaddrs[quic.Version1] = localMultiaddr
+	localMultiaddrs := map[quic.VersionNumber]ma.Multiaddr{quic.Version1: localMultiaddr}
 
 	if enableDraft29 {
 		localMultiaddr, err := toQuicMultiaddr(ln.Addr(), quic.VersionDraft29)

--- a/p2p/transport/quic/listener_test.go
+++ b/p2p/transport/quic/listener_test.go
@@ -66,7 +66,7 @@ func TestListenAddr(t *testing.T) {
 		defer ln.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
-		require.Equal(t, ln.Multiaddr().String(), fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic", port))
+		require.Equal(t, ln.Multiaddrs()[0].String(), fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic", port))
 	})
 
 	t.Run("for IPv6", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestListenAddr(t *testing.T) {
 		defer ln.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
-		require.Equal(t, ln.Multiaddr().String(), fmt.Sprintf("/ip6/::/udp/%d/quic", port))
+		require.Equal(t, ln.Multiaddrs()[0].String(), fmt.Sprintf("/ip6/::/udp/%d/quic", port))
 	})
 }
 

--- a/p2p/transport/quic/listener_test.go
+++ b/p2p/transport/quic/listener_test.go
@@ -71,6 +71,7 @@ func TestListenAddr(t *testing.T) {
 			multiaddrsStrings = append(multiaddrsStrings, a.String())
 		}
 		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic", port))
+		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic-v1", port))
 	})
 
 	t.Run("for IPv6", func(t *testing.T) {
@@ -85,6 +86,7 @@ func TestListenAddr(t *testing.T) {
 			multiaddrsStrings = append(multiaddrsStrings, a.String())
 		}
 		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip6/::/udp/%d/quic", port))
+		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip6/::/udp/%d/quic-v1", port))
 	})
 }
 

--- a/p2p/transport/quic/listener_test.go
+++ b/p2p/transport/quic/listener_test.go
@@ -66,7 +66,11 @@ func TestListenAddr(t *testing.T) {
 		defer ln.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
-		require.Equal(t, ln.Multiaddrs()[0].String(), fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic", port))
+		var multiaddrsStrings []string
+		for _, a := range ln.Multiaddrs() {
+			multiaddrsStrings = append(multiaddrsStrings, a.String())
+		}
+		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic", port))
 	})
 
 	t.Run("for IPv6", func(t *testing.T) {
@@ -76,7 +80,11 @@ func TestListenAddr(t *testing.T) {
 		defer ln.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
-		require.Equal(t, ln.Multiaddrs()[0].String(), fmt.Sprintf("/ip6/::/udp/%d/quic", port))
+		var multiaddrsStrings []string
+		for _, a := range ln.Multiaddrs() {
+			multiaddrsStrings = append(multiaddrsStrings, a.String())
+		}
+		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip6/::/udp/%d/quic", port))
 	})
 }
 

--- a/p2p/transport/quic/options.go
+++ b/p2p/transport/quic/options.go
@@ -4,6 +4,7 @@ type Option func(opts *config) error
 
 type config struct {
 	disableReuseport bool
+	disableDraft29   bool
 	metrics          bool
 }
 
@@ -20,6 +21,13 @@ func (cfg *config) apply(opts ...Option) error {
 func DisableReuseport() Option {
 	return func(cfg *config) error {
 		cfg.disableReuseport = true
+		return nil
+	}
+}
+
+func DisableDraft29() Option {
+	return func(cfg *config) error {
+		cfg.disableDraft29 = true
 		return nil
 	}
 }

--- a/p2p/transport/quic/options.go
+++ b/p2p/transport/quic/options.go
@@ -25,6 +25,9 @@ func DisableReuseport() Option {
 	}
 }
 
+// DisableDraft29 disables support for QUIC draft-29.
+// This option should be set, unless support for this legacy QUIC version is needed for backwards compatibility.
+// Support for QUIC draft-29 is already deprecated and will be removed in the future, see https://github.com/libp2p/go-libp2p/issues/1841.
 func DisableDraft29() Option {
 	return func(cfg *config) error {
 		cfg.disableDraft29 = true

--- a/p2p/transport/quic/quic_multiaddr.go
+++ b/p2p/transport/quic/quic_multiaddr.go
@@ -23,7 +23,7 @@ func toQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, err
 	case quic.Version1:
 		return udpMA.Encapsulate(quicV1MA), nil
 	default:
-		return nil, errors.New("unknown quic version")
+		return nil, errors.New("unknown QUIC version")
 	}
 }
 

--- a/p2p/transport/quic/quic_multiaddr.go
+++ b/p2p/transport/quic/quic_multiaddr.go
@@ -29,7 +29,7 @@ func toQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, err
 
 func fromQuicMultiaddr(addr ma.Multiaddr) (net.Addr, quic.VersionNumber, error) {
 	var version quic.VersionNumber
-	var partsBeforeQuic ma.Multiaddr
+	var partsBeforeQUIC ma.Multiaddr
 	ma.ForEach(addr, func(c ma.Component) bool {
 		switch c.Protocol().Code {
 		case ma.P_QUIC:
@@ -39,22 +39,22 @@ func fromQuicMultiaddr(addr ma.Multiaddr) (net.Addr, quic.VersionNumber, error) 
 			version = quic.Version1
 			return false
 		default:
-			if partsBeforeQuic == nil {
-				partsBeforeQuic = &c
+			if partsBeforeQUIC == nil {
+				partsBeforeQUIC = &c
 			} else {
-				partsBeforeQuic = partsBeforeQuic.Encapsulate(&c)
+				partsBeforeQUIC = partsBeforeQUIC.Encapsulate(&c)
 			}
 			return true
 		}
 	})
-	if partsBeforeQuic == nil {
-		return nil, version, errors.New("no addr before quic component")
+	if partsBeforeQUIC == nil {
+		return nil, version, errors.New("no addr before QUIC component")
 	}
 	if version == 0 {
 		// Not found
 		return nil, version, errors.New("unknown quic version")
 	}
-	netAddr, err := manet.ToNetAddr(partsBeforeQuic)
+	netAddr, err := manet.ToNetAddr(partsBeforeQUIC)
 	if err != nil {
 		return nil, version, err
 	}

--- a/p2p/transport/quic/quic_multiaddr.go
+++ b/p2p/transport/quic/quic_multiaddr.go
@@ -1,30 +1,62 @@
 package libp2pquic
 
 import (
+	"errors"
 	"net"
 
+	"github.com/lucas-clemente/quic-go"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-var quicMA ma.Multiaddr
+var quicV1MA ma.Multiaddr = ma.StringCast("/quic-v1")
+var quicDraft29MA ma.Multiaddr = ma.StringCast("/quic")
 
-func init() {
-	var err error
-	quicMA, err = ma.NewMultiaddr("/quic")
-	if err != nil {
-		panic(err)
-	}
-}
-
-func toQuicMultiaddr(na net.Addr) (ma.Multiaddr, error) {
+func toQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, error) {
 	udpMA, err := manet.FromNetAddr(na)
 	if err != nil {
 		return nil, err
 	}
-	return udpMA.Encapsulate(quicMA), nil
+	switch version {
+	case quic.VersionDraft29:
+		return udpMA.Encapsulate(quicDraft29MA), nil
+	case quic.Version1:
+		return udpMA.Encapsulate(quicV1MA), nil
+	default:
+		return nil, errors.New("unknown quic version")
+	}
 }
 
-func fromQuicMultiaddr(addr ma.Multiaddr) (net.Addr, error) {
-	return manet.ToNetAddr(addr.Decapsulate(quicMA))
+func fromQuicMultiaddr(addr ma.Multiaddr) (net.Addr, quic.VersionNumber, error) {
+	var version quic.VersionNumber
+	var partsBeforeQuic ma.Multiaddr
+	ma.ForEach(addr, func(c ma.Component) bool {
+		switch c.Protocol().Code {
+		case ma.P_QUIC:
+			version = quic.VersionDraft29
+			return false
+		case ma.P_QUIC_V1:
+			version = quic.Version1
+			return false
+		default:
+			if partsBeforeQuic == nil {
+				partsBeforeQuic = &c
+			} else {
+				partsBeforeQuic = partsBeforeQuic.Encapsulate(&c)
+			}
+			return true
+		}
+	})
+	if partsBeforeQuic == nil {
+		return nil, version, errors.New("no addr before quic component")
+	}
+	if version == 0 {
+		// Not found
+		return nil, version, errors.New("unknown quic version")
+	}
+	netAddr, err := manet.ToNetAddr(partsBeforeQuic)
+	if err != nil {
+		return nil, version, err
+	}
+	return netAddr, version, err
 }

--- a/p2p/transport/quic/quic_multiaddr_test.go
+++ b/p2p/transport/quic/quic_multiaddr_test.go
@@ -4,24 +4,45 @@ import (
 	"net"
 	"testing"
 
+	"github.com/lucas-clemente/quic-go"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConvertToQuicMultiaddr(t *testing.T) {
 	addr := &net.UDPAddr{IP: net.IPv4(192, 168, 0, 42), Port: 1337}
-	maddr, err := toQuicMultiaddr(addr)
+	maddr, err := toQuicMultiaddr(addr, quic.VersionDraft29)
 	require.NoError(t, err)
 	require.Equal(t, maddr.String(), "/ip4/192.168.0.42/udp/1337/quic")
 }
 
-func TestConvertFromQuicMultiaddr(t *testing.T) {
+func TestConvertToQuicV1Multiaddr(t *testing.T) {
+	addr := &net.UDPAddr{IP: net.IPv4(192, 168, 0, 42), Port: 1337}
+	maddr, err := toQuicMultiaddr(addr, quic.Version1)
+	require.NoError(t, err)
+	require.Equal(t, maddr.String(), "/ip4/192.168.0.42/udp/1337/quic-v1")
+}
+
+func TestConvertFromQuicDraft29Multiaddr(t *testing.T) {
 	maddr, err := ma.NewMultiaddr("/ip4/192.168.0.42/udp/1337/quic")
 	require.NoError(t, err)
-	addr, err := fromQuicMultiaddr(maddr)
+	addr, v, err := fromQuicMultiaddr(maddr)
 	require.NoError(t, err)
 	udpAddr, ok := addr.(*net.UDPAddr)
 	require.True(t, ok)
 	require.Equal(t, udpAddr.IP, net.IPv4(192, 168, 0, 42))
 	require.Equal(t, udpAddr.Port, 1337)
+	require.Equal(t, v, quic.VersionDraft29)
+}
+
+func TestConvertFromQuicV1Multiaddr(t *testing.T) {
+	maddr, err := ma.NewMultiaddr("/ip4/192.168.0.42/udp/1337/quic-v1")
+	require.NoError(t, err)
+	addr, v, err := fromQuicMultiaddr(maddr)
+	require.NoError(t, err)
+	udpAddr, ok := addr.(*net.UDPAddr)
+	require.True(t, ok)
+	require.Equal(t, udpAddr.IP, net.IPv4(192, 168, 0, 42))
+	require.Equal(t, udpAddr.Port, 1337)
+	require.Equal(t, v, quic.Version1)
 }

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -153,8 +153,6 @@ type transport struct {
 
 	connMx sync.Mutex
 	conns  map[quic.Connection]*conn
-
-	closeOnce sync.Once
 }
 
 var _ tpt.Transport = &transport{}
@@ -490,9 +488,5 @@ func (t *transport) String() string {
 }
 
 func (t *transport) Close() error {
-	// We may register multiple protocols, but they are all the same transport, so only support getting closed once.
-	t.closeOnce.Do(func() {
-		_ = t.connManager.Close()
-	})
-	return nil
+	return t.connManager.Close()
 }

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -413,7 +413,7 @@ loop:
 }
 
 // Don't use mafmt.QUIC as we don't want to dial DNS addresses. Just /ip{4,6}/udp/quic
-var dialMatcher = mafmt.And(mafmt.IP, mafmt.Base(ma.P_UDP), mafmt.Base(ma.P_QUIC))
+var dialMatcher = mafmt.And(mafmt.IP, mafmt.Base(ma.P_UDP), mafmt.Or(mafmt.Base(ma.P_QUIC), mafmt.Base(ma.P_QUIC_V1)))
 
 // CanDial determines if we can dial to an address
 func (t *transport) CanDial(addr ma.Multiaddr) bool {
@@ -474,7 +474,10 @@ func (t *transport) Proxy() bool {
 
 // Protocols returns the set of protocols handled by this transport.
 func (t *transport) Protocols() []int {
-	return []int{ma.P_QUIC}
+	if t.enableDraft29 {
+		return []int{ma.P_QUIC, ma.P_QUIC_V1}
+	}
+	return []int{ma.P_QUIC_V1}
 }
 
 func (t *transport) String() string {

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -276,13 +276,11 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 		return nil, err
 	}
 
-	clientConfig := t.clientConfig
+	clientConfig := t.clientConfig.Clone()
 	if v == quic.Version1 {
 		// The endpoint has explicit support for version 1, so we'll only use that version.
-		clientConfig = t.clientConfig.Clone()
 		clientConfig.Versions = []quic.VersionNumber{quic.Version1}
 	} else if v == quic.VersionDraft29 {
-		clientConfig = t.clientConfig.Clone()
 		clientConfig.Versions = []quic.VersionNumber{quic.VersionDraft29}
 	} else {
 		return nil, errors.New("unknown QUIC version")

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -281,6 +281,11 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 		// The endpoint has explicit support for version 1, so we'll only use that version.
 		clientConfig = t.clientConfig.Clone()
 		clientConfig.Versions = []quic.VersionNumber{quic.Version1}
+	} else if v == quic.VersionDraft29 {
+		clientConfig = t.clientConfig.Clone()
+		clientConfig.Versions = []quic.VersionNumber{quic.VersionDraft29}
+	} else {
+		return nil, errors.New("unknown QUIC version")
 	}
 
 	qconn, err := quicDialContext(ctx, pconn, addr, host, tlsConf, clientConfig)

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -153,6 +153,8 @@ type transport struct {
 
 	connMx sync.Mutex
 	conns  map[quic.Connection]*conn
+
+	closeOnce sync.Once
 }
 
 var _ tpt.Transport = &transport{}
@@ -485,5 +487,9 @@ func (t *transport) String() string {
 }
 
 func (t *transport) Close() error {
-	return t.connManager.Close()
+	// We may register multiple protocols, but they are all the same transport, so only support getting closed once.
+	t.closeOnce.Do(func() {
+		_ = t.connManager.Close()
+	})
+	return nil
 }

--- a/p2p/transport/quic/transport_test.go
+++ b/p2p/transport/quic/transport_test.go
@@ -35,11 +35,14 @@ func TestQUICProtocol(t *testing.T) {
 	defer tr.(io.Closer).Close()
 
 	protocols := tr.Protocols()
-	if len(protocols) != 1 {
-		t.Fatalf("expected to only support a single protocol, got %v", protocols)
+	if len(protocols) > 2 {
+		t.Fatalf("expected at most two protocols, got %v", protocols)
 	}
 	if protocols[0] != ma.P_QUIC {
-		t.Fatalf("expected the supported protocol to be QUIC, got %d", protocols[0])
+		t.Fatalf("expected the supported protocol to be draft 29 QUIC, got %d", protocols[0])
+	}
+	if protocols[1] != ma.P_QUIC_V1 {
+		t.Fatalf("expected the supported protocol to be QUIC v1, got %d", protocols[0])
 	}
 }
 

--- a/p2p/transport/tcp/tcp_test.go
+++ b/p2p/transport/tcp/tcp_test.go
@@ -86,10 +86,10 @@ func TestResourceManager(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		scope := mocknetwork.NewMockConnManagementScope(ctrl)
-		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddr()).Return(scope, nil)
+		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddrs()[0]).Return(scope, nil)
 		scope.EXPECT().SetPeer(peerA)
 		scope.EXPECT().PeerScope().Return(&network.NullScope{}).AnyTimes() // called by the upgrader
-		conn, err := tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		conn, err := tb.Dial(context.Background(), ln.Multiaddrs()[0], peerA)
 		require.NoError(t, err)
 		scope.EXPECT().Done()
 		defer conn.Close()
@@ -97,18 +97,18 @@ func TestResourceManager(t *testing.T) {
 
 	t.Run("connection denied", func(t *testing.T) {
 		rerr := errors.New("nope")
-		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddr()).Return(nil, rerr)
-		_, err = tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddrs()[0]).Return(nil, rerr)
+		_, err = tb.Dial(context.Background(), ln.Multiaddrs()[0], peerA)
 		require.ErrorIs(t, err, rerr)
 	})
 
 	t.Run("peer denied", func(t *testing.T) {
 		scope := mocknetwork.NewMockConnManagementScope(ctrl)
-		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddr()).Return(scope, nil)
+		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddrs()[0]).Return(scope, nil)
 		rerr := errors.New("nope")
 		scope.EXPECT().SetPeer(peerA).Return(rerr)
 		scope.EXPECT().Done()
-		_, err = tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		_, err = tb.Dial(context.Background(), ln.Multiaddrs()[0], peerA)
 		require.ErrorIs(t, err, rerr)
 	})
 }

--- a/p2p/transport/testsuite/stream_suite.go
+++ b/p2p/transport/testsuite/stream_suite.go
@@ -197,7 +197,7 @@ func SubtestStress(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr,
 			serve(t, l)
 		}()
 
-		c, err := tb.Dial(context.Background(), l.Multiaddr(), peerA)
+		c, err := tb.Dial(context.Background(), l.Multiaddrs()[0], peerA)
 		if err != nil {
 			t.Error(err)
 			return
@@ -259,7 +259,7 @@ func SubtestStreamOpenStress(t *testing.T, ta, tb transport.Transport, maddr ma.
 		connA, err = l.Accept()
 		accepted <- err
 	}()
-	connB, err = tb.Dial(context.Background(), l.Multiaddr(), peerA)
+	connB, err = tb.Dial(context.Background(), l.Multiaddrs()[0], peerA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +373,7 @@ func SubtestStreamReset(t *testing.T, ta, tb transport.Transport, maddr ma.Multi
 
 	}()
 
-	muxb, err := tb.Dial(context.Background(), l.Multiaddr(), peerA)
+	muxb, err := tb.Dial(context.Background(), l.Multiaddrs()[0], peerA)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/transport/testsuite/transport_suite.go
+++ b/p2p/transport/testsuite/transport_suite.go
@@ -111,11 +111,11 @@ func SubtestBasic(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, 
 		}
 	}()
 
-	if !tb.CanDial(list.Multiaddr()) {
+	if !tb.CanDial(list.Multiaddrs()[0]) {
 		t.Error("CanDial should have returned true")
 	}
 
-	connA, err = tb.Dial(ctx, list.Multiaddr(), peerA)
+	connA, err = tb.Dial(ctx, list.Multiaddrs()[0], peerA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,11 +232,11 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 		sWg.Wait()
 	}()
 
-	if !tb.CanDial(list.Multiaddr()) {
+	if !tb.CanDial(list.Multiaddrs()[0]) {
 		t.Error("CanDial should have returned true")
 	}
 
-	connB, err = tb.Dial(ctx, list.Multiaddr(), peerA)
+	connB, err = tb.Dial(ctx, list.Multiaddrs()[0], peerA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func SubtestCancel(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr,
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	c, err := tb.Dial(ctx, list.Multiaddr(), peerA)
+	c, err := tb.Dial(ctx, list.Multiaddrs()[0], peerA)
 	if err == nil {
 		c.Close()
 		t.Fatal("dial should have failed")

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -136,3 +136,7 @@ func (l *listener) Close() error {
 func (l *listener) Multiaddr() ma.Multiaddr {
 	return l.laddr
 }
+
+func (l *listener) Multiaddrs() []ma.Multiaddr {
+	return []ma.Multiaddr{l.laddr}
+}

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -190,7 +190,7 @@ func testWSSServer(t *testing.T, listenAddr ma.Multiaddr) (ma.Multiaddr, peer.ID
 		close(errChan)
 	}()
 
-	return l.Multiaddr(), id, errChan
+	return l.Multiaddrs()[0], id, errChan
 }
 
 func getTLSConf(t *testing.T, ip net.IP, start, end time.Time) *tls.Config {
@@ -330,9 +330,9 @@ func connectAndExchangeData(t *testing.T, laddr ma.Multiaddr, secure bool) {
 	l, err := tpt.Listen(laddr)
 	require.NoError(t, err)
 	if secure {
-		require.Contains(t, l.Multiaddr().String(), "tls")
+		require.Contains(t, l.Multiaddrs()[0].String(), "tls")
 	} else {
-		require.Equal(t, lastComponent(t, l.Multiaddr()), wsComponent)
+		require.Equal(t, lastComponent(t, l.Multiaddrs()[0]), wsComponent)
 	}
 	defer l.Close()
 
@@ -346,7 +346,7 @@ func connectAndExchangeData(t *testing.T, laddr ma.Multiaddr, secure bool) {
 		_, u := newUpgrader(t)
 		tpt, err := New(u, &network.NullResourceManager{}, opts...)
 		require.NoError(t, err)
-		c, err := tpt.Dial(context.Background(), l.Multiaddr(), server)
+		c, err := tpt.Dial(context.Background(), l.Multiaddrs()[0], server)
 		require.NoError(t, err)
 		str, err := c.OpenStream(context.Background())
 		require.NoError(t, err)
@@ -401,14 +401,14 @@ func TestWebsocketListenSecureAndInsecure(t *testing.T) {
 		require.NoError(t, err)
 
 		// dialing the insecure address should succeed
-		conn, err := client.Dial(context.Background(), lnInsecure.Multiaddr(), serverID)
+		conn, err := client.Dial(context.Background(), lnInsecure.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 		defer conn.Close()
 		require.Equal(t, lastComponent(t, conn.RemoteMultiaddr()).String(), wsComponent.String())
 		require.Equal(t, lastComponent(t, conn.LocalMultiaddr()).String(), wsComponent.String())
 
 		// dialing the secure address should fail
-		_, err = client.Dial(context.Background(), lnSecure.Multiaddr(), serverID)
+		_, err = client.Dial(context.Background(), lnSecure.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 	})
 
@@ -418,14 +418,14 @@ func TestWebsocketListenSecureAndInsecure(t *testing.T) {
 		require.NoError(t, err)
 
 		// dialing the insecure address should succeed
-		conn, err := client.Dial(context.Background(), lnSecure.Multiaddr(), serverID)
+		conn, err := client.Dial(context.Background(), lnSecure.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 		defer conn.Close()
 		require.Equal(t, lastComponent(t, conn.RemoteMultiaddr()), wssComponent)
 		require.Equal(t, lastComponent(t, conn.LocalMultiaddr()), wssComponent)
 
 		// dialing the insecure address should fail
-		_, err = client.Dial(context.Background(), lnInsecure.Multiaddr(), serverID)
+		_, err = client.Dial(context.Background(), lnInsecure.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 	})
 }

--- a/p2p/transport/webtransport/listener.go
+++ b/p2p/transport/webtransport/listener.go
@@ -218,11 +218,11 @@ func (l *listener) Addr() net.Addr {
 	return l.addr
 }
 
-func (l *listener) Multiaddr() ma.Multiaddr {
+func (l *listener) Multiaddrs() []ma.Multiaddr {
 	if l.transport.certManager == nil {
-		return l.multiaddr
+		return []ma.Multiaddr{l.multiaddr}
 	}
-	return l.multiaddr.Encapsulate(l.transport.certManager.AddrComponent())
+	return []ma.Multiaddr{l.multiaddr.Encapsulate(l.transport.certManager.AddrComponent())}
 }
 
 func (l *listener) Close() error {

--- a/p2p/transport/webtransport/multiaddr.go
+++ b/p2p/transport/webtransport/multiaddr.go
@@ -13,9 +13,9 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-var webtransportMA = ma.StringCast("/quic/webtransport")
+var webtransportMA = ma.StringCast("/quic-v1/webtransport")
 
-var webtransportMatcher = mafmt.And(mafmt.IP, mafmt.Base(ma.P_UDP), mafmt.Base(ma.P_QUIC), mafmt.Base(ma.P_WEBTRANSPORT))
+var webtransportMatcher = mafmt.And(mafmt.IP, mafmt.Base(ma.P_UDP), mafmt.Base(ma.P_QUIC_V1), mafmt.Base(ma.P_WEBTRANSPORT))
 
 func toWebtransportMultiaddr(na net.Addr) (ma.Multiaddr, error) {
 	addr, err := manet.FromNetAddr(na)

--- a/p2p/transport/webtransport/multiaddr_test.go
+++ b/p2p/transport/webtransport/multiaddr_test.go
@@ -16,7 +16,7 @@ func TestWebtransportMultiaddr(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		addr, err := toWebtransportMultiaddr(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1337})
 		require.NoError(t, err)
-		require.Equal(t, "/ip4/127.0.0.1/udp/1337/quic/webtransport", addr.String())
+		require.Equal(t, "/ip4/127.0.0.1/udp/1337/quic-v1/webtransport", addr.String())
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestWebtransportMultiaddrFromString(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		addr, err := stringToWebtransportMultiaddr("1.2.3.4:60042")
 		require.NoError(t, err)
-		require.Equal(t, "/ip4/1.2.3.4/udp/60042/quic/webtransport", addr.String())
+		require.Equal(t, "/ip4/1.2.3.4/udp/60042/quic-v1/webtransport", addr.String())
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -63,9 +63,9 @@ func TestExtractCertHashes(t *testing.T) {
 		addr   string
 		hashes []string
 	}{
-		{addr: "/ip4/127.0.0.1/udp/1234/quic/webtransport"},
-		{addr: fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic/webtransport/certhash/%s", fooHash), hashes: []string{"foo"}},
-		{addr: fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic/webtransport/certhash/%s/certhash/%s", fooHash, barHash), hashes: []string{"foo", "bar"}},
+		{addr: "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport"},
+		{addr: fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/%s", fooHash), hashes: []string{"foo"}},
+		{addr: fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/%s/certhash/%s", fooHash, barHash), hashes: []string{"foo", "bar"}},
 	} {
 		ch, err := extractCertHashes(ma.StringCast(tc.addr))
 		require.NoError(t, err)
@@ -78,9 +78,9 @@ func TestExtractCertHashes(t *testing.T) {
 
 func TestWebtransportResolve(t *testing.T) {
 	testCases := []string{
-		"/dns4/example.com/udp/1337/quic/webtransport",
-		"/dnsaddr/example.com/udp/1337/quic/webtransport",
-		"/ip4/127.0.0.1/udp/1337/quic/sni/example.com/webtransport",
+		"/dns4/example.com/udp/1337/quic-v1/webtransport",
+		"/dnsaddr/example.com/udp/1337/quic-v1/webtransport",
+		"/ip4/127.0.0.1/udp/1337/quic-v1/sni/example.com/webtransport",
 	}
 
 	tpt := &transport{}
@@ -97,7 +97,7 @@ func TestWebtransportResolve(t *testing.T) {
 	}
 
 	t.Run("No sni", func(t *testing.T) {
-		outMa, err := tpt.Resolve(ctx, ma.StringCast("/ip4/127.0.0.1/udp/1337/quic/webtransport"))
+		outMa, err := tpt.Resolve(ctx, ma.StringCast("/ip4/127.0.0.1/udp/1337/quic-v1/webtransport"))
 		require.NoError(t, err)
 		_, err = outMa[0].ValueForProtocol(ma.P_SNI)
 		require.Error(t, err)

--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -104,7 +104,9 @@ func New(key ic.PrivKey, gater connmgr.ConnectionGater, rcmgr network.ResourceMa
 		clock:   clock.New(),
 		conns:   map[uint64]*conn{},
 	}
-	t.quicConfig = &quic.Config{AllowConnectionWindowIncrease: t.allowWindowIncrease}
+	t.quicConfig = &quic.Config{
+		AllowConnectionWindowIncrease: t.allowWindowIncrease,
+		Versions:                      []quic.VersionNumber{quic.Version1}}
 	for _, opt := range opts {
 		if err := opt(t); err != nil {
 			return nil, err
@@ -373,7 +375,7 @@ func (t *transport) Resolve(ctx context.Context, maddr ma.Multiaddr) ([]ma.Multi
 	}
 
 	beforeQuicMA, afterIncludingQuicMA := ma.SplitFunc(maddr, func(c ma.Component) bool {
-		return c.Protocol().Code == ma.P_QUIC
+		return c.Protocol().Code == ma.P_QUIC_V1
 	})
 	quicComponent, afterQuicMA := ma.SplitFirst(afterIncludingQuicMA)
 	sniComponent, err := ma.NewComponent(ma.ProtocolWithCode(ma.P_SNI).Name, sni)

--- a/p2p/transport/webtransport/transport_test.go
+++ b/p2p/transport/webtransport/transport_test.go
@@ -103,7 +103,7 @@ func TestTransport(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -127,7 +127,7 @@ func TestTransport(t *testing.T) {
 		require.NoError(t, err)
 		_, port, err := net.SplitHostPort(addr)
 		require.NoError(t, err)
-		require.Equal(t, ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/%s/quic/webtransport", port)), conn.RemoteMultiaddr())
+		require.Equal(t, ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/%s/quic-v1/webtransport", port)), conn.RemoteMultiaddr())
 		addrChan <- conn.RemoteMultiaddr()
 	}()
 
@@ -149,7 +149,7 @@ func TestHashVerification(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	done := make(chan struct{})
 	go func() {
@@ -184,10 +184,10 @@ func TestHashVerification(t *testing.T) {
 
 func TestCanDial(t *testing.T) {
 	valid := []ma.Multiaddr{
-		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic/webtransport/certhash/" + randomMultihash(t)),
-		ma.StringCast("/ip6/b16b:8255:efc6:9cd5:1a54:ee86:2d7a:c2e6/udp/1234/quic/webtransport/certhash/" + randomMultihash(t)),
-		ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic/webtransport/certhash/%s/certhash/%s/certhash/%s", randomMultihash(t), randomMultihash(t), randomMultihash(t))),
-		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic/webtransport"), // no certificate hash
+		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/" + randomMultihash(t)),
+		ma.StringCast("/ip6/b16b:8255:efc6:9cd5:1a54:ee86:2d7a:c2e6/udp/1234/quic-v1/webtransport/certhash/" + randomMultihash(t)),
+		ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/%s/certhash/%s/certhash/%s", randomMultihash(t), randomMultihash(t), randomMultihash(t))),
+		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport"), // no certificate hash
 	}
 
 	invalid := []ma.Multiaddr{
@@ -211,15 +211,15 @@ func TestCanDial(t *testing.T) {
 
 func TestListenAddrValidity(t *testing.T) {
 	valid := []ma.Multiaddr{
-		ma.StringCast("/ip6/::/udp/0/quic/webtransport/"),
-		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic/webtransport/"),
+		ma.StringCast("/ip6/::/udp/0/quic-v1/webtransport/"),
+		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/"),
 	}
 
 	invalid := []ma.Multiaddr{
 		ma.StringCast("/ip4/127.0.0.1/udp/1234"),              // missing webtransport
 		ma.StringCast("/ip4/127.0.0.1/udp/1234/webtransport"), // missing quic
 		ma.StringCast("/ip4/127.0.0.1/tcp/1234/webtransport"), // WebTransport over TCP? Is this a joke?
-		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic/webtransport/certhash/" + randomMultihash(t)),
+		ma.StringCast("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/" + randomMultihash(t)),
 	}
 
 	_, key := newIdentity(t)
@@ -244,9 +244,9 @@ func TestListenerAddrs(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
 
-	ln1, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln1, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
-	ln2, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln2, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	hashes1 := extractCertHashes(ln1.Multiaddrs()[0])
 	require.Len(t, hashes1, 2)
@@ -259,7 +259,7 @@ func TestResourceManagerDialing(t *testing.T) {
 	defer ctrl.Finish()
 	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
 
-	addr := ma.StringCast("/ip4/9.8.7.6/udp/1234/quic/webtransport")
+	addr := ma.StringCast("/ip4/9.8.7.6/udp/1234/quic-v1/webtransport")
 	p := peer.ID("foobar")
 
 	_, key := newIdentity(t)
@@ -289,7 +289,7 @@ func TestResourceManagerListening(t *testing.T) {
 		rcmgr := mocknetwork.NewMockResourceManager(ctrl)
 		tr, err := libp2pwebtransport.New(key, nil, rcmgr)
 		require.NoError(t, err)
-		ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+		ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 		require.NoError(t, err)
 		defer ln.Close()
 
@@ -315,7 +315,7 @@ func TestResourceManagerListening(t *testing.T) {
 		rcmgr := mocknetwork.NewMockResourceManager(ctrl)
 		tr, err := libp2pwebtransport.New(key, nil, rcmgr)
 		require.NoError(t, err)
-		ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+		ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 		require.NoError(t, err)
 		defer ln.Close()
 
@@ -360,7 +360,7 @@ func TestConnectionGaterDialing(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -384,7 +384,7 @@ func TestConnectionGaterInterceptAccept(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, connGater, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -410,7 +410,7 @@ func TestConnectionGaterInterceptSecured(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, connGater, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -476,7 +476,7 @@ func TestStaticTLSConf(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, nil, &network.NullResourceManager{}, libp2pwebtransport.WithTLSConfig(tlsConf))
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 	require.Empty(t, extractCertHashes(ln.Multiaddrs()[0]), "listener address shouldn't contain any certhash")
@@ -528,7 +528,7 @@ func TestAcceptQueueFilledUp(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -569,7 +569,7 @@ func TestSNIIsSent(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
 
-	ln1, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln1, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 
 	_, key2 := newIdentity(t)
@@ -578,7 +578,7 @@ func TestSNIIsSent(t *testing.T) {
 	defer tr.(io.Closer).Close()
 
 	beforeQuicMa, withQuicMa := ma.SplitFunc(ln1.Multiaddrs()[0], func(c ma.Component) bool {
-		return c.Protocol().Code == ma.P_QUIC
+		return c.Protocol().Code == ma.P_QUIC_V1
 	})
 
 	quicComponent, restMa := ma.SplitLast(withQuicMa)
@@ -634,7 +634,7 @@ func TestFlowControlWindowIncrease(t *testing.T) {
 	tr, err := libp2pwebtransport.New(serverKey, nil, serverRcmgr)
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
 

--- a/p2p/transport/webtransport/transport_test.go
+++ b/p2p/transport/webtransport/transport_test.go
@@ -114,7 +114,7 @@ func TestTransport(t *testing.T) {
 		require.NoError(t, err)
 		defer tr2.(io.Closer).Close()
 
-		conn, err := tr2.Dial(context.Background(), ln.Multiaddr(), serverID)
+		conn, err := tr2.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 		str, err := conn.OpenStream(context.Background())
 		require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestTransport(t *testing.T) {
 		require.NoError(t, str.Close())
 
 		// check RemoteMultiaddr
-		_, addr, err := manet.DialArgs(ln.Multiaddr())
+		_, addr, err := manet.DialArgs(ln.Multiaddrs()[0])
 		require.NoError(t, err)
 		_, port, err := net.SplitHostPort(addr)
 		require.NoError(t, err)
@@ -167,14 +167,14 @@ func TestHashVerification(t *testing.T) {
 
 	t.Run("fails using only a wrong hash", func(t *testing.T) {
 		// replace the certificate hash in the multiaddr with a fake hash
-		addr := stripCertHashes(ln.Multiaddr()).Encapsulate(foobarHash)
+		addr := stripCertHashes(ln.Multiaddrs()[0]).Encapsulate(foobarHash)
 		_, err := tr2.Dial(context.Background(), addr, serverID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "CRYPTO_ERROR (0x12a): cert hash not found")
 	})
 
 	t.Run("fails when adding a wrong hash", func(t *testing.T) {
-		_, err := tr2.Dial(context.Background(), ln.Multiaddr().Encapsulate(foobarHash), serverID)
+		_, err := tr2.Dial(context.Background(), ln.Multiaddrs()[0].Encapsulate(foobarHash), serverID)
 		require.Error(t, err)
 	})
 
@@ -248,9 +248,9 @@ func TestListenerAddrs(t *testing.T) {
 	require.NoError(t, err)
 	ln2, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
 	require.NoError(t, err)
-	hashes1 := extractCertHashes(ln1.Multiaddr())
+	hashes1 := extractCertHashes(ln1.Multiaddrs()[0])
 	require.Len(t, hashes1, 2)
-	hashes2 := extractCertHashes(ln2.Multiaddr())
+	hashes2 := extractCertHashes(ln2.Multiaddrs()[0])
 	require.Equal(t, hashes1, hashes2)
 }
 
@@ -304,7 +304,7 @@ func TestResourceManagerListening(t *testing.T) {
 			return nil, errors.New("denied")
 		})
 
-		_, err = cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+		_, err = cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 		require.EqualError(t, err, "received status 503")
 	})
 
@@ -326,7 +326,7 @@ func TestResourceManagerListening(t *testing.T) {
 		scope.EXPECT().Done().Do(func() { close(serverDone) })
 
 		// The handshake will complete, but the server will immediately close the connection.
-		conn, err := cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+		conn, err := cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 		defer conn.Close()
 		clientDone := make(chan struct{})
@@ -365,13 +365,13 @@ func TestConnectionGaterDialing(t *testing.T) {
 	defer ln.Close()
 
 	connGater.EXPECT().InterceptSecured(network.DirOutbound, serverID, gomock.Any()).Do(func(_ network.Direction, _ peer.ID, addrs network.ConnMultiaddrs) {
-		require.Equal(t, stripCertHashes(ln.Multiaddr()), addrs.RemoteMultiaddr())
+		require.Equal(t, stripCertHashes(ln.Multiaddrs()[0]), addrs.RemoteMultiaddr())
 	})
 	_, key := newIdentity(t)
 	cl, err := libp2pwebtransport.New(key, connGater, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer cl.(io.Closer).Close()
-	_, err = cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+	_, err = cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 	require.EqualError(t, err, "secured connection gated")
 }
 
@@ -389,15 +389,15 @@ func TestConnectionGaterInterceptAccept(t *testing.T) {
 	defer ln.Close()
 
 	connGater.EXPECT().InterceptAccept(gomock.Any()).Do(func(addrs network.ConnMultiaddrs) {
-		require.Equal(t, stripCertHashes(ln.Multiaddr()), addrs.LocalMultiaddr())
-		require.NotEqual(t, stripCertHashes(ln.Multiaddr()), addrs.RemoteMultiaddr())
+		require.Equal(t, stripCertHashes(ln.Multiaddrs()[0]), addrs.LocalMultiaddr())
+		require.NotEqual(t, stripCertHashes(ln.Multiaddrs()[0]), addrs.RemoteMultiaddr())
 	})
 
 	_, key := newIdentity(t)
 	cl, err := libp2pwebtransport.New(key, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer cl.(io.Closer).Close()
-	_, err = cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+	_, err = cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 	require.EqualError(t, err, "received status 403")
 }
 
@@ -421,11 +421,11 @@ func TestConnectionGaterInterceptSecured(t *testing.T) {
 
 	connGater.EXPECT().InterceptAccept(gomock.Any()).Return(true)
 	connGater.EXPECT().InterceptSecured(network.DirInbound, clientID, gomock.Any()).Do(func(_ network.Direction, _ peer.ID, addrs network.ConnMultiaddrs) {
-		require.Equal(t, stripCertHashes(ln.Multiaddr()), addrs.LocalMultiaddr())
-		require.NotEqual(t, stripCertHashes(ln.Multiaddr()), addrs.RemoteMultiaddr())
+		require.Equal(t, stripCertHashes(ln.Multiaddrs()[0]), addrs.LocalMultiaddr())
+		require.NotEqual(t, stripCertHashes(ln.Multiaddrs()[0]), addrs.RemoteMultiaddr())
 	})
 	// The handshake will complete, but the server will immediately close the connection.
-	conn, err := cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+	conn, err := cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 	require.NoError(t, err)
 	defer conn.Close()
 	done := make(chan struct{})
@@ -479,7 +479,7 @@ func TestStaticTLSConf(t *testing.T) {
 	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic/webtransport"))
 	require.NoError(t, err)
 	defer ln.Close()
-	require.Empty(t, extractCertHashes(ln.Multiaddr()), "listener address shouldn't contain any certhash")
+	require.Empty(t, extractCertHashes(ln.Multiaddrs()[0]), "listener address shouldn't contain any certhash")
 
 	t.Run("fails when the certificate is invalid", func(t *testing.T) {
 		_, key := newIdentity(t)
@@ -487,7 +487,7 @@ func TestStaticTLSConf(t *testing.T) {
 		require.NoError(t, err)
 		defer cl.(io.Closer).Close()
 
-		_, err = cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+		_, err = cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 		require.Error(t, err)
 		if !strings.Contains(err.Error(), "certificate is not trusted") &&
 			!strings.Contains(err.Error(), "certificate signed by unknown authority") {
@@ -501,7 +501,7 @@ func TestStaticTLSConf(t *testing.T) {
 		require.NoError(t, err)
 		defer cl.(io.Closer).Close()
 
-		addr := ln.Multiaddr().Encapsulate(getCerthashComponent(t, []byte("foo")))
+		addr := ln.Multiaddrs()[0].Encapsulate(getCerthashComponent(t, []byte("foo")))
 		_, err = cl.Dial(context.Background(), addr, serverID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cert hash not found")
@@ -516,8 +516,8 @@ func TestStaticTLSConf(t *testing.T) {
 		require.NoError(t, err)
 		defer cl.(io.Closer).Close()
 
-		require.True(t, cl.CanDial(ln.Multiaddr()))
-		conn, err := cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+		require.True(t, cl.CanDial(ln.Multiaddrs()[0]))
+		conn, err := cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 		require.NoError(t, err)
 		defer conn.Close()
 	})
@@ -538,7 +538,7 @@ func TestAcceptQueueFilledUp(t *testing.T) {
 		cl, err := libp2pwebtransport.New(key, nil, &network.NullResourceManager{})
 		require.NoError(t, err)
 		defer cl.(io.Closer).Close()
-		return cl.Dial(context.Background(), ln.Multiaddr(), serverID)
+		return cl.Dial(context.Background(), ln.Multiaddrs()[0], serverID)
 	}
 
 	for i := 0; i < 16; i++ {
@@ -577,7 +577,7 @@ func TestSNIIsSent(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
 
-	beforeQuicMa, withQuicMa := ma.SplitFunc(ln1.Multiaddr(), func(c ma.Component) bool {
+	beforeQuicMa, withQuicMa := ma.SplitFunc(ln1.Multiaddrs()[0], func(c ma.Component) bool {
 		return c.Protocol().Code == ma.P_QUIC
 	})
 
@@ -663,7 +663,7 @@ func TestFlowControlWindowIncrease(t *testing.T) {
 	defer tr2.(io.Closer).Close()
 
 	var addr ma.Multiaddr
-	for _, comp := range ma.Split(ln.Multiaddr()) {
+	for _, comp := range ma.Split(ln.Multiaddrs()[0]) {
 		if _, err := comp.ValueForProtocol(ma.P_UDP); err == nil {
 			addr = addr.Encapsulate(ma.StringCast(fmt.Sprintf("/udp/%d", proxy.LocalPort())))
 			continue


### PR DESCRIPTION
Fixes #1841 see that issue for more context.

This lets transports advertise multiple multiaddrs. Allows the quic transport to advertise both QUIC versions draft29 and 1. Changes webtransport to only support QUIC version 1.

Before merge: 
- [ ] Fix go.mod to use updated quic-go after https://github.com/lucas-clemente/quic-go/pull/3620 is merged and released.
 