### PR TITLE
webtransport: tame log output of tests

### DIFF
--- a/p2p/transport/webtransport/cert_manager_test.go
+++ b/p2p/transport/webtransport/cert_manager_test.go
@@ -3,7 +3,6 @@ package libp2pwebtransport
 import (
 	"crypto/sha256"
 	"crypto/tls"
-	"fmt"
 	"testing"
 	"testing/quick"
 	"time"
@@ -115,30 +114,28 @@ func TestDeterministicCertsAcrossReboots(t *testing.T) {
 	// Run this test 100 times to make sure it's deterministic
 	runs := 100
 	for i := 0; i < runs; i++ {
-		t.Run(fmt.Sprintf("Run=%d", i), func(t *testing.T) {
-			cl := clock.NewMock()
-			priv, _, err := test.SeededTestKeyPair(crypto.Ed25519, 256, 0)
-			require.NoError(t, err)
-			m, err := newCertManager(priv, cl)
-			require.NoError(t, err)
-			defer m.Close()
+		cl := clock.NewMock()
+		priv, _, err := test.SeededTestKeyPair(crypto.Ed25519, 256, 0)
+		require.NoError(t, err)
+		m, err := newCertManager(priv, cl)
+		require.NoError(t, err)
+		defer m.Close()
 
-			conf := m.GetConfig()
-			require.Len(t, conf.Certificates, 1)
-			oldCerts := m.serializedCertHashes
+		conf := m.GetConfig()
+		require.Len(t, conf.Certificates, 1)
+		oldCerts := m.serializedCertHashes
 
-			m.Close()
+		m.Close()
 
-			cl.Add(time.Hour)
-			// reboot
-			m, err = newCertManager(priv, cl)
-			require.NoError(t, err)
-			defer m.Close()
+		cl.Add(time.Hour)
+		// reboot
+		m, err = newCertManager(priv, cl)
+		require.NoError(t, err)
+		defer m.Close()
 
-			newCerts := m.serializedCertHashes
+		newCerts := m.serializedCertHashes
 
-			require.Equal(t, oldCerts, newCerts)
-		})
+		require.Equal(t, oldCerts, newCerts)
 	}
 }
 

--- a/p2p/transport/webtransport/crypto_test.go
+++ b/p2p/transport/webtransport/crypto_test.go
@@ -138,25 +138,23 @@ func TestDeterministicCertHashes(t *testing.T) {
 	// Run this test 1000 times since we want to make sure the signatures are deterministic
 	runs := 1000
 	for i := 0; i < runs; i++ {
-		t.Run(fmt.Sprintf("Run=%d", i), func(t *testing.T) {
-			zeroSeed := [32]byte{}
-			priv, _, err := ic.GenerateEd25519Key(bytes.NewReader(zeroSeed[:]))
-			require.NoError(t, err)
-			cert, certPriv, err := generateCert(priv, time.Time{}, time.Time{}.Add(time.Hour*24*14))
-			require.NoError(t, err)
+		zeroSeed := [32]byte{}
+		priv, _, err := ic.GenerateEd25519Key(bytes.NewReader(zeroSeed[:]))
+		require.NoError(t, err)
+		cert, certPriv, err := generateCert(priv, time.Time{}, time.Time{}.Add(time.Hour*24*14))
+		require.NoError(t, err)
 
-			keyBytes, err := x509.MarshalECPrivateKey(certPriv)
-			require.NoError(t, err)
+		keyBytes, err := x509.MarshalECPrivateKey(certPriv)
+		require.NoError(t, err)
 
-			cert2, certPriv2, err := generateCert(priv, time.Time{}, time.Time{}.Add(time.Hour*24*14))
-			require.NoError(t, err)
+		cert2, certPriv2, err := generateCert(priv, time.Time{}, time.Time{}.Add(time.Hour*24*14))
+		require.NoError(t, err)
 
-			require.Equal(t, cert2.Signature, cert.Signature)
-			require.Equal(t, cert2.Raw, cert.Raw)
-			keyBytes2, err := x509.MarshalECPrivateKey(certPriv2)
-			require.NoError(t, err)
-			require.Equal(t, keyBytes, keyBytes2)
-		})
+		require.Equal(t, cert2.Signature, cert.Signature)
+		require.Equal(t, cert2.Raw, cert.Raw)
+		keyBytes2, err := x509.MarshalECPrivateKey(certPriv2)
+		require.NoError(t, err)
+		require.Equal(t, keyBytes, keyBytes2)
 	}
 }
 
@@ -168,33 +166,31 @@ func TestDeterministicSig(t *testing.T) {
 	// Run this test 1000 times since we want to make sure the signatures are deterministic
 	runs := 1000
 	for i := 0; i < runs; i++ {
-		t.Run(fmt.Sprintf("Run=%d", i), func(t *testing.T) {
-			zeroSeed := [32]byte{}
-			deterministicHKDFReader := newDeterministicReader(zeroSeed[:], nil, deterministicCertInfo)
-			b := [1024]byte{}
-			io.ReadFull(deterministicHKDFReader, b[:])
-			caPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), deterministicHKDFReader)
-			require.NoError(t, err)
+		zeroSeed := [32]byte{}
+		deterministicHKDFReader := newDeterministicReader(zeroSeed[:], nil, deterministicCertInfo)
+		b := [1024]byte{}
+		io.ReadFull(deterministicHKDFReader, b[:])
+		caPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), deterministicHKDFReader)
+		require.NoError(t, err)
 
-			sig, err := caPrivateKey.Sign(deterministicHKDFReader, b[:], crypto.SHA256)
-			require.NoError(t, err)
+		sig, err := caPrivateKey.Sign(deterministicHKDFReader, b[:], crypto.SHA256)
+		require.NoError(t, err)
 
-			deterministicHKDFReader = newDeterministicReader(zeroSeed[:], nil, deterministicCertInfo)
-			b2 := [1024]byte{}
-			io.ReadFull(deterministicHKDFReader, b2[:])
-			caPrivateKey2, err := ecdsa.GenerateKey(elliptic.P256(), deterministicHKDFReader)
-			require.NoError(t, err)
+		deterministicHKDFReader = newDeterministicReader(zeroSeed[:], nil, deterministicCertInfo)
+		b2 := [1024]byte{}
+		io.ReadFull(deterministicHKDFReader, b2[:])
+		caPrivateKey2, err := ecdsa.GenerateKey(elliptic.P256(), deterministicHKDFReader)
+		require.NoError(t, err)
 
-			sig2, err := caPrivateKey2.Sign(deterministicHKDFReader, b2[:], crypto.SHA256)
-			require.NoError(t, err)
+		sig2, err := caPrivateKey2.Sign(deterministicHKDFReader, b2[:], crypto.SHA256)
+		require.NoError(t, err)
 
-			keyBytes, err := x509.MarshalECPrivateKey(caPrivateKey)
-			require.NoError(t, err)
-			keyBytes2, err := x509.MarshalECPrivateKey(caPrivateKey2)
-			require.NoError(t, err)
+		keyBytes, err := x509.MarshalECPrivateKey(caPrivateKey)
+		require.NoError(t, err)
+		keyBytes2, err := x509.MarshalECPrivateKey(caPrivateKey2)
+		require.NoError(t, err)
 
-			require.Equal(t, sig, sig2)
-			require.Equal(t, keyBytes, keyBytes2)
-		})
+		require.Equal(t, sig, sig2)
+		require.Equal(t, keyBytes, keyBytes2)
 	}
 }


### PR DESCRIPTION
Every `t.Run` emits one log line, making the test output very lengthy.