### PR TITLE
tls / noise: prefer the client's muxer preferences

### DIFF
--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -88,10 +88,10 @@ func (t *Transport) ID() protocol.ID {
 }
 
 func matchMuxers(initiatorMuxers, responderMuxers []string) string {
-	for _, muxer := range responderMuxers {
-		for _, initMuxer := range initiatorMuxers {
-			if initMuxer == muxer {
-				return muxer
+	for _, initMuxer := range initiatorMuxers {
+		for _, respMuxer := range responderMuxers {
+			if initMuxer == respMuxer {
+				return initMuxer
 			}
 		}
 	}

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -185,14 +185,41 @@ type testcase struct {
 
 func TestHandshakeWithNextProtoSucceeds(t *testing.T) {
 	tests := []testcase{
-		{clientProtos: nil, serverProtos: nil, expectedResult: ""},
-		{clientProtos: []protocol.ID{"muxer1", "muxer2"}, serverProtos: []protocol.ID{"muxer2", "muxer1"}, expectedResult: "muxer2"},
-		{clientProtos: []protocol.ID{"muxer1", "muxer2", "libp2p"}, serverProtos: []protocol.ID{"muxer2", "muxer1", "libp2p"}, expectedResult: "muxer2"},
-		{clientProtos: []protocol.ID{"muxer1", "libp2p"}, serverProtos: []protocol.ID{"libp2p"}, expectedResult: ""},
-		{clientProtos: []protocol.ID{"libp2p"}, serverProtos: []protocol.ID{"libp2p"}, expectedResult: ""},
-		{clientProtos: []protocol.ID{"muxer1"}, serverProtos: []protocol.ID{}, expectedResult: ""},
-		{clientProtos: []protocol.ID{}, serverProtos: []protocol.ID{"muxer1"}, expectedResult: ""},
-		{clientProtos: []protocol.ID{"muxer2"}, serverProtos: []protocol.ID{"muxer1"}, expectedResult: ""},
+		{
+			clientProtos:   []protocol.ID{"muxer1", "muxer2"},
+			serverProtos:   []protocol.ID{"muxer2", "muxer1"},
+			expectedResult: "muxer1",
+		},
+		{
+			clientProtos:   []protocol.ID{"muxer1", "muxer2", "libp2p"},
+			serverProtos:   []protocol.ID{"muxer2", "muxer1", "libp2p"},
+			expectedResult: "muxer1",
+		},
+		{
+			clientProtos:   []protocol.ID{"muxer1", "libp2p"},
+			serverProtos:   []protocol.ID{"libp2p"},
+			expectedResult: "",
+		},
+		{
+			clientProtos:   []protocol.ID{"libp2p"},
+			serverProtos:   []protocol.ID{"libp2p"},
+			expectedResult: "",
+		},
+		{
+			clientProtos:   []protocol.ID{"muxer1"},
+			serverProtos:   []protocol.ID{},
+			expectedResult: "",
+		},
+		{
+			clientProtos:   []protocol.ID{},
+			serverProtos:   []protocol.ID{"muxer1"},
+			expectedResult: "",
+		},
+		{
+			clientProtos:   []protocol.ID{"muxer2"},
+			serverProtos:   []protocol.ID{"muxer1"},
+			expectedResult: "",
+		},
 	}
 
 	clientID, clientKey := createPeer(t)


### PR DESCRIPTION
As the integration test (#1887) has revealed, TLS and Noise both selected the muxer according to the server's preferences, whereas the multistream negotiation selects according to the client's preferences. This PR changes TLS' and Noise's behavior to match the multistream behavior.

Since TLS' ALPN selection algorithm also selects according to the server's preferences, we have to play a little trick to overwrite that behavior.