### PR TITLE
ci: update actions/checkout and actions/setup-go to v3 in go-crypto

### DIFF
--- a/.github/workflows/go-crypto.yml
+++ b/.github/workflows/go-crypto.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     name: ${{ matrix.os }} ${{ matrix.backend }} (go ${{ matrix.go }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Go information


### PR DESCRIPTION
That should resolve the deprecation warnings: 
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/1478487/202347398-a02c3ac4-f7eb-4dab-996b-aace8a871738.png">
