### PR TITLE
tls: fix flaky TestHandshakeConnectionCancellations test

### DIFF
--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -324,7 +324,7 @@ func TestHandshakeConnectionCancellations(t *testing.T) {
 		}()
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err = clientTransport.SecureOutbound(ctx, clientInsecureConn, serverID)
+		_, err = clientTransport.SecureOutbound(ctx, &delayedConn{Conn: clientInsecureConn, delay: 5 * time.Millisecond}, serverID)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Error(t, <-errChan)
 	})


### PR DESCRIPTION
Explanation: https://github.com/libp2p/go-libp2p/blob/84ded7d47a74c7bfb8e6e257f32b01ea54ea3ad2/p2p/security/tls/transport_test.go#L289-L291