### PR TITLE
swarm / rcmgr: synchronize the concurrent outbound dials with limits

### DIFF
--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -492,7 +492,7 @@ var DefaultLimits = ScalingLimitConfig{
 	},
 
 	PeerBaseLimit: BaseLimit{
-		ConnsInbound:    4,
+		ConnsInbound:    8,
 		ConnsOutbound:   8,
 		Conns:           8,
 		StreamsInbound:  256,

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -492,6 +492,9 @@ var DefaultLimits = ScalingLimitConfig{
 	},
 
 	PeerBaseLimit: BaseLimit{
+		// 8 for now so that it matches the number of concurrent dials we may do
+		// in swarm_dial.go. With future smart dialing work we should bring this
+		// down
 		ConnsInbound:    8,
 		ConnsOutbound:   8,
 		Conns:           8,


### PR DESCRIPTION
We see flakiness in CI because a client will dial with concurrency 8 but the limit on the server is 4 so we get rcmgr failures. We notice this when we have a lot of addrs to dial.

 Fixes #1816
 Fixes #1765
 Fixes #1730
 Fixes #1668
 
 (will rebase to master after https://github.com/libp2p/go-libp2p/pull/1881 is merged)