### PR TITLE
circuitv2: disable the resource manager in tests

### DIFF
--- a/p2p/protocol/circuitv2/client/reservation_test.go
+++ b/p2p/protocol/circuitv2/client/reservation_test.go
@@ -82,7 +82,7 @@ func TestReservationFailures(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			host, err := libp2p.New()
+			host, err := libp2p.New(libp2p.ResourceManager(&network.NullResourceManager{}))
 			require.NoError(t, err)
 			defer host.Close()
 			if tc.streamHandler != nil {


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p/issues/1816
Fixes https://github.com/libp2p/go-libp2p/issues/1765
Fixes https://github.com/libp2p/go-libp2p/issues/1730
Fixes https://github.com/libp2p/go-libp2p/issues/1668