### PR TITLE
transports: expose the name of the transport in the ConnectionState

### DIFF
--- a/core/network/conn.go
+++ b/core/network/conn.go
@@ -36,10 +36,12 @@ type Conn interface {
 
 // ConnectionState holds information about the connection.
 type ConnectionState struct {
-	// The stream multiplexer used on this connection (if any).
+	// The stream multiplexer used on this connection (if any). For example: /yamux/1.0.0
 	StreamMultiplexer string
-	// The security protocol used on this connection (if any).
+	// The security protocol used on this connection (if any). For example: /tls/1.0.0
 	Security string
+	// the transport used on this connection. For example: tcp
+	Transport string
 }
 
 // ConnSecurity is the interface that one can mix into a connection interface to

--- a/p2p/net/upgrader/conn.go
+++ b/p2p/net/upgrader/conn.go
@@ -58,5 +58,6 @@ func (t *transportConn) ConnState() network.ConnectionState {
 	return network.ConnectionState{
 		StreamMultiplexer: string(t.muxer),
 		Security:          string(t.security),
+		Transport:         "tcp",
 	}
 }

--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -71,45 +71,32 @@ func (c *conn) AcceptStream() (network.MuxedStream, error) {
 }
 
 // LocalPeer returns our peer ID
-func (c *conn) LocalPeer() peer.ID {
-	return c.localPeer
-}
+func (c *conn) LocalPeer() peer.ID { return c.localPeer }
 
 // LocalPrivateKey returns our private key
-func (c *conn) LocalPrivateKey() ic.PrivKey {
-	return c.privKey
-}
+func (c *conn) LocalPrivateKey() ic.PrivKey { return c.privKey }
 
 // RemotePeer returns the peer ID of the remote peer.
-func (c *conn) RemotePeer() peer.ID {
-	return c.remotePeerID
-}
+func (c *conn) RemotePeer() peer.ID { return c.remotePeerID }
 
 // RemotePublicKey returns the public key of the remote peer.
-func (c *conn) RemotePublicKey() ic.PubKey {
-	return c.remotePubKey
-}
-
-// ConnState is the state of security connection.
-// It is empty if not supported.
-func (c *conn) ConnState() network.ConnectionState {
-	return network.ConnectionState{}
-}
+func (c *conn) RemotePublicKey() ic.PubKey { return c.remotePubKey }
 
 // LocalMultiaddr returns the local Multiaddr associated
-func (c *conn) LocalMultiaddr() ma.Multiaddr {
-	return c.localMultiaddr
-}
+func (c *conn) LocalMultiaddr() ma.Multiaddr { return c.localMultiaddr }
 
 // RemoteMultiaddr returns the remote Multiaddr associated
-func (c *conn) RemoteMultiaddr() ma.Multiaddr {
-	return c.remoteMultiaddr
-}
+func (c *conn) RemoteMultiaddr() ma.Multiaddr { return c.remoteMultiaddr }
 
-func (c *conn) Transport() tpt.Transport {
-	return c.transport
-}
+func (c *conn) Transport() tpt.Transport { return c.transport }
 
-func (c *conn) Scope() network.ConnScope {
-	return c.scope
+func (c *conn) Scope() network.ConnScope { return c.scope }
+
+// ConnState is the state of security connection.
+func (c *conn) ConnState() network.ConnectionState {
+	t := "quic-v1"
+	if _, err := c.LocalMultiaddr().ValueForProtocol(ma.P_QUIC); err == nil {
+		t = "quic"
+	}
+	return network.ConnectionState{Transport: t}
 }

--- a/p2p/transport/websocket/conn.go
+++ b/p2p/transport/websocket/conn.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/transport"
+
 	ws "github.com/gorilla/websocket"
 )
 
@@ -148,4 +151,14 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 	defer c.writeLock.Unlock()
 
 	return c.Conn.SetWriteDeadline(t)
+}
+
+type capableConn struct {
+	transport.CapableConn
+}
+
+func (c *capableConn) ConnState() network.ConnectionState {
+	cs := c.CapableConn.ConnState()
+	cs.Transport = "websocket"
+	return cs
 }

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/libp2p/go-libp2p/core/transport"
+
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
@@ -139,4 +141,16 @@ func (l *listener) Multiaddr() ma.Multiaddr {
 
 func (l *listener) Multiaddrs() []ma.Multiaddr {
 	return []ma.Multiaddr{l.laddr}
+}
+
+type transportListener struct {
+	transport.Listener
+}
+
+func (l *transportListener) Accept() (transport.CapableConn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return &capableConn{CapableConn: conn}, nil
 }

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -166,7 +166,11 @@ func (t *WebsocketTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p pee
 		connScope.Done()
 		return nil, err
 	}
-	return t.upgrader.Upgrade(ctx, t, macon, network.DirOutbound, p, connScope)
+	conn, err := t.upgrader.Upgrade(ctx, t, macon, network.DirOutbound, p, connScope)
+	if err != nil {
+		return nil, err
+	}
+	return &capableConn{CapableConn: conn}, nil
 }
 
 func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (manet.Conn, error) {
@@ -230,5 +234,5 @@ func (t *WebsocketTransport) Listen(a ma.Multiaddr) (transport.Listener, error) 
 	if err != nil {
 		return nil, err
 	}
-	return t.upgrader.UpgradeListener(t, malist), nil
+	return &transportListener{Listener: t.upgrader.UpgradeListener(t, malist)}, nil
 }

--- a/p2p/transport/webtransport/conn.go
+++ b/p2p/transport/webtransport/conn.go
@@ -75,3 +75,7 @@ func (c *conn) Close() error {
 func (c *conn) IsClosed() bool           { return c.session.Context().Err() != nil }
 func (c *conn) Scope() network.ConnScope { return c.scope }
 func (c *conn) Transport() tpt.Transport { return c.transport }
+
+func (c *conn) ConnState() network.ConnectionState {
+	return network.ConnectionState{Transport: "webtransport"}
+}


### PR DESCRIPTION
Prerequisite for our metrics effort, specifically #1910.