### PR TITLE
use a different set of default transports when PSK is enabled

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -45,6 +45,15 @@ var DefaultTransports = ChainOptions(
 	Transport(ws.New),
 )
 
+// DefaultPrivateTransports are the default libp2p transports when a PSK is supplied.
+//
+// Use this option when you want to *extend* the set of transports used by
+// libp2p instead of replacing them.
+var DefaultPrivateTransports = ChainOptions(
+	Transport(tcp.NewTCPTransport),
+	Transport(ws.New),
+)
+
 // DefaultPeerstore configures libp2p to use the default peerstore.
 var DefaultPeerstore Option = func(cfg *Config) error {
 	ps, err := pstoremem.NewPeerstore()
@@ -135,8 +144,12 @@ var defaults = []struct {
 		opt:      DefaultListenAddrs,
 	},
 	{
-		fallback: func(cfg *Config) bool { return cfg.Transports == nil },
+		fallback: func(cfg *Config) bool { return cfg.Transports == nil && cfg.PSK == nil },
 		opt:      DefaultTransports,
+	},
+	{
+		fallback: func(cfg *Config) bool { return cfg.Transports == nil && cfg.PSK != nil },
+		opt:      DefaultPrivateTransports,
 	},
 	{
 		fallback: func(cfg *Config) bool { return cfg.Muxers == nil },


### PR DESCRIPTION
### Problem

The current behavior in `go-libp2p` is that the transports are provided through `fx` by default when no other options are specified. 
QUIC is listed in the defaults but does not support PSK usage, so creating a new app will always result in an error.
The way that libp2p is currently bootstrapped does not allow for dynamically enabling/disabling transports, so we cannot disable QUIC once it's been provided as a value group.

### Solution

This PR adds a new default transport option that gets activated when `cfg.Transports == nil && cfg.PSK != nil`. The new option is mutually exclusive with the current one on the condition of `cfg.PSK == nil`.  

Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>