### PR TITLE
ci: fix path to interop test plan composition file

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -17,7 +17,7 @@ jobs:
   run-ping-interop-cross-implementation:
     uses: "libp2p/test-plans/.github/workflows/run-composition.yml@master"
     with:
-      composition_file: "ping/_compositions/go-rust-interop-latest.toml"
+      composition_file: "ping/_compositions/all-interop-latest.toml"
       custom_git_target: github.com/${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
       custom_git_reference: ${{ github.event.pull_request.head.sha || github.sha }}
       custom_interop_target: go


### PR DESCRIPTION
https://github.com/libp2p/test-plans/pull/70 broke our CI, since the composition file was moved.