### PR TITLE
quic: fix race condition in TestClientCanDialDifferentQUICVersions

### DIFF
--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -758,7 +758,6 @@ func TestClientCanDialDifferentQUICVersions(t *testing.T) {
 						panic("unexpected version")
 					}
 					require.NoError(t, err)
-					defer conn.Close()
 
 					_, versionConnLocal, err := quicreuse.FromQuicMultiaddr(conn.LocalMultiaddr())
 					require.NoError(t, err)


### PR DESCRIPTION
Fixes #1913.
The server shouldn't close the connection before the client had the chance to accept it.