### PR TITLE
Add fuzz function.

### DIFF
--- a/fuzz/encode_decode_fuzz.go
+++ b/fuzz/encode_decode_fuzz.go
@@ -1,0 +1,20 @@
+package fuzz
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func FuzzEncodeDecodeID(data []byte) int {
+	var id peer.ID
+	if err := id.UnmarshalText(data); err == nil {
+		encoded := peer.Encode(id)
+		id2, err := peer.Decode(encoded)
+		if err != nil {
+			return 1
+		}
+		if id != id2 {
+			return 1
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p/issues/857 by integrating an existing fuzzer (see https://github.com/libp2p/go-libp2p/issues/1694) that encodes a random byte stream and decodes it checking if (1) decode failed for a successful encode; and (2) encoded and decoded IDs match.

See: https://github.com/google/oss-fuzz/pull/9185