### PR TITLE
quic / webtransport: extend test to test dialing a draft-29 and a v1 

### DIFF
--- a/p2p/test/quic/quic_test.go
+++ b/p2p/test/quic/quic_test.go
@@ -109,10 +109,11 @@ func TestDisableQUICDraft29(t *testing.T) {
 
 func TestQUICAndWebTransport(t *testing.T) {
 	h1, err := libp2p.New(
-		libp2p.QUICReuse(quicreuse.NewConnManager, quicreuse.DisableDraft29()),
+		libp2p.QUICReuse(quicreuse.NewConnManager),
 		libp2p.Transport(libp2pquic.NewTransport),
 		libp2p.Transport(webtransport.New),
 		libp2p.ListenAddrStrings(
+			"/ip4/127.0.0.1/udp/12347/quic/",
 			"/ip4/127.0.0.1/udp/12347/quic-v1",
 			"/ip4/127.0.0.1/udp/12347/quic-v1/webtransport",
 		),
@@ -121,20 +122,22 @@ func TestQUICAndWebTransport(t *testing.T) {
 	defer h1.Close()
 
 	addrs := h1.Addrs()
-	require.Len(t, addrs, 2)
-	require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(addrs[0]))
-	require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(addrs[1]))
-	var quicAddr, webtransportAddr ma.Multiaddr
+	require.Len(t, addrs, 3)
+	var quicDraft29Addr, quicV1Addr, webtransportAddr ma.Multiaddr
 	for _, addr := range addrs {
 		if _, err := addr.ValueForProtocol(ma.P_WEBTRANSPORT); err == nil {
 			webtransportAddr = addr
+		} else if _, err := addr.ValueForProtocol(ma.P_QUIC_V1); err == nil {
+			quicV1Addr = addr
 		} else {
-			quicAddr = addr
+			quicDraft29Addr = addr
 		}
 	}
 	require.NotNil(t, webtransportAddr, "expected to have a WebTransport address")
-	require.NotNil(t, quicAddr, "expected to have a QUIC v1 address")
+	require.NotNil(t, quicDraft29Addr, "expected to have a QUIC draft-29 address")
+	require.NotNil(t, quicV1Addr, "expected to have a QUIC v1 address")
 
+	// first test that we can dial a QUIC v1
 	h2, err := libp2p.New(
 		libp2p.Transport(libp2pquic.NewTransport),
 		libp2p.NoListenAddrs,
@@ -151,13 +154,36 @@ func TestQUICAndWebTransport(t *testing.T) {
 	}
 	h2.Close()
 
+	// then test that we can dial a QUIC draft-29
 	h3, err := libp2p.New(
+		libp2p.Transport(libp2pquic.NewTransport),
+		libp2p.NoListenAddrs,
+	)
+	require.NoError(t, err)
+	require.NoError(t, h3.Connect(context.Background(), peer.AddrInfo{
+		ID: h1.ID(),
+		// a libp2p host will prefer dialing v1 if it supports both versions,
+		// so we need to filter the addresses so it thinks that h1 only supports draft-29
+		Addrs: ma.FilterAddrs(h1.Addrs(), func(addr ma.Multiaddr) bool { _, err := addr.ValueForProtocol(ma.P_QUIC); return err == nil }),
+	}))
+	for _, conns := range [][]network.Conn{h3.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h3.ID())} {
+		require.Len(t, conns, 1)
+		if _, err := conns[0].LocalMultiaddr().ValueForProtocol(ma.P_WEBTRANSPORT); err == nil {
+			t.Fatalf("expected a QUIC connection, got a WebTransport connection (%s <-> %s)", conns[0].LocalMultiaddr(), conns[0].RemoteMultiaddr())
+		}
+		require.Equal(t, ma.P_QUIC, getQUICMultiaddrCode(conns[0].LocalMultiaddr()))
+		require.Equal(t, ma.P_QUIC, getQUICMultiaddrCode(conns[0].RemoteMultiaddr()))
+	}
+	h3.Close()
+
+	// finally, test that we can dial a WebTransport connection
+	h4, err := libp2p.New(
 		libp2p.Transport(webtransport.New),
 		libp2p.NoListenAddrs,
 	)
 	require.NoError(t, err)
-	require.NoError(t, h3.Connect(context.Background(), peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}))
-	for _, conns := range [][]network.Conn{h3.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h3.ID())} {
+	require.NoError(t, h4.Connect(context.Background(), peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}))
+	for _, conns := range [][]network.Conn{h4.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h4.ID())} {
 		require.Len(t, conns, 1)
 		if _, err := conns[0].LocalMultiaddr().ValueForProtocol(ma.P_WEBTRANSPORT); err != nil {
 			t.Fatalf("expected a WebTransport connection, got a QUIC connection (%s <-> %s)", conns[0].LocalMultiaddr(), conns[0].RemoteMultiaddr())
@@ -165,5 +191,5 @@ func TestQUICAndWebTransport(t *testing.T) {
 		require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(conns[0].LocalMultiaddr()))
 		require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(conns[0].RemoteMultiaddr()))
 	}
-	h3.Close()
+	h4.Close()
 }


### PR DESCRIPTION
This test now:
1. sets up a node that speaks QUIC draft-29 and v1, and WebTransport
2. connects to that node, validating that if we're offered all 3 addresses, we pick QUIC v1
3. connects to that node, passing only the draft-29 address to the dialer, validating that we can dial a draft-29 connection
4. connects to that node from a node that only speaks WebTransport but not QUIC, validating that we can dial a WebTransport connection