### PR TITLE
roadmap: remove optimizations of the TCP-based handshake

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,8 +31,7 @@ https://github.com/libp2p/go-libp2p/issues/1806
     - [3. WebTransport: Update to new draft versions](#3-webtransport-update-to-new-draft-versions)
   - [B. ⚡️ Handshakes at the Speed of Light](#b-️-handshakes-at-the-speed-of-light)
     - [1. Early Muxer Negotiation](#1-early-muxer-negotiation)
-    - [2. Adding security protocol](#2-adding-security-protocol)
-    - [3. 0.5 RTT data optimization](#3-05-rtt-data-optimization)
+    - [2. 0.5 RTT data optimization](#2-05-rtt-data-optimization-(for-QUIC))
   - [C. 🧠 Smart Dialing](#c--smart-dialing)
     - [1. Happy Eyeballs](#1-happy-eyeballs)
     - [2. QUIC Blackhole detector](#2-quic-blackhole-detector)
@@ -97,16 +96,15 @@ These projects are parallel workstreams, weighed equally with roadmap items in t
 ### 2023
 
 #### Early Q1 (January)
-- [B.2 ⚡ Adding security protocol](#2-adding-security-protocol)
 - [C.2 🧠 QUIC Blackhole detector](#2-quic-blackhole-detector)
 
 #### Mid Q1 (February)
+- [B.2 ⚡ 0.5 RTT data optimization (for QUIC)](#3-05-rtt-data-optimization)
+  -  🎉 Estimated Project Completion
 - [C.3 🧠 RTT estimation](#3-rtt-estimation)
   - 🎉 Estimated Project Completion
 
 #### End of Q1 (March)
-- [B.3 ⚡ 0.5 RTT data optimization (for QUIC)](#3-05-rtt-data-optimization)
-  -  🎉 Estimated Project Completion
 - [***➡️ test-plans/Benchmarking using remote runners***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#2-benchmarking-using-remote-runners)
 
 ### Up Next
@@ -140,10 +138,8 @@ As the protocol is still under development by IETF and W3C, the go-libp2p implem
 
 #### 1. [Early Muxer Negotiation](https://github.com/libp2p/specs/issues/426)
 Cutting off the 1 RTT wasted on muxer negotiation
-#### 2. [Adding security protocol](https://github.com/libp2p/specs/pull/353)
-Cutting off the 1 RTT wasted on security protocol negotiation by including the security protocol in the multiaddr
-#### 3. 0.5 RTT data optimization
-Using 0.5-RTT data (for TLS) / a Noise Extension to ship the list of Identify protocols, cutting of 1 RTT that many protocols spend waiting on `IdentifyWait`
+#### 2. 0.5 RTT data optimization (for QUIC)
+Using 0.5-RTT data (for QUIC) to ship the list of Identify protocols, cutting of 1 RTT that many protocols spend waiting on `IdentifyWait`
 
 ### [C. 🧠 Smart Dialing](https://github.com/libp2p/go-libp2p/issues/1808)
 


### PR DESCRIPTION
As an early result of the swarm metrics effort (#1910), we've discovered that >80% of the connections that a (full) node on the IPFS network establishes / accepts are QUIC connections. We can expect similar numbers for other libp2p networks that use go-libp2p (and that enabled the QUIC transport).

It therefore makes sense to focus our attention on cutting down roundtrips for QUIC users. This makes sense for multiple reasons:
1. At the risk of stating the obvious, improving the handshake latency for >80% of the connections is more impactful than improving the handshake latency for <20% of the connections.
2. Optimizing the TCP-based handshake by getting rid of the security protocol negotiation reduces the latency of a TCP handshake 4 to 3 RTTs (including Identify in the calculation here), that's 25%. Optimizing the QUIC handshake (by using 0.5-RTT data for Identify) allows us to bring down the latency from 2 to 1 RTT, a speedup of 50%.
3. Moving the security protocol is a complicated change, requiring changes to the libp2p specification (https://github.com/libp2p/specs/pull/353), and requires both nodes to upgrade to the latest versions. Using 0.5-RTT data in QUIC on the other hand is a backwards-compatible change, as it doesn't require the client to upgrade. Thus, the performance impact will materialize much faster.

I suggest _removing_ the TCP-based optimizations instead of just _deprioritizing_ them, since given our current staffing situation, and the recent addition of the libp2p+HTTP work, we already have a lot on our plate.