### PR TITLE
config: initialize the null rcmgr in fx, not in the transports

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,8 +187,12 @@ func (cfg *Config) addTransports(h host.Host) error {
 		fx.Provide(func() crypto.PrivKey { return h.Peerstore().PrivKey(h.ID()) }),
 		fx.Provide(func() connmgr.ConnectionGater { return cfg.ConnectionGater }),
 		fx.Provide(func() pnet.PSK { return cfg.PSK }),
-		fx.Provide(func() network.ResourceManager { return cfg.ResourceManager }),
 		fx.Provide(func() *madns.Resolver { return cfg.MultiaddrResolver }),
+	}
+	if cfg.ResourceManager != nil {
+		fxopts = append(fxopts, fx.Supply(cfg.ResourceManager))
+	} else {
+		fxopts = append(fxopts, fx.Supply(&network.NullResourceManager{}))
 	}
 	fxopts = append(fxopts, cfg.Transports...)
 	if cfg.Insecure {

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/sec"
@@ -50,7 +51,7 @@ func makeSwarm(t *testing.T) *Swarm {
 
 	var tcpOpts []tcp.Option
 	tcpOpts = append(tcpOpts, tcp.DisableReuseport())
-	tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, tcpOpts...)
+	tcpTransport, err := tcp.NewTCPTransport(upgrader, &network.NullResourceManager{}, tcpOpts...)
 	require.NoError(t, err)
 	if err := s.AddTransport(tcpTransport); err != nil {
 		t.Fatal(err)
@@ -63,7 +64,7 @@ func makeSwarm(t *testing.T) *Swarm {
 	if err != nil {
 		t.Fatal(err)
 	}
-	quicTransport, err := quic.NewTransport(priv, reuse, nil, nil, nil)
+	quicTransport, err := quic.NewTransport(priv, reuse, nil, nil, &network.NullResourceManager{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +83,7 @@ func makeUpgrader(t *testing.T, n *Swarm) transport.Upgrader {
 	pk := n.Peerstore().PrivKey(id)
 	st := insecure.NewWithIdentity(insecure.ID, id, pk)
 
-	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: "/yamux/1.0.0", Muxer: yamux.DefaultTransport}}, nil, nil, nil)
+	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: "/yamux/1.0.0", Muxer: yamux.DefaultTransport}}, nil, &network.NullResourceManager{}, nil)
 	require.NoError(t, err)
 	return u
 }

--- a/p2p/net/swarm/testing/testing.go
+++ b/p2p/net/swarm/testing/testing.go
@@ -105,7 +105,14 @@ func GenUpgrader(t *testing.T, n *swarm.Swarm, connGater connmgr.ConnectionGater
 	pk := n.Peerstore().PrivKey(id)
 	st := insecure.NewWithIdentity(insecure.ID, id, pk)
 
-	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: "/yamux/1.0.0", Muxer: yamux.DefaultTransport}}, nil, nil, connGater, opts...)
+	u, err := tptu.New(
+		[]sec.SecureTransport{st},
+		[]tptu.StreamMuxer{{ID: "/yamux/1.0.0", Muxer: yamux.DefaultTransport}},
+		nil,
+		&network.NullResourceManager{},
+		connGater,
+		opts...,
+	)
 	require.NoError(t, err)
 	return u
 }
@@ -150,7 +157,7 @@ func GenSwarm(t *testing.T, opts ...Option) *swarm.Swarm {
 		if cfg.disableReuseport {
 			tcpOpts = append(tcpOpts, tcp.DisableReuseport())
 		}
-		tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, tcpOpts...)
+		tcpTransport, err := tcp.NewTCPTransport(upgrader, &network.NullResourceManager{}, tcpOpts...)
 		require.NoError(t, err)
 		if err := s.AddTransport(tcpTransport); err != nil {
 			t.Fatal(err)
@@ -166,7 +173,7 @@ func GenSwarm(t *testing.T, opts ...Option) *swarm.Swarm {
 		if err != nil {
 			t.Fatal(err)
 		}
-		quicTransport, err := quic.NewTransport(priv, reuse, nil, cfg.connectionGater, nil)
+		quicTransport, err := quic.NewTransport(priv, reuse, nil, cfg.connectionGater, &network.NullResourceManager{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -87,9 +87,6 @@ func New(security []sec.SecureTransport, muxers []StreamMuxer, psk ipnet.PSK, rc
 			return nil, err
 		}
 	}
-	if u.rcmgr == nil {
-		u.rcmgr = &network.NullResourceManager{}
-	}
 	u.muxerIDs = make([]string, 0, len(muxers))
 	for _, m := range muxers {
 		u.muxerMuxer.AddHandler(string(m.ID), nil)

--- a/p2p/net/upgrader/upgrader_test.go
+++ b/p2p/net/upgrader/upgrader_test.go
@@ -25,11 +25,11 @@ import (
 )
 
 func createUpgrader(t *testing.T) (peer.ID, transport.Upgrader) {
-	return createUpgraderWithMuxers(t, []upgrader.StreamMuxer{{ID: "negotiate", Muxer: &negotiatingMuxer{}}}, nil, nil)
+	return createUpgraderWithMuxers(t, []upgrader.StreamMuxer{{ID: "negotiate", Muxer: &negotiatingMuxer{}}}, &network.NullResourceManager{}, nil)
 }
 
 func createUpgraderWithConnGater(t *testing.T, connGater connmgr.ConnectionGater) (peer.ID, transport.Upgrader) {
-	return createUpgraderWithMuxers(t, []upgrader.StreamMuxer{{ID: "negotiate", Muxer: &negotiatingMuxer{}}}, nil, connGater)
+	return createUpgraderWithMuxers(t, []upgrader.StreamMuxer{{ID: "negotiate", Muxer: &negotiatingMuxer{}}}, &network.NullResourceManager{}, connGater)
 }
 
 func createUpgraderWithResourceManager(t *testing.T, rcmgr network.ResourceManager) (peer.ID, transport.Upgrader) {
@@ -37,7 +37,7 @@ func createUpgraderWithResourceManager(t *testing.T, rcmgr network.ResourceManag
 }
 
 func createUpgraderWithOpts(t *testing.T, opts ...upgrader.Option) (peer.ID, transport.Upgrader) {
-	return createUpgraderWithMuxers(t, []upgrader.StreamMuxer{{ID: "negotiate", Muxer: &negotiatingMuxer{}}}, nil, nil, opts...)
+	return createUpgraderWithMuxers(t, []upgrader.StreamMuxer{{ID: "negotiate", Muxer: &negotiatingMuxer{}}}, &network.NullResourceManager{}, nil, opts...)
 }
 
 func newPeer(t *testing.T) (peer.ID, crypto.PrivKey) {

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -88,12 +88,12 @@ func testHandshake(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 
 	handshake := func(t *testing.T, ln tpt.Listener) {
-		clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, nil)
+		clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 		require.NoError(t, err)
 		defer clientTransport.(io.Closer).Close()
 		conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
@@ -280,13 +280,13 @@ func testStreams(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
 	defer ln.Close()
 
-	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 	conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
@@ -321,12 +321,12 @@ func testHandshakeFailPeerIDMismatch(t *testing.T, tc *connTestCase) {
 	_, clientKey := createPeer(t)
 	thirdPartyID, _ := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
 
-	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	// dial, but expect the wrong peer ID
 	_, err = clientTransport.Dial(context.Background(), ln.Multiaddr(), thirdPartyID)
@@ -367,7 +367,7 @@ func testConnectionGating(t *testing.T, tc *connTestCase) {
 	cg := NewMockConnectionGater(mockCtrl)
 
 	t.Run("accepted connections", func(t *testing.T) {
-		serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, cg, nil)
+		serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, cg, &network.NullResourceManager{})
 		defer serverTransport.(io.Closer).Close()
 		require.NoError(t, err)
 		ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
@@ -382,7 +382,7 @@ func testConnectionGating(t *testing.T, tc *connTestCase) {
 			require.NoError(t, err)
 		}()
 
-		clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, nil)
+		clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 		require.NoError(t, err)
 		defer clientTransport.(io.Closer).Close()
 		// make sure that connection attempts fails
@@ -411,7 +411,7 @@ func testConnectionGating(t *testing.T, tc *connTestCase) {
 	})
 
 	t.Run("secured connections", func(t *testing.T) {
-		serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, nil)
+		serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 		require.NoError(t, err)
 		defer serverTransport.(io.Closer).Close()
 		ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
@@ -420,7 +420,7 @@ func testConnectionGating(t *testing.T, tc *connTestCase) {
 		cg := NewMockConnectionGater(mockCtrl)
 		cg.EXPECT().InterceptSecured(gomock.Any(), gomock.Any(), gomock.Any())
 
-		clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, cg, nil)
+		clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, cg, &network.NullResourceManager{})
 		require.NoError(t, err)
 		defer clientTransport.(io.Closer).Close()
 
@@ -450,12 +450,12 @@ func testDialTwo(t *testing.T, tc *connTestCase) {
 	_, clientKey := createPeer(t)
 	serverID2, serverKey2 := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln1 := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
 	defer ln1.Close()
-	serverTransport2, err := NewTransport(serverKey2, newConnManager(t, tc.Options...), nil, nil, nil)
+	serverTransport2, err := NewTransport(serverKey2, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer serverTransport2.(io.Closer).Close()
 	ln2 := runServer(t, serverTransport2, "/ip4/127.0.0.1/udp/0/quic-v1")
@@ -481,7 +481,7 @@ func testDialTwo(t *testing.T, tc *connTestCase) {
 		}
 	}()
 
-	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 	c1, err := clientTransport.Dial(context.Background(), ln1.Multiaddr(), serverID)
@@ -529,7 +529,7 @@ func testStatelessReset(t *testing.T, tc *connTestCase) {
 	serverID, serverKey := createPeer(t)
 	_, clientKey := createPeer(t)
 
-	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	serverTransport, err := NewTransport(serverKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
@@ -544,7 +544,7 @@ func testStatelessReset(t *testing.T, tc *connTestCase) {
 	proxyLocalAddr := proxy.LocalAddr()
 
 	// establish a connection
-	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, nil)
+	clientTransport, err := NewTransport(clientKey, newConnManager(t, tc.Options...), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer clientTransport.(io.Closer).Close()
 	proxyAddr, err := quicreuse.ToQuicMultiaddr(proxy.LocalAddr(), quic.Version1)
@@ -608,7 +608,7 @@ func TestHolePunching(t *testing.T) {
 	serverID, serverKey := createPeer(t)
 	clientID, clientKey := createPeer(t)
 
-	t1, err := NewTransport(serverKey, newConnManager(t), nil, nil, nil)
+	t1, err := NewTransport(serverKey, newConnManager(t), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer t1.(io.Closer).Close()
 	laddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/quic-v1")
@@ -622,7 +622,7 @@ func TestHolePunching(t *testing.T) {
 		require.Error(t, err, "didn't expect to accept any connections")
 	}()
 
-	t2, err := NewTransport(clientKey, newConnManager(t), nil, nil, nil)
+	t2, err := NewTransport(clientKey, newConnManager(t), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer t2.(io.Closer).Close()
 	ln2, err := t2.Listen(laddr)
@@ -681,7 +681,7 @@ func TestHolePunching(t *testing.T) {
 func TestGetErrorWhenListeningWithDraft29WhenDisabled(t *testing.T) {
 	_, serverKey := createPeer(t)
 
-	t1, err := NewTransport(serverKey, newConnManager(t, quicreuse.DisableDraft29()), nil, nil, nil)
+	t1, err := NewTransport(serverKey, newConnManager(t, quicreuse.DisableDraft29()), nil, nil, &network.NullResourceManager{})
 	require.NoError(t, err)
 	defer t1.(io.Closer).Close()
 	laddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/quic")
@@ -717,7 +717,7 @@ func TestClientCanDialDifferentQUICVersions(t *testing.T) {
 				serverOpts = append(serverOpts, quicreuse.DisableDraft29())
 			}
 
-			t1, err := NewTransport(serverKey, newConnManager(t, serverOpts...), nil, nil, nil)
+			t1, err := NewTransport(serverKey, newConnManager(t, serverOpts...), nil, nil, &network.NullResourceManager{})
 			require.NoError(t, err)
 			defer t1.(io.Closer).Close()
 			laddr := ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")
@@ -735,7 +735,7 @@ func TestClientCanDialDifferentQUICVersions(t *testing.T) {
 				mas = append(mas, ln2.Multiaddr())
 			}
 
-			t2, err := NewTransport(clientKey, newConnManager(t), nil, nil, nil)
+			t2, err := NewTransport(clientKey, newConnManager(t), nil, nil, &network.NullResourceManager{})
 			require.NoError(t, err)
 			defer t2.(io.Closer).Close()
 

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -83,10 +83,6 @@ func NewTransport(key ic.PrivKey, connManager *quicreuse.ConnManager, psk pnet.P
 		return nil, err
 	}
 
-	if rcmgr == nil {
-		rcmgr = &network.NullResourceManager{}
-	}
-
 	return &transport{
 		privKey:      key,
 		localPeer:    localPeer,

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -135,9 +135,6 @@ var _ transport.Transport = &TcpTransport{}
 // NewTCPTransport creates a tcp transport object that tracks dialers and listeners
 // created. It represents an entire TCP stack (though it might not necessarily be).
 func NewTCPTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*TcpTransport, error) {
-	if rcmgr == nil {
-		rcmgr = &network.NullResourceManager{}
-	}
 	tr := &TcpTransport{
 		upgrader:       upgrader,
 		connectTimeout: defaultConnectTimeout, // can be set by using the WithConnectionTimeout option

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -92,9 +92,6 @@ type WebsocketTransport struct {
 var _ transport.Transport = (*WebsocketTransport)(nil)
 
 func New(u transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*WebsocketTransport, error) {
-	if rcmgr == nil {
-		rcmgr = &network.NullResourceManager{}
-	}
 	t := &WebsocketTransport{
 		upgrader:      u,
 		rcmgr:         rcmgr,

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -38,7 +38,7 @@ import (
 func newUpgrader(t *testing.T) (peer.ID, transport.Upgrader) {
 	t.Helper()
 	id, m := newInsecureMuxer(t)
-	u, err := tptu.New(m, []tptu.StreamMuxer{{ID: "/yamux", Muxer: yamux.DefaultTransport}}, nil, nil, nil)
+	u, err := tptu.New(m, []tptu.StreamMuxer{{ID: "/yamux", Muxer: yamux.DefaultTransport}}, nil, &network.NullResourceManager{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func newUpgrader(t *testing.T) (peer.ID, transport.Upgrader) {
 func newSecureUpgrader(t *testing.T) (peer.ID, transport.Upgrader) {
 	t.Helper()
 	id, m := newSecureMuxer(t)
-	u, err := tptu.New(m, []tptu.StreamMuxer{{ID: "/yamux", Muxer: yamux.DefaultTransport}}, nil, nil, nil)
+	u, err := tptu.New(m, []tptu.StreamMuxer{{ID: "/yamux", Muxer: yamux.DefaultTransport}}, nil, &network.NullResourceManager{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This would fix https://github.com/ipfs/kubo/issues/9516.