### PR TITLE
webtransport: initialize a NullResourceManager if none is provided

### DIFF
--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -89,6 +89,9 @@ func New(key ic.PrivKey, psk pnet.PSK, connManager *quicreuse.ConnManager, gater
 		log.Error("WebTransport doesn't support private networks yet.")
 		return nil, errors.New("WebTransport doesn't support private networks yet")
 	}
+	if rcmgr == nil {
+		rcmgr = &network.NullResourceManager{}
+	}
 	id, err := peer.IDFromPrivateKey(key)
 	if err != nil {
 		return nil, err

--- a/p2p/transport/webtransport/transport_test.go
+++ b/p2p/transport/webtransport/transport_test.go
@@ -107,7 +107,7 @@ func newConnManager(t *testing.T, opts ...quicreuse.Option) *quicreuse.ConnManag
 
 func TestTransport(t *testing.T) {
 	serverID, serverKey := newIdentity(t)
-	tr, err := libp2pwebtransport.New(serverKey, nil, newConnManager(t), nil, &network.NullResourceManager{})
+	tr, err := libp2pwebtransport.New(serverKey, nil, newConnManager(t), nil, nil)
 	require.NoError(t, err)
 	defer tr.(io.Closer).Close()
 	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport"))
@@ -117,7 +117,7 @@ func TestTransport(t *testing.T) {
 	addrChan := make(chan ma.Multiaddr)
 	go func() {
 		_, clientKey := newIdentity(t)
-		tr2, err := libp2pwebtransport.New(clientKey, nil, newConnManager(t), nil, &network.NullResourceManager{})
+		tr2, err := libp2pwebtransport.New(clientKey, nil, newConnManager(t), nil, nil)
 		require.NoError(t, err)
 		defer tr2.(io.Closer).Close()
 


### PR DESCRIPTION
This will fix https://github.com/ipfs/kubo/issues/9516 in an easier way than #1960, which might be more appropriate for a patch release.