### PR TITLE
quic, tcp: only register Prometheus counters when metrics are enabled

### DIFF
--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -54,7 +54,7 @@ func NewConnManager(statelessResetKey quic.StatelessResetKey, opts ...Option) (*
 		tracers = append(tracers, qlogTracer)
 	}
 	if cm.enableMetrics {
-		tracers = append(tracers, &metricsTracer{})
+		tracers = append(tracers, newMetricsTracer())
 	}
 	if len(tracers) > 0 {
 		quicConf.Tracer = quiclogging.NewMultiplexedTracer(tracers...)

--- a/p2p/transport/quicreuse/tracer_metrics.go
+++ b/p2p/transport/quicreuse/tracer_metrics.go
@@ -85,7 +85,9 @@ func (c *aggregatingCollector) RemoveConn(id string) {
 
 var collector *aggregatingCollector
 
-func init() {
+var initMetricsOnce sync.Once
+
+func initMetrics() {
 	const (
 		direction = "direction"
 		encLevel  = "encryption_level"
@@ -172,6 +174,11 @@ type metricsTracer struct {
 }
 
 var _ logging.Tracer = &metricsTracer{}
+
+func newMetricsTracer() *metricsTracer {
+	initMetricsOnce.Do(func() { initMetrics() })
+	return &metricsTracer{}
+}
 
 func (m *metricsTracer) TracerForConnection(_ context.Context, p logging.Perspective, connID logging.ConnectionID) logging.ConnectionTracer {
 	return &metricsConnTracer{perspective: p, connID: connID}

--- a/p2p/transport/tcp/metrics.go
+++ b/p2p/transport/tcp/metrics.go
@@ -26,7 +26,9 @@ const collectFrequency = 10 * time.Second
 
 var collector *aggregatingCollector
 
-func init() {
+var initMetricsOnce sync.Once
+
+func initMetrics() {
 	segsSentDesc = prometheus.NewDesc("tcp_sent_segments_total", "TCP segments sent", nil, nil)
 	segsRcvdDesc = prometheus.NewDesc("tcp_rcvd_segments_total", "TCP segments received", nil, nil)
 	bytesSentDesc = prometheus.NewDesc("tcp_sent_bytes", "TCP bytes sent", nil, nil)
@@ -210,6 +212,7 @@ type tracingConn struct {
 }
 
 func newTracingConn(c manet.Conn, isClient bool) (*tracingConn, error) {
+	initMetricsOnce.Do(func() { initMetrics() })
 	conn, err := tcp.NewConn(c)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Due to the performance impact, we're only collecting metrics when explicitly enabled anyway. We shouldn't even register the Prometheus metrics if not.