### PR TITLE
feat!: rcmgr: Change LimitConfig to use LimitVal type

### DIFF
--- a/p2p/host/resource-manager/README.md
+++ b/p2p/host/resource-manager/README.md
@@ -33,7 +33,7 @@ libp2p.SetDefaultServiceLimits(&scalingLimits)
 scaledDefaultLimits := scalingLimits.AutoScale()
 
 // Tweak certain settings
-cfg := rcmgr.LimitConfig{
+cfg := rcmgr.PartialLimitConfig{
   System: &rcmgr.ResourceLimits{
     // Allow unlimited outbound streams
     StreamsOutbound: rcmgr.Unlimited,
@@ -42,7 +42,7 @@ cfg := rcmgr.LimitConfig{
 }
 
 // Create our limits by using our cfg and replacing the default values with values from `scaledDefaultLimits`
-limits := cfg.Reify(scaledDefaultLimits)
+limits := cfg.Build(scaledDefaultLimits)
 
 // The resource manager expects a limiter, se we create one from our limits.
 limiter := rcmgr.NewFixedLimiter(limits)
@@ -64,12 +64,12 @@ host, err := libp2p.New(libp2p.ResourceManager(rm))
 ```
 
 ### Saving the limits config
-The easiest way to save the defined limits is to serialize the `LimitConfig`
+The easiest way to save the defined limits is to serialize the `PartialLimitConfig`
 type as JSON.
 
 ```go
 noisyNeighbor, _ := peer.Decode("QmVvtzcZgCkMnSFf2dnrBPXrWuNFWNM9J3MpZQCvWPuVZf")
-cfg := rcmgr.LimitConfig{
+cfg := rcmgr.PartialLimitConfig{
   System: &rcmgr.ResourceLimits{
     // Allow unlimited outbound streams
     StreamsOutbound: rcmgr.Unlimited,
@@ -338,7 +338,7 @@ This is done using the `ScalingLimitConfig`. For every scope, this configuration
 struct defines the absolutely bare minimum limits, and an (optional) increase of
 these limits, which will be applied on nodes that have sufficient memory.
 
-A `ScalingLimitConfig` can be converted into a `LimitConfig` (which can then be
+A `ScalingLimitConfig` can be converted into a `ConcreteLimitConfig` (which can then be
 used to initialize a fixed limiter with `NewFixedLimiter`) by calling the `Scale` method.
 The `Scale` method takes two parameters: the amount of memory and the number of file
 descriptors that an application is willing to dedicate to libp2p.
@@ -406,7 +406,7 @@ go-libp2p process. For the default definitions see [`DefaultLimits` and
 
 If the defaults seem mostly okay, but you want to adjust one facet you can
 simply copy the default struct object and update the field you want to change. You can
-apply changes to a `BaseLimit`, `BaseLimitIncrease`, and `LimitConfig` with
+apply changes to a `BaseLimit`, `BaseLimitIncrease`, and `ConcreteLimitConfig` with
 `.Apply`.
 
 Example

--- a/p2p/host/resource-manager/README.md
+++ b/p2p/host/resource-manager/README.md
@@ -28,7 +28,7 @@ scalingLimits := rcmgr.DefaultLimits
 // Add limits around included libp2p protocols
 libp2p.SetDefaultServiceLimits(&scalingLimits)
 
-// Turn the scaling limits into a reified set of limits using `.AutoScale`. This
+// Turn the scaling limits into a concrete set of limits using `.AutoScale`. This
 // scales the limits proportional to your system memory.
 scaledDefaultLimits := scalingLimits.AutoScale()
 

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -110,8 +110,8 @@ func valueOrBlockAll64(n int64) LimitVal64 {
 }
 
 // ToResourceLimits converts the BaseLimit to a ResourceLimits
-func (l BaseLimit) ToResourceLimits() ResourceLimits {
-	return ResourceLimits{
+func (l BaseLimit) ToResourceLimits() *ResourceLimits {
+	return &ResourceLimits{
 		Streams:         valueOrBlockAll(l.Streams),
 		StreamsInbound:  valueOrBlockAll(l.StreamsInbound),
 		StreamsOutbound: valueOrBlockAll(l.StreamsOutbound),

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -100,12 +100,16 @@ type BaseLimit struct {
 func valueOrBlockAll(n int) LimitVal {
 	if n == 0 {
 		return BlockAllLimit
+	} else if n == math.MaxInt {
+		return Unlimited
 	}
 	return LimitVal(n)
 }
 func valueOrBlockAll64(n int64) LimitVal64 {
 	if n == 0 {
 		return BlockAllLimit64
+	} else if n == math.MaxInt {
+		return Unlimited64
 	}
 	return LimitVal64(n)
 }

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -231,7 +231,7 @@ func (l *BaseLimitIncrease) Apply(l2 BaseLimitIncrease) {
 	}
 }
 
-func (l *BaseLimit) GetStreamLimit(dir network.Direction) int {
+func (l BaseLimit) GetStreamLimit(dir network.Direction) int {
 	if dir == network.DirInbound {
 		return l.StreamsInbound
 	} else {
@@ -239,11 +239,11 @@ func (l *BaseLimit) GetStreamLimit(dir network.Direction) int {
 	}
 }
 
-func (l *BaseLimit) GetStreamTotalLimit() int {
+func (l BaseLimit) GetStreamTotalLimit() int {
 	return l.Streams
 }
 
-func (l *BaseLimit) GetConnLimit(dir network.Direction) int {
+func (l BaseLimit) GetConnLimit(dir network.Direction) int {
 	if dir == network.DirInbound {
 		return l.ConnsInbound
 	} else {
@@ -251,15 +251,15 @@ func (l *BaseLimit) GetConnLimit(dir network.Direction) int {
 	}
 }
 
-func (l *BaseLimit) GetConnTotalLimit() int {
+func (l BaseLimit) GetConnTotalLimit() int {
 	return l.Conns
 }
 
-func (l *BaseLimit) GetFDLimit() int {
+func (l BaseLimit) GetFDLimit() int {
 	return l.FD
 }
 
-func (l *BaseLimit) GetMemoryLimit() int64 {
+func (l BaseLimit) GetMemoryLimit() int64 {
 	return l.Memory
 }
 

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -114,28 +114,6 @@ func valueOrBlockAll64(n int64) LimitVal64 {
 	return LimitVal64(n)
 }
 
-func limitValFromInt(i int, defaultVal int) LimitVal {
-	if i == defaultVal {
-		return DefaultLimit
-	} else if i == math.MaxInt {
-		return Unlimited
-	} else if i == 0 {
-		return BlockAllLimit
-	}
-	return LimitVal(i)
-}
-
-func limitValFromInt64(i int64, defaultVal int64) LimitVal64 {
-	if i == defaultVal {
-		return DefaultLimit64
-	} else if i == math.MaxInt {
-		return Unlimited64
-	} else if i == 0 {
-		return BlockAllLimit64
-	}
-	return LimitVal64(i)
-}
-
 // ToResourceLimits converts the BaseLimit to a ResourceLimits
 func (l BaseLimit) ToResourceLimits() ResourceLimits {
 	return ResourceLimits{
@@ -147,19 +125,6 @@ func (l BaseLimit) ToResourceLimits() ResourceLimits {
 		ConnsOutbound:   valueOrBlockAll(l.ConnsOutbound),
 		FD:              valueOrBlockAll(l.FD),
 		Memory:          valueOrBlockAll64(l.Memory),
-	}
-}
-
-func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) ResourceLimits {
-	return ResourceLimits{
-		Streams:         limitValFromInt(l.Streams, defaultLimit.Streams),
-		StreamsInbound:  limitValFromInt(l.StreamsInbound, defaultLimit.StreamsInbound),
-		StreamsOutbound: limitValFromInt(l.StreamsOutbound, defaultLimit.StreamsOutbound),
-		Conns:           limitValFromInt(l.Conns, defaultLimit.Conns),
-		ConnsInbound:    limitValFromInt(l.ConnsInbound, defaultLimit.ConnsInbound),
-		ConnsOutbound:   limitValFromInt(l.ConnsOutbound, defaultLimit.ConnsOutbound),
-		FD:              limitValFromInt(l.FD, defaultLimit.FD),
-		Memory:          limitValFromInt64(l.Memory, defaultLimit.Memory),
 	}
 }
 

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -133,8 +133,8 @@ func limitValFromInt64(i int64, defaultVal int64) LimitVal64 {
 }
 
 // ToResourceLimits converts the BaseLimit to a ResourceLimits
-func (l BaseLimit) ToResourceLimits() *ResourceLimits {
-	return &ResourceLimits{
+func (l BaseLimit) ToResourceLimits() ResourceLimits {
+	return ResourceLimits{
 		Streams:         valueOrBlockAll(l.Streams),
 		StreamsInbound:  valueOrBlockAll(l.StreamsInbound),
 		StreamsOutbound: valueOrBlockAll(l.StreamsOutbound),
@@ -146,8 +146,8 @@ func (l BaseLimit) ToResourceLimits() *ResourceLimits {
 	}
 }
 
-func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) *ResourceLimits {
-	out := ResourceLimits{
+func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) ResourceLimits {
+	return ResourceLimits{
 		Streams:         limitValFromInt(l.Streams, defaultLimit.Streams),
 		StreamsInbound:  limitValFromInt(l.StreamsInbound, defaultLimit.StreamsInbound),
 		StreamsOutbound: limitValFromInt(l.StreamsOutbound, defaultLimit.StreamsOutbound),
@@ -157,12 +157,6 @@ func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) *Resource
 		FD:              limitValFromInt(l.FD, defaultLimit.FD),
 		Memory:          limitValFromInt64(l.Memory, defaultLimit.Memory),
 	}
-
-	if out.IsDefault() {
-		return nil
-	}
-
-	return &out
 }
 
 // Apply overwrites all zero-valued limits with the values of l2

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -12,6 +12,7 @@ package rcmgr
 import (
 	"encoding/json"
 	"io"
+	"math"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -109,6 +110,28 @@ func valueOrBlockAll64(n int64) LimitVal64 {
 	return LimitVal64(n)
 }
 
+func limitValFromInt(i int, defaultVal int) LimitVal {
+	if i == defaultVal {
+		return DefaultLimit
+	} else if i == math.MaxInt {
+		return Unlimited
+	} else if i == 0 {
+		return BlockAllLimit
+	}
+	return LimitVal(i)
+}
+
+func limitValFromInt64(i int64, defaultVal int64) LimitVal64 {
+	if i == defaultVal {
+		return DefaultLimit64
+	} else if i == math.MaxInt {
+		return Unlimited64
+	} else if i == 0 {
+		return BlockAllLimit64
+	}
+	return LimitVal64(i)
+}
+
 // ToResourceLimits converts the BaseLimit to a ResourceLimits
 func (l BaseLimit) ToResourceLimits() *ResourceLimits {
 	return &ResourceLimits{
@@ -120,6 +143,19 @@ func (l BaseLimit) ToResourceLimits() *ResourceLimits {
 		ConnsOutbound:   valueOrBlockAll(l.ConnsOutbound),
 		FD:              valueOrBlockAll(l.FD),
 		Memory:          valueOrBlockAll64(l.Memory),
+	}
+}
+
+func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) *ResourceLimits {
+	return &ResourceLimits{
+		Streams:         limitValFromInt(l.Streams, defaultLimit.Streams),
+		StreamsInbound:  limitValFromInt(l.StreamsInbound, defaultLimit.StreamsInbound),
+		StreamsOutbound: limitValFromInt(l.StreamsOutbound, defaultLimit.StreamsOutbound),
+		Conns:           limitValFromInt(l.Conns, defaultLimit.Conns),
+		ConnsInbound:    limitValFromInt(l.ConnsInbound, defaultLimit.ConnsInbound),
+		ConnsOutbound:   limitValFromInt(l.ConnsOutbound, defaultLimit.ConnsOutbound),
+		FD:              limitValFromInt(l.FD, defaultLimit.FD),
+		Memory:          limitValFromInt64(l.Memory, defaultLimit.Memory),
 	}
 }
 

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -52,7 +52,7 @@ type Limiter interface {
 // NewDefaultLimiterFromJSON creates a new limiter by parsing a json configuration,
 // using the default limits for fallback.
 func NewDefaultLimiterFromJSON(in io.Reader) (Limiter, error) {
-	return NewLimiterFromJSON(in, DefaultReifiedLimits)
+	return NewLimiterFromJSON(in, DefaultLimits.AutoScale())
 }
 
 // NewLimiterFromJSON creates a new limiter by parsing a json configuration.

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -158,14 +158,7 @@ func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) *Resource
 		Memory:          limitValFromInt64(l.Memory, defaultLimit.Memory),
 	}
 
-	if out.Streams == DefaultLimit &&
-		out.StreamsInbound == DefaultLimit &&
-		out.StreamsOutbound == DefaultLimit &&
-		out.Conns == DefaultLimit &&
-		out.ConnsInbound == DefaultLimit &&
-		out.ConnsOutbound == DefaultLimit &&
-		out.FD == DefaultLimit &&
-		out.Memory == DefaultLimit64 {
+	if out.IsDefault() {
 		return nil
 	}
 

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -147,7 +147,7 @@ func (l BaseLimit) ToResourceLimits() *ResourceLimits {
 }
 
 func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) *ResourceLimits {
-	return &ResourceLimits{
+	out := ResourceLimits{
 		Streams:         limitValFromInt(l.Streams, defaultLimit.Streams),
 		StreamsInbound:  limitValFromInt(l.StreamsInbound, defaultLimit.StreamsInbound),
 		StreamsOutbound: limitValFromInt(l.StreamsOutbound, defaultLimit.StreamsOutbound),
@@ -157,6 +157,19 @@ func (l BaseLimit) ToResourceLimitsWithDefault(defaultLimit BaseLimit) *Resource
 		FD:              limitValFromInt(l.FD, defaultLimit.FD),
 		Memory:          limitValFromInt64(l.Memory, defaultLimit.Memory),
 	}
+
+	if out.Streams == DefaultLimit &&
+		out.StreamsInbound == DefaultLimit &&
+		out.StreamsOutbound == DefaultLimit &&
+		out.Conns == DefaultLimit &&
+		out.ConnsInbound == DefaultLimit &&
+		out.ConnsOutbound == DefaultLimit &&
+		out.FD == DefaultLimit &&
+		out.Memory == DefaultLimit64 {
+		return nil
+	}
+
+	return &out
 }
 
 // Apply overwrites all zero-valued limits with the values of l2

--- a/p2p/host/resource-manager/limit.go
+++ b/p2p/host/resource-manager/limit.go
@@ -57,7 +57,7 @@ func NewDefaultLimiterFromJSON(in io.Reader) (Limiter, error) {
 }
 
 // NewLimiterFromJSON creates a new limiter by parsing a json configuration.
-func NewLimiterFromJSON(in io.Reader, defaults ReifiedLimitConfig) (Limiter, error) {
+func NewLimiterFromJSON(in io.Reader, defaults ConcreteLimitConfig) (Limiter, error) {
 	cfg, err := readLimiterConfigFromJSON(in, defaults)
 	if err != nil {
 		return nil, err
@@ -65,22 +65,22 @@ func NewLimiterFromJSON(in io.Reader, defaults ReifiedLimitConfig) (Limiter, err
 	return &fixedLimiter{cfg}, nil
 }
 
-func readLimiterConfigFromJSON(in io.Reader, defaults ReifiedLimitConfig) (ReifiedLimitConfig, error) {
-	var cfg LimitConfig
+func readLimiterConfigFromJSON(in io.Reader, defaults ConcreteLimitConfig) (ConcreteLimitConfig, error) {
+	var cfg PartialLimitConfig
 	if err := json.NewDecoder(in).Decode(&cfg); err != nil {
-		return ReifiedLimitConfig{}, err
+		return ConcreteLimitConfig{}, err
 	}
-	return cfg.Reify(defaults), nil
+	return cfg.Build(defaults), nil
 }
 
 // fixedLimiter is a limiter with fixed limits.
 type fixedLimiter struct {
-	ReifiedLimitConfig
+	ConcreteLimitConfig
 }
 
 var _ Limiter = (*fixedLimiter)(nil)
 
-func NewFixedLimiter(conf ReifiedLimitConfig) Limiter {
+func NewFixedLimiter(conf ConcreteLimitConfig) Limiter {
 	log.Debugw("initializing new limiter with config", "limits", conf)
 	return &fixedLimiter{conf}
 }

--- a/p2p/host/resource-manager/limit_config_test.backwards-compat.json
+++ b/p2p/host/resource-manager/limit_config_test.backwards-compat.json
@@ -1,0 +1,45 @@
+{
+    "System": {
+        "Memory": 65536,
+        "Conns": 16,
+        "ConnsInbound": 8,
+        "ConnsOutbound": 16,
+        "FD": 16
+    },
+    "ServiceDefault": {
+        "Memory": 8765
+    },
+    "Service": {
+        "A": {
+            "Memory": 8192
+        },
+        "B": {}
+    },
+    "ServicePeerDefault": {
+        "Memory": 2048
+    },
+    "ServicePeer": {
+        "A": {
+            "Memory": 4096
+        }
+    },
+    "ProtocolDefault": {
+        "Memory": 2048
+    },
+    "ProtocolPeerDefault": {
+        "Memory": 1024
+    },
+    "Protocol": {
+        "/A": {
+            "Memory": 8192
+        }
+    },
+    "PeerDefault": {
+        "Memory": 4096
+    },
+    "Peer": {
+        "12D3KooWPFH2Bx2tPfw6RLxN8k2wh47GRXgkt9yrAHU37zFwHWzS": {
+            "Memory": 4097
+        }
+    }
+}

--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -94,12 +94,12 @@ func TestLimitConfigParser(t *testing.T) {
 	require.Equal(t, int64(4097), cfg.peer[peerID].Memory)
 
 	// Roundtrip
-	limitConfig := cfg.ToLimitConfig()
+	limitConfig := cfg.ToPartialLimitConfig()
 	jsonBytes, err := json.Marshal(&limitConfig)
 	require.NoError(t, err)
 	cfgAfterRoundTrip, err := readLimiterConfigFromJSON(bytes.NewReader(jsonBytes), defaults)
 	require.NoError(t, err)
-	require.Equal(t, limitConfig, cfgAfterRoundTrip.ToLimitConfig())
+	require.Equal(t, limitConfig, cfgAfterRoundTrip.ToPartialLimitConfig())
 }
 
 func TestLimitConfigRoundTrip(t *testing.T) {
@@ -115,7 +115,7 @@ func TestLimitConfigRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Roundtrip
-	limitConfig := concreteCfg.ToLimitConfig()
+	limitConfig := concreteCfg.ToPartialLimitConfig()
 	// Using InfiniteLimits because it's different then the defaults used above.
 	// If anything was marked "default" in the round trip, it would show up as a
 	// difference here.

--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -111,16 +111,16 @@ func TestLimitConfigRoundTrip(t *testing.T) {
 	defaults := DefaultLimits
 	defaults.AddServiceLimit("C", DefaultLimits.ServiceBaseLimit, BaseLimitIncrease{})
 	defaults.AddProtocolPeerLimit("C", DefaultLimits.ServiceBaseLimit, BaseLimitIncrease{})
-	reifiedCfg, err := readLimiterConfigFromJSON(in, defaults.AutoScale())
+	concreteCfg, err := readLimiterConfigFromJSON(in, defaults.AutoScale())
 	require.NoError(t, err)
 
 	// Roundtrip
-	limitConfig := reifiedCfg.ToLimitConfig()
+	limitConfig := concreteCfg.ToLimitConfig()
 	// Using InfiniteLimits because it's different then the defaults used above.
 	// If anything was marked "default" in the round trip, it would show up as a
 	// difference here.
-	reifiedCfgRT := limitConfig.Build(InfiniteLimits)
-	require.Equal(t, reifiedCfg, reifiedCfgRT)
+	concreteCfgRT := limitConfig.Build(InfiniteLimits)
+	require.Equal(t, concreteCfg, concreteCfgRT)
 }
 
 func TestReadmeLimitConfigSerialization(t *testing.T) {

--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -103,7 +103,7 @@ func TestLimitConfigParser(t *testing.T) {
 }
 
 func TestLimitConfigRoundTrip(t *testing.T) {
-	// Tests that we can roundtrip a LimitConfig to a ReifiedLimitConfig and back.
+	// Tests that we can roundtrip a PartialLimitConfig to a ConcreteLimitConfig and back.
 	in, err := os.Open("limit_config_test.json")
 	require.NoError(t, err)
 	defer in.Close()
@@ -119,13 +119,13 @@ func TestLimitConfigRoundTrip(t *testing.T) {
 	// Using InfiniteLimits because it's different then the defaults used above.
 	// If anything was marked "default" in the round trip, it would show up as a
 	// difference here.
-	reifiedCfgRT := limitConfig.Reify(InfiniteLimits)
+	reifiedCfgRT := limitConfig.Build(InfiniteLimits)
 	require.Equal(t, reifiedCfg, reifiedCfgRT)
 }
 
 func TestReadmeLimitConfigSerialization(t *testing.T) {
 	noisyNeighbor, _ := peer.Decode("QmVvtzcZgCkMnSFf2dnrBPXrWuNFWNM9J3MpZQCvWPuVZf")
-	cfg := LimitConfig{
+	cfg := PartialLimitConfig{
 		System: &ResourceLimits{
 			// Allow unlimited outbound streams
 			StreamsOutbound: Unlimited,

--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -17,6 +17,43 @@ func withMemoryLimit(l BaseLimit, m int64) BaseLimit {
 	return l2
 }
 
+func TestLimitConfigParserBackwardsCompat(t *testing.T) {
+	in, err := os.Open("limit_config_test.json")
+	require.NoError(t, err)
+	defer in.Close()
+
+	DefaultLimits.AddServiceLimit("C", DefaultLimits.ServiceBaseLimit, BaseLimitIncrease{})
+	DefaultLimits.AddProtocolPeerLimit("C", DefaultLimits.ServiceBaseLimit, BaseLimitIncrease{})
+	defaults := DefaultLimits.AutoScale()
+	cfg, err := readLimiterConfigFromJSON(in, defaults)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(65536), cfg.system.Memory)
+	require.Equal(t, defaults.system.Streams, cfg.system.Streams)
+	require.Equal(t, defaults.system.StreamsInbound, cfg.system.StreamsInbound)
+	require.Equal(t, defaults.system.StreamsOutbound, cfg.system.StreamsOutbound)
+	require.Equal(t, 16, cfg.system.Conns)
+	require.Equal(t, 8, cfg.system.ConnsInbound)
+	require.Equal(t, 16, cfg.system.ConnsOutbound)
+	require.Equal(t, 16, cfg.system.FD)
+
+	require.Equal(t, defaults.transient, cfg.transient)
+	require.Equal(t, int64(8765), cfg.serviceDefault.Memory)
+
+	require.Contains(t, cfg.service, "A")
+	require.Equal(t, withMemoryLimit(cfg.serviceDefault, 8192), cfg.service["A"])
+	require.Contains(t, cfg.service, "B")
+	require.Equal(t, cfg.serviceDefault, cfg.service["B"])
+	require.Contains(t, cfg.service, "C")
+	require.Equal(t, defaults.service["C"], cfg.service["C"])
+
+	require.Equal(t, int64(4096), cfg.peerDefault.Memory)
+	peerID, err := peer.Decode("12D3KooWPFH2Bx2tPfw6RLxN8k2wh47GRXgkt9yrAHU37zFwHWzS")
+	require.NoError(t, err)
+	require.Contains(t, cfg.peer, peerID)
+	require.Equal(t, int64(4097), cfg.peer[peerID].Memory)
+}
+
 func TestLimitConfigParser(t *testing.T) {
 	in, err := os.Open("limit_config_test.json")
 	require.NoError(t, err)
@@ -28,33 +65,34 @@ func TestLimitConfigParser(t *testing.T) {
 	cfg, err := readLimiterConfigFromJSON(in, defaults)
 	require.NoError(t, err)
 
-	require.Equal(t, int64(65536), cfg.System.Memory)
-	require.Equal(t, defaults.System.Streams, cfg.System.Streams)
-	require.Equal(t, defaults.System.StreamsInbound, cfg.System.StreamsInbound)
-	require.Equal(t, defaults.System.StreamsOutbound, cfg.System.StreamsOutbound)
-	require.Equal(t, 16, cfg.System.Conns)
-	require.Equal(t, 8, cfg.System.ConnsInbound)
-	require.Equal(t, 16, cfg.System.ConnsOutbound)
-	require.Equal(t, 16, cfg.System.FD)
+	require.Equal(t, int64(65536), cfg.system.Memory)
+	require.Equal(t, defaults.system.Streams, cfg.system.Streams)
+	require.Equal(t, defaults.system.StreamsInbound, cfg.system.StreamsInbound)
+	require.Equal(t, defaults.system.StreamsOutbound, cfg.system.StreamsOutbound)
+	require.Equal(t, 16, cfg.system.Conns)
+	require.Equal(t, 8, cfg.system.ConnsInbound)
+	require.Equal(t, 16, cfg.system.ConnsOutbound)
+	require.Equal(t, 16, cfg.system.FD)
 
-	require.Equal(t, defaults.Transient, cfg.Transient)
-	require.Equal(t, int64(8765), cfg.ServiceDefault.Memory)
+	require.Equal(t, defaults.transient, cfg.transient)
+	require.Equal(t, int64(8765), cfg.serviceDefault.Memory)
 
-	require.Contains(t, cfg.Service, "A")
-	require.Equal(t, withMemoryLimit(cfg.ServiceDefault, 8192), cfg.Service["A"])
-	require.Contains(t, cfg.Service, "B")
-	require.Equal(t, cfg.ServiceDefault, cfg.Service["B"])
-	require.Contains(t, cfg.Service, "C")
-	require.Equal(t, defaults.Service["C"], cfg.Service["C"])
+	require.Contains(t, cfg.service, "A")
+	require.Equal(t, withMemoryLimit(cfg.serviceDefault, 8192), cfg.service["A"])
+	require.Contains(t, cfg.service, "B")
+	require.Equal(t, cfg.serviceDefault, cfg.service["B"])
+	require.Contains(t, cfg.service, "C")
+	require.Equal(t, defaults.service["C"], cfg.service["C"])
 
-	require.Equal(t, int64(4096), cfg.PeerDefault.Memory)
+	require.Equal(t, int64(4096), cfg.peerDefault.Memory)
 	peerID, err := peer.Decode("12D3KooWPFH2Bx2tPfw6RLxN8k2wh47GRXgkt9yrAHU37zFwHWzS")
 	require.NoError(t, err)
-	require.Contains(t, cfg.Peer, peerID)
-	require.Equal(t, int64(4097), cfg.Peer[peerID].Memory)
+	require.Contains(t, cfg.peer, peerID)
+	require.Equal(t, int64(4097), cfg.peer[peerID].Memory)
 
 	// Roundtrip
-	jsonBytes, err := json.Marshal(&cfg)
+	limitConfig := FromReifiedLimitConfig(cfg, defaults)
+	jsonBytes, err := json.Marshal(&limitConfig)
 	require.NoError(t, err)
 	cfgAfterRoundTrip, err := readLimiterConfigFromJSON(bytes.NewReader(jsonBytes), defaults)
 	require.NoError(t, err)

--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -94,12 +94,12 @@ func TestLimitConfigParser(t *testing.T) {
 	require.Equal(t, int64(4097), cfg.peer[peerID].Memory)
 
 	// Roundtrip
-	limitConfig := cfg.ToLimitConfigWithDefaults(defaults)
+	limitConfig := cfg.ToLimitConfig()
 	jsonBytes, err := json.Marshal(&limitConfig)
 	require.NoError(t, err)
 	cfgAfterRoundTrip, err := readLimiterConfigFromJSON(bytes.NewReader(jsonBytes), defaults)
 	require.NoError(t, err)
-	require.Equal(t, cfg, cfgAfterRoundTrip)
+	require.Equal(t, limitConfig, cfgAfterRoundTrip.ToLimitConfig())
 }
 
 func TestLimitConfigRoundTrip(t *testing.T) {

--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -126,7 +126,7 @@ func TestLimitConfigRoundTrip(t *testing.T) {
 func TestReadmeLimitConfigSerialization(t *testing.T) {
 	noisyNeighbor, _ := peer.Decode("QmVvtzcZgCkMnSFf2dnrBPXrWuNFWNM9J3MpZQCvWPuVZf")
 	cfg := PartialLimitConfig{
-		System: &ResourceLimits{
+		System: ResourceLimits{
 			// Allow unlimited outbound streams
 			StreamsOutbound: Unlimited,
 		},
@@ -146,5 +146,5 @@ func TestReadmeLimitConfigSerialization(t *testing.T) {
 	}
 	jsonBytes, err := json.Marshal(&cfg)
 	require.NoError(t, err)
-	require.Equal(t, `{"System":{"StreamsOutbound":"unlimited"},"Peer":{"QmVvtzcZgCkMnSFf2dnrBPXrWuNFWNM9J3MpZQCvWPuVZf":{"StreamsInbound":"blockAll","StreamsOutbound":"unlimited","ConnsInbound":"blockAll"}}}`, string(jsonBytes))
+	require.Equal(t, `{"Peer":{"QmVvtzcZgCkMnSFf2dnrBPXrWuNFWNM9J3MpZQCvWPuVZf":{"StreamsInbound":"blockAll","StreamsOutbound":"unlimited","ConnsInbound":"blockAll"}},"System":{"StreamsOutbound":"unlimited"}}`, string(jsonBytes))
 }

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -148,6 +148,12 @@ func (l *LimitVal) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &val); err != nil {
 		return err
 	}
+
+	if val == 0 {
+		// If there is an explicit 0 in the JSON we should interpret this as block all.
+		*l = BlockAllLimit
+	}
+
 	*l = LimitVal(val)
 	return nil
 }
@@ -576,7 +582,7 @@ func resourceLimitsMapFromBaseLimitMap[K comparable](baseLimitMap map[K]BaseLimi
 	return out
 }
 
-// ToLimitConfig converts a ReifiedLimitConfig to a PartialLimitConfig. The returned
+// ToLimitConfig converts a ConcreteLimitConfig to a PartialLimitConfig. The returned
 // PartialLimitConfig will have no default values.
 func (cfg ConcreteLimitConfig) ToLimitConfig() PartialLimitConfig {
 	return PartialLimitConfig{

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -553,9 +553,9 @@ func resourceLimitsMapFromBaseLimitMap[K comparable](baseLimitMap map[K]BaseLimi
 	return out
 }
 
-// ToLimitConfig converts a ConcreteLimitConfig to a PartialLimitConfig. The returned
-// PartialLimitConfig will have no default values.
-func (cfg ConcreteLimitConfig) ToLimitConfig() PartialLimitConfig {
+// ToPartialLimitConfig converts a ConcreteLimitConfig to a PartialLimitConfig.
+// The returned PartialLimitConfig will have no default values.
+func (cfg ConcreteLimitConfig) ToPartialLimitConfig() PartialLimitConfig {
 	return PartialLimitConfig{
 		System:               cfg.system.ToResourceLimits(),
 		Transient:            cfg.transient.ToResourceLimits(),

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -333,47 +333,12 @@ func resourceLimitsMapFromBaseLimitMapWithDefaults[K comparable](m map[K]BaseLim
 	out := make(map[K]ResourceLimits, len(m))
 	for k, v := range m {
 		if defaultForKey, ok := defaultLimits[k]; ok {
-			out[k] = *resourceLimitsFromBaseLimit(v, defaultForKey)
+			out[k] = *v.ToResourceLimitsWithDefault(defaultForKey)
 		} else {
-			out[k] = *resourceLimitsFromBaseLimit(v, fallbackDefault)
+			out[k] = *v.ToResourceLimitsWithDefault(fallbackDefault)
 		}
 	}
 	return out
-}
-
-func resourceLimitsFromBaseLimit(l BaseLimit, defaultLimit BaseLimit) *ResourceLimits {
-	return &ResourceLimits{
-		Streams:         limitValFromInt(l.Streams, defaultLimit.Streams),
-		StreamsInbound:  limitValFromInt(l.StreamsInbound, defaultLimit.StreamsInbound),
-		StreamsOutbound: limitValFromInt(l.StreamsOutbound, defaultLimit.StreamsOutbound),
-		Conns:           limitValFromInt(l.Conns, defaultLimit.Conns),
-		ConnsInbound:    limitValFromInt(l.ConnsInbound, defaultLimit.ConnsInbound),
-		ConnsOutbound:   limitValFromInt(l.ConnsOutbound, defaultLimit.ConnsOutbound),
-		FD:              limitValFromInt(l.FD, defaultLimit.FD),
-		Memory:          limitValFromInt64(l.Memory, defaultLimit.Memory),
-	}
-}
-
-func limitValFromInt(i int, defaultVal int) LimitVal {
-	if i == defaultVal {
-		return DefaultLimit
-	} else if i == math.MaxInt {
-		return Unlimited
-	} else if i == 0 {
-		return BlockAllLimit
-	}
-	return LimitVal(i)
-}
-
-func limitValFromInt64(i int64, defaultVal int64) LimitVal64 {
-	if i == defaultVal {
-		return DefaultLimit64
-	} else if i == math.MaxInt {
-		return Unlimited64
-	} else if i == 0 {
-		return BlockAllLimit64
-	}
-	return LimitVal64(i)
 }
 
 func (cfg *LimitConfig) MarshalJSON() ([]byte, error) {
@@ -516,29 +481,29 @@ type ReifiedLimitConfig struct {
 func (cfg ReifiedLimitConfig) ToLimitConfigWithDefaults(defaults ReifiedLimitConfig) LimitConfig {
 	out := LimitConfig{}
 
-	out.System = resourceLimitsFromBaseLimit(cfg.system, defaults.system)
-	out.Transient = resourceLimitsFromBaseLimit(cfg.transient, defaults.transient)
+	out.System = cfg.system.ToResourceLimitsWithDefault(defaults.system)
+	out.Transient = cfg.transient.ToResourceLimitsWithDefault(defaults.transient)
 
-	out.AllowlistedSystem = resourceLimitsFromBaseLimit(cfg.allowlistedSystem, defaults.allowlistedSystem)
-	out.AllowlistedTransient = resourceLimitsFromBaseLimit(cfg.allowlistedTransient, defaults.allowlistedTransient)
+	out.AllowlistedSystem = cfg.allowlistedSystem.ToResourceLimitsWithDefault(defaults.allowlistedSystem)
+	out.AllowlistedTransient = cfg.allowlistedTransient.ToResourceLimitsWithDefault(defaults.allowlistedTransient)
 
-	out.ServiceDefault = resourceLimitsFromBaseLimit(cfg.serviceDefault, defaults.serviceDefault)
+	out.ServiceDefault = cfg.serviceDefault.ToResourceLimitsWithDefault(defaults.serviceDefault)
 	out.Service = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.service, defaults.service, defaults.serviceDefault)
 
-	out.ServicePeerDefault = resourceLimitsFromBaseLimit(cfg.servicePeerDefault, defaults.servicePeerDefault)
+	out.ServicePeerDefault = cfg.servicePeerDefault.ToResourceLimitsWithDefault(defaults.servicePeerDefault)
 	out.ServicePeer = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.servicePeer, defaults.servicePeer, defaults.servicePeerDefault)
 
-	out.ProtocolDefault = resourceLimitsFromBaseLimit(cfg.protocolDefault, defaults.protocolDefault)
+	out.ProtocolDefault = cfg.protocolDefault.ToResourceLimitsWithDefault(defaults.protocolDefault)
 	out.Protocol = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.protocol, defaults.protocol, defaults.protocolDefault)
 
-	out.ProtocolPeerDefault = resourceLimitsFromBaseLimit(cfg.protocolPeerDefault, defaults.protocolPeerDefault)
+	out.ProtocolPeerDefault = cfg.protocolPeerDefault.ToResourceLimitsWithDefault(defaults.protocolPeerDefault)
 	out.ProtocolPeer = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.protocolPeer, defaults.protocolPeer, defaults.protocolPeerDefault)
 
-	out.PeerDefault = resourceLimitsFromBaseLimit(cfg.peerDefault, defaults.peerDefault)
+	out.PeerDefault = cfg.peerDefault.ToResourceLimitsWithDefault(defaults.peerDefault)
 	out.Peer = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.peer, defaults.peer, defaults.peerDefault)
 
-	out.Conn = resourceLimitsFromBaseLimit(cfg.conn, defaults.conn)
-	out.Stream = resourceLimitsFromBaseLimit(cfg.stream, defaults.stream)
+	out.Conn = cfg.conn.ToResourceLimitsWithDefault(defaults.conn)
+	out.Stream = cfg.stream.ToResourceLimitsWithDefault(defaults.stream)
 
 	return out
 }

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -157,7 +157,7 @@ func (l LimitVal) Reify(defaultVal int) int {
 		return defaultVal
 	}
 	if l == Unlimited {
-		return math.MaxInt32
+		return math.MaxInt
 	}
 	if l == BlockAllLimit {
 		return 0
@@ -227,7 +227,7 @@ func (l LimitVal64) Reify(defaultVal int64) int64 {
 		return defaultVal
 	}
 	if l == Unlimited64 {
-		return math.MaxInt32
+		return math.MaxInt64
 	}
 	if l == BlockAllLimit64 {
 		return 0

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -503,7 +503,7 @@ func reifyMapWithDefault[K comparable](definedLimits map[K]ResourceLimits, defau
 
 // ReifiedLimitConfig is similar to LimitConfig, but all values are defined.
 // There is no unset "default" value. Commonly constructed by calling
-// LimitConfig.Reify(DefaultReifiedLimits)
+// LimitConfig.Reify(rcmgr.DefaultLimits.AutoScale())
 type ReifiedLimitConfig struct {
 	system    BaseLimit
 	transient BaseLimit
@@ -618,8 +618,6 @@ func scale(base BaseLimit, inc BaseLimitIncrease, memory int64, numFD int) BaseL
 	}
 	return l
 }
-
-var DefaultReifiedLimits = DefaultLimits.AutoScale()
 
 // DefaultLimits are the limits used by the default limiter constructors.
 var DefaultLimits = ScalingLimitConfig{

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 
@@ -319,22 +320,30 @@ func (l *ResourceLimits) Apply(l2 ResourceLimits) {
 	}
 }
 
-func (l *ResourceLimits) Build(defaults BaseLimit) BaseLimit {
+func (l *ResourceLimits) Build(defaults Limit) BaseLimit {
 	if l == nil {
-		return defaults
+		return BaseLimit{
+			Streams:         defaults.GetStreamTotalLimit(),
+			StreamsInbound:  defaults.GetStreamLimit(network.DirInbound),
+			StreamsOutbound: defaults.GetStreamLimit(network.DirOutbound),
+			Conns:           defaults.GetConnTotalLimit(),
+			ConnsInbound:    defaults.GetConnLimit(network.DirInbound),
+			ConnsOutbound:   defaults.GetConnLimit(network.DirOutbound),
+			FD:              defaults.GetFDLimit(),
+			Memory:          defaults.GetMemoryLimit(),
+		}
 	}
 
-	out := defaults
-	out.Streams = l.Streams.Build(defaults.Streams)
-	out.StreamsInbound = l.StreamsInbound.Build(defaults.StreamsInbound)
-	out.StreamsOutbound = l.StreamsOutbound.Build(defaults.StreamsOutbound)
-	out.Conns = l.Conns.Build(defaults.Conns)
-	out.ConnsInbound = l.ConnsInbound.Build(defaults.ConnsInbound)
-	out.ConnsOutbound = l.ConnsOutbound.Build(defaults.ConnsOutbound)
-	out.FD = l.FD.Build(defaults.FD)
-	out.Memory = l.Memory.Build(defaults.Memory)
-
-	return out
+	return BaseLimit{
+		Streams:         l.Streams.Build(defaults.GetStreamTotalLimit()),
+		StreamsInbound:  l.StreamsInbound.Build(defaults.GetStreamLimit(network.DirInbound)),
+		StreamsOutbound: l.StreamsOutbound.Build(defaults.GetStreamLimit(network.DirOutbound)),
+		Conns:           l.Conns.Build(defaults.GetConnTotalLimit()),
+		ConnsInbound:    l.ConnsInbound.Build(defaults.GetConnLimit(network.DirInbound)),
+		ConnsOutbound:   l.ConnsOutbound.Build(defaults.GetConnLimit(network.DirOutbound)),
+		FD:              l.FD.Build(defaults.GetFDLimit()),
+		Memory:          l.Memory.Build(defaults.GetMemoryLimit()),
+	}
 }
 
 type PartialLimitConfig struct {

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -247,6 +247,24 @@ type ResourceLimits struct {
 	Memory          LimitVal64 `json:",omitempty"`
 }
 
+func (l *ResourceLimits) IsDefault() bool {
+	if l == nil {
+		return true
+	}
+
+	if l.Streams == DefaultLimit &&
+		l.StreamsInbound == DefaultLimit &&
+		l.StreamsOutbound == DefaultLimit &&
+		l.Conns == DefaultLimit &&
+		l.ConnsInbound == DefaultLimit &&
+		l.ConnsOutbound == DefaultLimit &&
+		l.FD == DefaultLimit &&
+		l.Memory == DefaultLimit64 {
+		return true
+	}
+	return false
+}
+
 // Apply overwrites all default limits with the values of l2
 func (l *ResourceLimits) Apply(l2 *ResourceLimits) {
 	if l2 == nil {

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -332,10 +332,13 @@ func resourceLimitsMapFromBaseLimitMapWithDefaults[K comparable](m map[K]BaseLim
 
 	out := make(map[K]ResourceLimits, len(m))
 	for k, v := range m {
+		def := fallbackDefault
 		if defaultForKey, ok := defaultLimits[k]; ok {
-			out[k] = *v.ToResourceLimitsWithDefault(defaultForKey)
-		} else {
-			out[k] = *v.ToResourceLimitsWithDefault(fallbackDefault)
+			def = defaultForKey
+		}
+		rl := v.ToResourceLimitsWithDefault(def)
+		if rl != nil {
+			out[k] = *rl
 		}
 	}
 	return out

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -279,6 +279,10 @@ func (l *ResourceLimits) Apply(l2 *ResourceLimits) {
 }
 
 func (l *ResourceLimits) Reify(defaults BaseLimit) BaseLimit {
+	if l == nil {
+		return defaults
+	}
+
 	out := defaults
 	out.Streams = l.Streams.Reify(defaults.Streams)
 	out.StreamsInbound = l.StreamsInbound.Reify(defaults.StreamsInbound)

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -152,6 +152,7 @@ func (l *LimitVal) UnmarshalJSON(b []byte) error {
 	if val == 0 {
 		// If there is an explicit 0 in the JSON we should interpret this as block all.
 		*l = BlockAllLimit
+		return nil
 	}
 
 	*l = LimitVal(val)
@@ -215,6 +216,12 @@ func (l *LimitVal64) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("failed to unmarshal limit value: %w", err)
 		}
 
+		if val == 0 {
+			// If there is an explicit 0 in the JSON we should interpret this as block all.
+			*l = BlockAllLimit64
+			return nil
+		}
+
 		*l = LimitVal64(val)
 		return nil
 	}
@@ -223,8 +230,14 @@ func (l *LimitVal64) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	*l = LimitVal64(i)
 
+	if i == 0 {
+		// If there is an explicit 0 in the JSON we should interpret this as block all.
+		*l = BlockAllLimit64
+		return nil
+	}
+
+	*l = LimitVal64(i)
 	return nil
 }
 

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -375,23 +375,6 @@ type PartialLimitConfig struct {
 	Stream ResourceLimits `json:",omitempty"`
 }
 
-func resourceLimitsMapFromBaseLimitMapWithDefaults[K comparable](m map[K]BaseLimit, defaultLimits map[K]BaseLimit, fallbackDefault BaseLimit) map[K]ResourceLimits {
-	if len(m) == 0 {
-		return nil
-	}
-
-	out := make(map[K]ResourceLimits, len(m))
-	for k, v := range m {
-		def := fallbackDefault
-		if defaultForKey, ok := defaultLimits[k]; ok {
-			def = defaultForKey
-		}
-		rl := v.ToResourceLimitsWithDefault(def)
-		out[k] = rl
-	}
-	return out
-}
-
 func (cfg *PartialLimitConfig) MarshalJSON() ([]byte, error) {
 	// we want to marshal the encoded peer id
 	encodedPeerMap := make(map[string]ResourceLimits, len(cfg.Peer))
@@ -555,40 +538,6 @@ type ConcreteLimitConfig struct {
 
 	conn   BaseLimit
 	stream BaseLimit
-}
-
-// ToLimitConfigWithDefaults converts a ConcreteLimitConfig to a PartialLimitConfig.
-// Uses the defaults config to know what was specifically set and what was left
-// as default. Returns a minimal PartialLimitConfig. Build the returned PartialLimitConfig
-// with the defaults to get back to the original ConcreteLimitConfig.
-func (cfg ConcreteLimitConfig) ToLimitConfigWithDefaults(defaults ConcreteLimitConfig) PartialLimitConfig {
-	out := PartialLimitConfig{}
-
-	out.System = cfg.system.ToResourceLimitsWithDefault(defaults.system)
-	out.Transient = cfg.transient.ToResourceLimitsWithDefault(defaults.transient)
-
-	out.AllowlistedSystem = cfg.allowlistedSystem.ToResourceLimitsWithDefault(defaults.allowlistedSystem)
-	out.AllowlistedTransient = cfg.allowlistedTransient.ToResourceLimitsWithDefault(defaults.allowlistedTransient)
-
-	out.ServiceDefault = cfg.serviceDefault.ToResourceLimitsWithDefault(defaults.serviceDefault)
-	out.Service = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.service, defaults.service, defaults.serviceDefault)
-
-	out.ServicePeerDefault = cfg.servicePeerDefault.ToResourceLimitsWithDefault(defaults.servicePeerDefault)
-	out.ServicePeer = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.servicePeer, defaults.servicePeer, defaults.servicePeerDefault)
-
-	out.ProtocolDefault = cfg.protocolDefault.ToResourceLimitsWithDefault(defaults.protocolDefault)
-	out.Protocol = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.protocol, defaults.protocol, defaults.protocolDefault)
-
-	out.ProtocolPeerDefault = cfg.protocolPeerDefault.ToResourceLimitsWithDefault(defaults.protocolPeerDefault)
-	out.ProtocolPeer = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.protocolPeer, defaults.protocolPeer, defaults.protocolPeerDefault)
-
-	out.PeerDefault = cfg.peerDefault.ToResourceLimitsWithDefault(defaults.peerDefault)
-	out.Peer = resourceLimitsMapFromBaseLimitMapWithDefaults(cfg.peer, defaults.peer, defaults.peerDefault)
-
-	out.Conn = cfg.conn.ToResourceLimitsWithDefault(defaults.conn)
-	out.Stream = cfg.stream.ToResourceLimitsWithDefault(defaults.stream)
-
-	return out
 }
 
 func resourceLimitsMapFromBaseLimitMap[K comparable](baseLimitMap map[K]BaseLimit) map[K]ResourceLimits {

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -187,12 +187,12 @@ func TestJSONRoundTripInt64(t *testing.T) {
 
 func TestRoundTripFromConcreteAndBack(t *testing.T) {
 	l := PartialLimitConfig{
-		System: &ResourceLimits{
+		System: ResourceLimits{
 			Conns:  1234,
 			Memory: 54321,
 		},
 
-		ServiceDefault: &ResourceLimits{
+		ServiceDefault: ResourceLimits{
 			Conns: 2,
 		},
 

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -2,6 +2,7 @@ package rcmgr
 
 import (
 	"encoding/json"
+	"math"
 	"runtime"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestScaling(t *testing.T) {
 	t.Run("no scaling if no increase is defined", func(t *testing.T) {
 		cfg := ScalingLimitConfig{ServiceBaseLimit: base}
 		scaled := cfg.Scale(8<<30, 100)
-		require.Equal(t, base, scaled.ServiceDefault)
+		require.Equal(t, base, scaled.serviceDefault)
 	})
 
 	t.Run("scaling", func(t *testing.T) {
@@ -50,14 +51,14 @@ func TestScaling(t *testing.T) {
 			},
 		}
 		scaled := cfg.Scale(128<<20+4<<30, 1000)
-		require.Equal(t, 500, scaled.Transient.FD)
-		require.Equal(t, base.Streams+4, scaled.Transient.Streams)
-		require.Equal(t, base.StreamsInbound+4*2, scaled.Transient.StreamsInbound)
-		require.Equal(t, base.StreamsOutbound+4*3, scaled.Transient.StreamsOutbound)
-		require.Equal(t, base.Conns+4*4, scaled.Transient.Conns)
-		require.Equal(t, base.ConnsInbound+4*5, scaled.Transient.ConnsInbound)
-		require.Equal(t, base.ConnsOutbound+4*6, scaled.Transient.ConnsOutbound)
-		require.Equal(t, base.Memory+4*7, scaled.Transient.Memory)
+		require.Equal(t, 500, scaled.transient.FD)
+		require.Equal(t, base.Streams+4, scaled.transient.Streams)
+		require.Equal(t, base.StreamsInbound+4*2, scaled.transient.StreamsInbound)
+		require.Equal(t, base.StreamsOutbound+4*3, scaled.transient.StreamsOutbound)
+		require.Equal(t, base.Conns+4*4, scaled.transient.Conns)
+		require.Equal(t, base.ConnsInbound+4*5, scaled.transient.ConnsInbound)
+		require.Equal(t, base.ConnsOutbound+4*6, scaled.transient.ConnsOutbound)
+		require.Equal(t, base.Memory+4*7, scaled.transient.Memory)
 	})
 
 	t.Run("scaling and using the base amounts", func(t *testing.T) {
@@ -75,14 +76,14 @@ func TestScaling(t *testing.T) {
 			},
 		}
 		scaled := cfg.Scale(1, 10)
-		require.Equal(t, 1, scaled.Transient.FD)
-		require.Equal(t, base.Streams, scaled.Transient.Streams)
-		require.Equal(t, base.StreamsInbound, scaled.Transient.StreamsInbound)
-		require.Equal(t, base.StreamsOutbound, scaled.Transient.StreamsOutbound)
-		require.Equal(t, base.Conns, scaled.Transient.Conns)
-		require.Equal(t, base.ConnsInbound, scaled.Transient.ConnsInbound)
-		require.Equal(t, base.ConnsOutbound, scaled.Transient.ConnsOutbound)
-		require.Equal(t, base.Memory, scaled.Transient.Memory)
+		require.Equal(t, 1, scaled.transient.FD)
+		require.Equal(t, base.Streams, scaled.transient.Streams)
+		require.Equal(t, base.StreamsInbound, scaled.transient.StreamsInbound)
+		require.Equal(t, base.StreamsOutbound, scaled.transient.StreamsOutbound)
+		require.Equal(t, base.Conns, scaled.transient.Conns)
+		require.Equal(t, base.ConnsInbound, scaled.transient.ConnsInbound)
+		require.Equal(t, base.ConnsOutbound, scaled.transient.ConnsOutbound)
+		require.Equal(t, base.Memory, scaled.transient.Memory)
 	})
 
 	t.Run("scaling limits in maps", func(t *testing.T) {
@@ -99,16 +100,16 @@ func TestScaling(t *testing.T) {
 		}
 		scaled := cfg.Scale(128<<20+4<<30, 1000)
 
-		require.Len(t, scaled.Service, 2)
-		require.Contains(t, scaled.Service, "A")
-		require.Equal(t, 10, scaled.Service["A"].Streams)
-		require.Equal(t, int64(100), scaled.Service["A"].Memory)
-		require.Equal(t, 9, scaled.Service["A"].FD)
+		require.Len(t, scaled.service, 2)
+		require.Contains(t, scaled.service, "A")
+		require.Equal(t, 10, scaled.service["A"].Streams)
+		require.Equal(t, int64(100), scaled.service["A"].Memory)
+		require.Equal(t, 9, scaled.service["A"].FD)
 
-		require.Contains(t, scaled.Service, "B")
-		require.Equal(t, 20+4*2, scaled.Service["B"].Streams)
-		require.Equal(t, int64(200+4*3), scaled.Service["B"].Memory)
-		require.Equal(t, 400, scaled.Service["B"].FD)
+		require.Contains(t, scaled.service, "B")
+		require.Equal(t, 20+4*2, scaled.service["B"].Streams)
+		require.Equal(t, int64(200+4*3), scaled.service["B"].Memory)
+		require.Equal(t, 400, scaled.service["B"].FD)
 
 	})
 }
@@ -139,8 +140,75 @@ func TestReadmeExample(t *testing.T) {
 
 	limitConf := scalingLimits.Scale(4<<30, 1000)
 
-	require.Equal(t, 384, limitConf.System.Conns)
-	require.Equal(t, 1000, limitConf.System.FD)
+	require.Equal(t, 384, limitConf.system.Conns)
+	require.Equal(t, 1000, limitConf.system.FD)
+}
+
+func TestJSONMarshalling(t *testing.T) {
+	bl := ResourceLimits{
+		Streams:         DefaultLimit,
+		StreamsInbound:  10,
+		StreamsOutbound: 10,
+		Conns:           10,
+		// ConnsInbound:    DefaultLimit,
+		ConnsOutbound: Unlimited,
+		Memory:        Unlimited64,
+	}
+
+	jsonEncoded, err := json.Marshal(bl)
+	require.NoError(t, err)
+
+	require.Equal(t, string(jsonEncoded), `{"StreamsInbound":10,"StreamsOutbound":10,"Conns":10,"ConnsOutbound":"unlimited","Memory":"unlimited"}`)
+
+	// Roundtrip
+	var blDecoded ResourceLimits
+	err = json.Unmarshal(jsonEncoded, &blDecoded)
+	require.NoError(t, err)
+
+	require.Equal(t, bl, blDecoded)
+}
+
+func TestJSONRoundTripInt64(t *testing.T) {
+	bl := ResourceLimits{
+		Memory: math.MaxInt64,
+	}
+
+	jsonEncoded, err := json.Marshal(bl)
+	require.NoError(t, err)
+
+	require.Equal(t, string(jsonEncoded), `{"Memory":"9223372036854775807"}`)
+
+	// Roundtrip
+	var blDecoded ResourceLimits
+	err = json.Unmarshal(jsonEncoded, &blDecoded)
+	require.NoError(t, err)
+
+	require.Equal(t, bl, blDecoded)
+}
+
+func TestRoundTripFromReifyAndBack(t *testing.T) {
+	l := LimitConfig{
+		System: ResourceLimits{
+			Conns:  1234,
+			Memory: 54321,
+		},
+
+		ServiceDefault: ResourceLimits{
+			Conns: 2,
+		},
+
+		Service: map[string]ResourceLimits{
+			"foo": {
+				Conns: 3,
+			},
+		},
+	}
+
+	reified := l.Reify(InfiniteLimits)
+
+	// Roundtrip
+	fromReified := FromReifiedLimitConfig(reified, InfiniteLimits)
+	require.Equal(t, l, fromReified)
 }
 
 func TestSerializeJSON(t *testing.T) {

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -206,8 +206,8 @@ func TestRoundTripFromConcreteAndBack(t *testing.T) {
 	concrete := l.Build(InfiniteLimits)
 
 	// Roundtrip
-	fromConcrete := concrete.ToLimitConfigWithDefaults(InfiniteLimits)
-	require.Equal(t, l, fromConcrete)
+	fromConcrete := concrete.ToLimitConfig().Build(InfiniteLimits)
+	require.Equal(t, concrete, fromConcrete)
 }
 
 func TestSerializeJSON(t *testing.T) {

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -206,7 +206,7 @@ func TestRoundTripFromConcreteAndBack(t *testing.T) {
 	concrete := l.Build(InfiniteLimits)
 
 	// Roundtrip
-	fromConcrete := concrete.ToLimitConfig().Build(InfiniteLimits)
+	fromConcrete := concrete.ToPartialLimitConfig().Build(InfiniteLimits)
 	require.Equal(t, concrete, fromConcrete)
 }
 

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -227,3 +227,24 @@ func TestSerializeJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "{\"Streams\":10}", string(out))
 }
+
+func TestWhatIsZeroInResourceLimits(t *testing.T) {
+	l := ResourceLimits{
+		Streams: BlockAllLimit,
+		Memory:  BlockAllLimit64,
+	}
+
+	out, err := json.Marshal(l)
+	require.NoError(t, err)
+	require.Equal(t, `{"Streams":"blockAll","Memory":"blockAll"}`, string(out))
+
+	l2 := ResourceLimits{}
+	err = json.Unmarshal([]byte(`{"Streams":0,"Memory":0}`), &l2)
+	require.NoError(t, err)
+	require.Equal(t, l, l2)
+
+	l3 := ResourceLimits{}
+	err = json.Unmarshal([]byte(`{"Streams":0,"Memory":"0"}`), &l3)
+	require.NoError(t, err)
+	require.Equal(t, l, l3)
+}

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -187,12 +187,12 @@ func TestJSONRoundTripInt64(t *testing.T) {
 
 func TestRoundTripFromReifyAndBack(t *testing.T) {
 	l := LimitConfig{
-		System: ResourceLimits{
+		System: &ResourceLimits{
 			Conns:  1234,
 			Memory: 54321,
 		},
 
-		ServiceDefault: ResourceLimits{
+		ServiceDefault: &ResourceLimits{
 			Conns: 2,
 		},
 
@@ -206,7 +206,7 @@ func TestRoundTripFromReifyAndBack(t *testing.T) {
 	reified := l.Reify(InfiniteLimits)
 
 	// Roundtrip
-	fromReified := FromReifiedLimitConfig(reified, InfiniteLimits)
+	fromReified := reified.ToLimitConfigWithDefaults(InfiniteLimits)
 	require.Equal(t, l, fromReified)
 }
 

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -185,8 +185,8 @@ func TestJSONRoundTripInt64(t *testing.T) {
 	require.Equal(t, bl, blDecoded)
 }
 
-func TestRoundTripFromReifyAndBack(t *testing.T) {
-	l := LimitConfig{
+func TestRoundTripFromConcreteAndBack(t *testing.T) {
+	l := PartialLimitConfig{
 		System: &ResourceLimits{
 			Conns:  1234,
 			Memory: 54321,
@@ -203,7 +203,7 @@ func TestRoundTripFromReifyAndBack(t *testing.T) {
 		},
 	}
 
-	reified := l.Reify(InfiniteLimits)
+	reified := l.Build(InfiniteLimits)
 
 	// Roundtrip
 	fromReified := reified.ToLimitConfigWithDefaults(InfiniteLimits)

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -203,11 +203,11 @@ func TestRoundTripFromConcreteAndBack(t *testing.T) {
 		},
 	}
 
-	reified := l.Build(InfiniteLimits)
+	concrete := l.Build(InfiniteLimits)
 
 	// Roundtrip
-	fromReified := reified.ToLimitConfigWithDefaults(InfiniteLimits)
-	require.Equal(t, l, fromReified)
+	fromConcrete := concrete.ToLimitConfigWithDefaults(InfiniteLimits)
+	require.Equal(t, l, fromConcrete)
 }
 
 func TestSerializeJSON(t *testing.T) {

--- a/p2p/host/resource-manager/limit_test.go
+++ b/p2p/host/resource-manager/limit_test.go
@@ -148,7 +148,7 @@ func TestJSONMarshalling(t *testing.T) {
 	bl := ResourceLimits{
 		Streams:         DefaultLimit,
 		StreamsInbound:  10,
-		StreamsOutbound: 10,
+		StreamsOutbound: BlockAllLimit,
 		Conns:           10,
 		// ConnsInbound:    DefaultLimit,
 		ConnsOutbound: Unlimited,
@@ -157,8 +157,7 @@ func TestJSONMarshalling(t *testing.T) {
 
 	jsonEncoded, err := json.Marshal(bl)
 	require.NoError(t, err)
-
-	require.Equal(t, string(jsonEncoded), `{"StreamsInbound":10,"StreamsOutbound":10,"Conns":10,"ConnsOutbound":"unlimited","Memory":"unlimited"}`)
+	require.Equal(t, string(jsonEncoded), `{"StreamsInbound":10,"StreamsOutbound":"blockAll","Conns":10,"ConnsOutbound":"unlimited","Memory":"unlimited"}`)
 
 	// Roundtrip
 	var blDecoded ResourceLimits

--- a/p2p/host/resource-manager/rcmgr_test.go
+++ b/p2p/host/resource-manager/rcmgr_test.go
@@ -21,7 +21,7 @@ func TestResourceManager(t *testing.T) {
 	svcA := "A.svc"
 	svcB := "B.svc"
 	nmgr, err := NewResourceManager(
-		NewFixedLimiter(ReifiedLimitConfig{
+		NewFixedLimiter(ConcreteLimitConfig{
 			system: BaseLimit{
 				Memory:          16384,
 				StreamsInbound:  3,

--- a/p2p/host/resource-manager/rcmgr_test.go
+++ b/p2p/host/resource-manager/rcmgr_test.go
@@ -21,8 +21,8 @@ func TestResourceManager(t *testing.T) {
 	svcA := "A.svc"
 	svcB := "B.svc"
 	nmgr, err := NewResourceManager(
-		NewFixedLimiter(LimitConfig{
-			System: BaseLimit{
+		NewFixedLimiter(ReifiedLimitConfig{
+			system: BaseLimit{
 				Memory:          16384,
 				StreamsInbound:  3,
 				StreamsOutbound: 3,
@@ -32,7 +32,7 @@ func TestResourceManager(t *testing.T) {
 				Conns:           6,
 				FD:              2,
 			},
-			Transient: BaseLimit{
+			transient: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  1,
 				StreamsOutbound: 1,
@@ -42,7 +42,7 @@ func TestResourceManager(t *testing.T) {
 				Conns:           2,
 				FD:              1,
 			},
-			ServiceDefault: BaseLimit{
+			serviceDefault: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  1,
 				StreamsOutbound: 1,
@@ -52,13 +52,13 @@ func TestResourceManager(t *testing.T) {
 				Conns:           2,
 				FD:              1,
 			},
-			ServicePeerDefault: BaseLimit{
+			servicePeerDefault: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  5,
 				StreamsOutbound: 5,
 				Streams:         10,
 			},
-			Service: map[string]BaseLimit{
+			service: map[string]BaseLimit{
 				svcA: {
 					Memory:          8192,
 					StreamsInbound:  2,
@@ -80,7 +80,7 @@ func TestResourceManager(t *testing.T) {
 					FD:              1,
 				},
 			},
-			ServicePeer: map[string]BaseLimit{
+			servicePeer: map[string]BaseLimit{
 				svcB: {
 					Memory:          8192,
 					StreamsInbound:  1,
@@ -88,13 +88,13 @@ func TestResourceManager(t *testing.T) {
 					Streams:         2,
 				},
 			},
-			ProtocolDefault: BaseLimit{
+			protocolDefault: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  1,
 				StreamsOutbound: 1,
 				Streams:         2,
 			},
-			Protocol: map[protocol.ID]BaseLimit{
+			protocol: map[protocol.ID]BaseLimit{
 				protoA: {
 					Memory:          8192,
 					StreamsInbound:  2,
@@ -102,7 +102,7 @@ func TestResourceManager(t *testing.T) {
 					Streams:         2,
 				},
 			},
-			ProtocolPeer: map[protocol.ID]BaseLimit{
+			protocolPeer: map[protocol.ID]BaseLimit{
 				protoB: {
 					Memory:          8192,
 					StreamsInbound:  1,
@@ -110,7 +110,7 @@ func TestResourceManager(t *testing.T) {
 					Streams:         2,
 				},
 			},
-			PeerDefault: BaseLimit{
+			peerDefault: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  1,
 				StreamsOutbound: 1,
@@ -120,13 +120,13 @@ func TestResourceManager(t *testing.T) {
 				Conns:           2,
 				FD:              1,
 			},
-			ProtocolPeerDefault: BaseLimit{
+			protocolPeerDefault: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  5,
 				StreamsOutbound: 5,
 				Streams:         10,
 			},
-			Peer: map[peer.ID]BaseLimit{
+			peer: map[peer.ID]BaseLimit{
 				peerA: {
 					Memory:          8192,
 					StreamsInbound:  2,
@@ -138,14 +138,14 @@ func TestResourceManager(t *testing.T) {
 					FD:              1,
 				},
 			},
-			Conn: BaseLimit{
+			conn: BaseLimit{
 				Memory:        4096,
 				ConnsInbound:  1,
 				ConnsOutbound: 1,
 				Conns:         1,
 				FD:            1,
 			},
-			Stream: BaseLimit{
+			stream: BaseLimit{
 				Memory:          4096,
 				StreamsInbound:  1,
 				StreamsOutbound: 1,
@@ -979,24 +979,24 @@ func TestResourceManagerWithAllowlist(t *testing.T) {
 	peerA := test.RandPeerIDFatal(t)
 
 	limits := DefaultLimits.AutoScale()
-	limits.System.Conns = 0
-	limits.Transient.Conns = 0
+	limits.system.Conns = 0
+	limits.transient.Conns = 0
 
 	baseLimit := BaseLimit{
 		Conns:         2,
 		ConnsInbound:  2,
 		ConnsOutbound: 1,
 	}
-	baseLimit.Apply(limits.AllowlistedSystem)
-	limits.AllowlistedSystem = baseLimit
+	baseLimit.Apply(limits.allowlistedSystem)
+	limits.allowlistedSystem = baseLimit
 
 	baseLimit = BaseLimit{
 		Conns:         1,
 		ConnsInbound:  1,
 		ConnsOutbound: 1,
 	}
-	baseLimit.Apply(limits.AllowlistedTransient)
-	limits.AllowlistedTransient = baseLimit
+	baseLimit.Apply(limits.allowlistedTransient)
+	limits.allowlistedTransient = baseLimit
 
 	rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
 		multiaddr.StringCast("/ip4/1.2.3.4"),

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 
 	"github.com/stretchr/testify/require"
 )
@@ -291,7 +292,7 @@ func waitForChannel(ready chan struct{}, timeout time.Duration) func() error {
 	}
 }
 
-func TestReadmeLimitConfigSerialization(t *testing.T) {
+func TestReadmeExample(t *testing.T) {
 	// Start with the default scaling limits.
 	scalingLimits := rcmgr.DefaultLimits
 
@@ -331,4 +332,9 @@ func TestReadmeLimitConfigSerialization(t *testing.T) {
 
 	// Create a libp2p host
 	host, err := libp2p.New(libp2p.ResourceManager(rm))
+	if err != nil {
+		panic(err)
+	}
+
+	host.Close()
 }

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -57,7 +57,7 @@ func TestResourceManagerConnInbound(t *testing.T) {
 			ConnsOutbound: 1,
 			Conns:         1,
 		},
-	}.Reify(rcmgr.DefaultReifiedLimits)
+	}.Reify(rcmgr.DefaultLimits.AutoScale())
 
 	echos := createEchos(t, 5, makeRcmgrOption(t, cfg))
 	defer closeEchos(echos)
@@ -98,7 +98,7 @@ func TestResourceManagerConnOutbound(t *testing.T) {
 			ConnsOutbound: 1,
 			Conns:         1,
 		},
-	}.Reify(rcmgr.DefaultReifiedLimits)
+	}.Reify(rcmgr.DefaultLimits.AutoScale())
 	echos := createEchos(t, 5, makeRcmgrOption(t, cfg))
 	defer closeEchos(echos)
 	defer closeRcmgrs(echos)
@@ -133,7 +133,7 @@ func TestResourceManagerServiceInbound(t *testing.T) {
 			StreamsOutbound: 1024,
 			Streams:         1024,
 		},
-	}.Reify(rcmgr.DefaultReifiedLimits)
+	}.Reify(rcmgr.DefaultLimits.AutoScale())
 	echos := createEchos(t, 5, makeRcmgrOption(t, cfg))
 	defer closeEchos(echos)
 	defer closeRcmgrs(echos)

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -48,13 +48,13 @@ func TestResourceManagerConnInbound(t *testing.T) {
 	// this test checks that we can not exceed the inbound conn limit at system level
 	// we specify: 1 conn per peer, 3 conns total, and we try to create 4 conns
 	cfg := rcmgr.PartialLimitConfig{
-		System: &rcmgr.ResourceLimits{
+		System: rcmgr.ResourceLimits{
 			ConnsInbound:    3,
 			ConnsOutbound:   1024,
 			Conns:           1024,
 			StreamsOutbound: rcmgr.Unlimited,
 		},
-		PeerDefault: &rcmgr.ResourceLimits{
+		PeerDefault: rcmgr.ResourceLimits{
 			ConnsInbound:  1,
 			ConnsOutbound: 1,
 			Conns:         1,
@@ -90,12 +90,12 @@ func TestResourceManagerConnOutbound(t *testing.T) {
 	// this test checks that we can not exceed the inbound conn limit at system level
 	// we specify: 1 conn per peer, 3 conns total, and we try to create 4 conns
 	cfg := rcmgr.PartialLimitConfig{
-		System: &rcmgr.ResourceLimits{
+		System: rcmgr.ResourceLimits{
 			ConnsInbound:  1024,
 			ConnsOutbound: 3,
 			Conns:         1024,
 		},
-		PeerDefault: &rcmgr.ResourceLimits{
+		PeerDefault: rcmgr.ResourceLimits{
 			ConnsInbound:  1,
 			ConnsOutbound: 1,
 			Conns:         1,
@@ -130,7 +130,7 @@ func TestResourceManagerServiceInbound(t *testing.T) {
 	// this test checks that we can not exceed the inbound stream limit at service level
 	// we specify: 3 streams for the service, and we try to create 4 streams
 	cfg := rcmgr.PartialLimitConfig{
-		ServiceDefault: &rcmgr.ResourceLimits{
+		ServiceDefault: rcmgr.ResourceLimits{
 			StreamsInbound:  3,
 			StreamsOutbound: 1024,
 			Streams:         1024,
@@ -305,7 +305,7 @@ func TestReadmeExample(t *testing.T) {
 
 	// Tweak certain settings
 	cfg := rcmgr.PartialLimitConfig{
-		System: &rcmgr.ResourceLimits{
+		System: rcmgr.ResourceLimits{
 			// Allow unlimited outbound streams
 			StreamsOutbound: rcmgr.Unlimited,
 		},

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -299,7 +299,7 @@ func TestReadmeExample(t *testing.T) {
 	// Add limits around included libp2p protocols
 	libp2p.SetDefaultServiceLimits(&scalingLimits)
 
-	// Turn the scaling limits into a reified set of limits using `.AutoScale`. This
+	// Turn the scaling limits into a concrete set of limits using `.AutoScale`. This
 	// scales the limits proportional to your system memory.
 	scaledDefaultLimits := scalingLimits.AutoScale()
 

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -47,7 +47,6 @@ func TestResourceManagerConnInbound(t *testing.T) {
 	// this test checks that we can not exceed the inbound conn limit at system level
 	// we specify: 1 conn per peer, 3 conns total, and we try to create 4 conns
 	cfg := rcmgr.LimitConfig{
-
 		System: rcmgr.ResourceLimits{
 			ConnsInbound:  3,
 			ConnsOutbound: 1024,


### PR DESCRIPTION
This solves the problem around the encoding having different semantics than the config that is passed into the resource manager [context](https://github.com/libp2p/go-libp2p/pull/1998#issuecomment-1386348540). This makes special values explicit (Unlimited, default, block all). And I think it's a more ergonomic API (create a struct with sane defaults, rather than having to copy some pre-initialized struct, then modify relevant values).

The high level idea is you have some custom configuration called `PartialLimitConfig` that gets constructed with a `ConcreteLimitConfig` (a configuration that has no special or missing values, zero means zero, max means max). The `.Build` method fills in any missing information from the `PartialLimitConfig` and returns a complete `ConcreteLimitConfig`. Another way to think about it is that `PartialLimitConfig` is a partial overrides config, and you add it to a complete `ConcreteLimitConfig` to get another `ConcreteLimitConfig`.  

Also take a look at the README for some updates on the description there.

Changes:
* Introduces a new type `LimitVal` which can explicitly specify "use default", "unlimited", "block all", as well as any positive number. The zero value of `LimitVal` (the value when you create the object in Go) is "Use default".
  * The JSON marshalling of this is straightforward.
* Introduces a new `ResourceLimits` type which uses `LimitVal` instead of ints so it can encode the above for the resources.
* Changes `LimitConfig` to `PartialLimitConfig` and uses `ResourceLimits`. This along with the marshalling changes means you can now marshal the fact that some resource limit is set to block all.
  * Because the default is to use the defaults, this avoids the footgun of initializing the resource manager with 0 limits (that would block everything).

Before:
```
	cfg := rcmgr.DefaultLimits.AutoScale()
	cfg.System.ConnsInbound = 3
	cfg.System.ConnsOutbound = 1024
	cfg.System.Conns = 1024
	cfg.PeerDefault.Conns = 1
	cfg.PeerDefault.ConnsInbound = 1
	cfg.PeerDefault.ConnsOutbound = 1
```

After:
```
	cfg := rcmgr.PartialLimitConfig{
		System: &rcmgr.ResourceLimits{
			ConnsInbound:  3,
			ConnsOutbound: 1024,
			Conns:         1024,
		},
		PeerDefault: &rcmgr.ResourceLimits{
			ConnsInbound:  1,
			ConnsOutbound: 1,
			Conns:         1,
		},
	}.Build(rcmgr.DefaultLimits.AutoScale())
```

And the JSON encoding:

```
	bl := ResourceLimits{
		Streams:         DefaultLimit,
		StreamsInbound:  10,
		StreamsOutbound: BlockAllLimit,
		Conns:           10,
		// ConnsInbound:    DefaultLimit,
		ConnsOutbound: Unlimited,
		Memory:        Unlimited64,
	}

	jsonEncoded, err := json.Marshal(bl)
	require.NoError(t, err)
	require.Equal(t, string(jsonEncoded), `{"StreamsInbound":10,"StreamsOutbound":"blockAll","Conns":10,"ConnsOutbound":"unlimited","Memory":"unlimited"}`)
```

This doesn't affect the ScalingLimitConfig. That has a lot of knobs and represents the developer's knowledge of how the resource usage should scale. LimitConfig on the other hand is more like the manual tweaks an end-user would make. It's used in conjunction with the defaults created from a ScalingLimitConfig.