### PR TITLE
fix(sec): upgrade github.com/libp2p/go-libp2p to 0.18.0-rc1

### DIFF
--- a/test-plans/go.mod
+++ b/test-plans/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/libp2p/go-libp2p v0.0.0
+	github.com/libp2p/go-libp2p v0.18.0-rc1
 	github.com/multiformats/go-multiaddr v0.8.0
 )
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/libp2p/go-libp2p v0.0.0
- [CVE-2022-23492](https://www.oscs1024.com/hd/CVE-2022-23492)


### What did I do？
Upgrade github.com/libp2p/go-libp2p from v0.0.0 to 0.18.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS