### PR TITLE
consistently use protocol.ID instead of strings

### DIFF
--- a/core/host/host.go
+++ b/core/host/host.go
@@ -52,7 +52,7 @@ type Host interface {
 
 	// SetStreamHandlerMatch sets the protocol handler on the Host's Mux
 	// using a matching function for protocol selection.
-	SetStreamHandlerMatch(protocol.ID, func(string) bool, network.StreamHandler)
+	SetStreamHandlerMatch(protocol.ID, func(protocol.ID) bool, network.StreamHandler)
 
 	// RemoveStreamHandler removes a handler on the mux that was set by
 	// SetStreamHandler

--- a/core/network/conn.go
+++ b/core/network/conn.go
@@ -42,7 +42,7 @@ type ConnectionState struct {
 	// The security protocol used on this connection (if any). For example: /tls/1.0.0
 	Security protocol.ID
 	// the transport used on this connection. For example: tcp
-	Transport protocol.ID
+	Transport string
 }
 
 // ConnSecurity is the interface that one can mix into a connection interface to

--- a/core/network/conn.go
+++ b/core/network/conn.go
@@ -6,6 +6,7 @@ import (
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -37,11 +38,11 @@ type Conn interface {
 // ConnectionState holds information about the connection.
 type ConnectionState struct {
 	// The stream multiplexer used on this connection (if any). For example: /yamux/1.0.0
-	StreamMultiplexer string
+	StreamMultiplexer protocol.ID
 	// The security protocol used on this connection (if any). For example: /tls/1.0.0
-	Security string
+	Security protocol.ID
 	// the transport used on this connection. For example: tcp
-	Transport string
+	Transport protocol.ID
 }
 
 // ConnSecurity is the interface that one can mix into a connection interface to

--- a/core/peerstore/peerstore.go
+++ b/core/peerstore/peerstore.go
@@ -11,6 +11,7 @@ import (
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/record"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -230,19 +231,19 @@ type Metrics interface {
 
 // ProtoBook tracks the protocols supported by peers.
 type ProtoBook interface {
-	GetProtocols(peer.ID) ([]string, error)
-	AddProtocols(peer.ID, ...string) error
-	SetProtocols(peer.ID, ...string) error
-	RemoveProtocols(peer.ID, ...string) error
+	GetProtocols(peer.ID) ([]protocol.ID, error)
+	AddProtocols(peer.ID, ...protocol.ID) error
+	SetProtocols(peer.ID, ...protocol.ID) error
+	RemoveProtocols(peer.ID, ...protocol.ID) error
 
 	// SupportsProtocols returns the set of protocols the peer supports from among the given protocols.
 	// If the returned error is not nil, the result is indeterminate.
-	SupportsProtocols(peer.ID, ...string) ([]string, error)
+	SupportsProtocols(peer.ID, ...protocol.ID) ([]protocol.ID, error)
 
 	// FirstSupportedProtocol returns the first protocol that the peer supports among the given protocols.
-	// If the peer does not support any of the given protocols, this function will return an empty string and a nil error.
+	// If the peer does not support any of the given protocols, this function will return an empty protocol.ID and a nil error.
 	// If the returned error is not nil, the result is indeterminate.
-	FirstSupportedProtocol(peer.ID, ...string) (string, error)
+	FirstSupportedProtocol(peer.ID, ...protocol.ID) (protocol.ID, error)
 
 	// RemovePeer removes all protocols associated with a peer.
 	RemovePeer(peer.ID)

--- a/core/protocol/switch.go
+++ b/core/protocol/switch.go
@@ -3,7 +3,13 @@ package protocol
 
 import (
 	"io"
+
+	"github.com/multiformats/go-multistream"
 )
+
+type StringLike interface {
+	~string
+}
 
 // HandlerFunc is a user-provided function used by the Router to
 // handle a protocol/stream.
@@ -11,7 +17,7 @@ import (
 // Will be invoked with the protocol ID string as the first argument,
 // which may differ from the ID used for registration if the handler
 // was registered using a match function.
-type HandlerFunc = func(protocol string, rwc io.ReadWriteCloser) error
+type HandlerFunc = multistream.HandlerFunc[ID]
 
 // Router is an interface that allows users to add and remove protocol handlers,
 // which will be invoked when incoming stream requests for registered protocols
@@ -25,7 +31,7 @@ type Router interface {
 
 	// AddHandler registers the given handler to be invoked for
 	// an exact literal match of the given protocol ID string.
-	AddHandler(protocol string, handler HandlerFunc)
+	AddHandler(protocol ID, handler HandlerFunc)
 
 	// AddHandlerWithFunc registers the given handler to be invoked
 	// when the provided match function returns true.
@@ -35,17 +41,17 @@ type Router interface {
 	// the protocol. Note that the protocol ID argument is not
 	// used for matching; if you want to match the protocol ID
 	// string exactly, you must check for it in your match function.
-	AddHandlerWithFunc(protocol string, match func(string) bool, handler HandlerFunc)
+	AddHandlerWithFunc(protocol ID, match func(ID) bool, handler HandlerFunc)
 
 	// RemoveHandler removes the registered handler (if any) for the
 	// given protocol ID string.
-	RemoveHandler(protocol string)
+	RemoveHandler(protocol ID)
 
 	// Protocols returns a list of all registered protocol ID strings.
 	// Note that the Router may be able to handle protocol IDs not
 	// included in this list if handlers were added with match functions
 	// using AddHandlerWithFunc.
-	Protocols() []string
+	Protocols() []ID
 }
 
 // Negotiator is a component capable of reaching agreement over what protocols
@@ -55,7 +61,7 @@ type Negotiator interface {
 	// inbound stream, returning after the protocol has been determined and the
 	// Negotiator has finished using the stream for negotiation. Returns an
 	// error if negotiation fails.
-	Negotiate(rwc io.ReadWriteCloser) (string, HandlerFunc, error)
+	Negotiate(rwc io.ReadWriteCloser) (ID, HandlerFunc, error)
 
 	// Handle calls Negotiate to determine which protocol handler to use for an
 	// inbound stream, then invokes the protocol handler function, passing it

--- a/core/protocol/switch.go
+++ b/core/protocol/switch.go
@@ -7,10 +7,6 @@ import (
 	"github.com/multiformats/go-multistream"
 )
 
-type StringLike interface {
-	~string
-}
-
 // HandlerFunc is a user-provided function used by the Router to
 // handle a protocol/stream.
 //

--- a/examples/ipfs-camp-2019/05-Discovery/protocol.go
+++ b/examples/ipfs-camp-2019/05-Discovery/protocol.go
@@ -51,7 +51,7 @@ func chatInputLoop(ctx context.Context, h host.Host, donec chan struct{}) {
 	for scanner.Scan() {
 		msg := scanner.Text()
 		for _, peer := range h.Network().Peers() {
-			if _, err := h.Peerstore().SupportsProtocols(peer, string(chatProtocol)); err == nil {
+			if _, err := h.Peerstore().SupportsProtocols(peer, chatProtocol); err == nil {
 				s, err := h.NewStream(ctx, peer, chatProtocol)
 				defer func() {
 					if err != nil {

--- a/examples/ipfs-camp-2019/05-Discovery/protocol.go
+++ b/examples/ipfs-camp-2019/05-Discovery/protocol.go
@@ -51,7 +51,7 @@ func chatInputLoop(ctx context.Context, h host.Host, donec chan struct{}) {
 	for scanner.Scan() {
 		msg := scanner.Text()
 		for _, peer := range h.Network().Peers() {
-			if _, err := h.Peerstore().SupportsProtocols(peer, chatProtocol); err == nil {
+			if _, err := h.Peerstore().SupportsProtocols(peer, string(chatProtocol)); err == nil {
 				s, err := h.NewStream(ctx, peer, chatProtocol)
 				defer func() {
 					if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/multiformats/go-multibase v0.1.1
 	github.com/multiformats/go-multicodec v0.7.0
 	github.com/multiformats/go-multihash v0.2.1
-	github.com/multiformats/go-multistream v0.3.3
+	github.com/multiformats/go-multistream v0.4.0
 	github.com/multiformats/go-varint v0.0.7
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,6 @@ github.com/multiformats/go-multicodec v0.7.0/go.mod h1:GUC8upxSBE4oG+q3kWZRw/+6y
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d16Vve9l108=
 github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
-github.com/multiformats/go-multistream v0.3.3 h1:d5PZpjwRgVlbwfdTDjife7XszfZd8KYWfROYFlGcR8o=
-github.com/multiformats/go-multistream v0.3.3/go.mod h1:ODRoqamLUsETKS9BNcII4gcRsJBU5VAwRIv7O39cEXg=
 github.com/multiformats/go-multistream v0.4.0 h1:5i4JbawClkbuaX+mIVXiHQYVPxUW+zjv6w7jtSRukxc=
 github.com/multiformats/go-multistream v0.4.0/go.mod h1:BS6ZSYcA4NwYEaIMeCtpJydp2Dc+fNRA6uJMSu/m8+4=
 github.com/multiformats/go-varint v0.0.1/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d
 github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-multistream v0.3.3 h1:d5PZpjwRgVlbwfdTDjife7XszfZd8KYWfROYFlGcR8o=
 github.com/multiformats/go-multistream v0.3.3/go.mod h1:ODRoqamLUsETKS9BNcII4gcRsJBU5VAwRIv7O39cEXg=
+github.com/multiformats/go-multistream v0.4.0 h1:5i4JbawClkbuaX+mIVXiHQYVPxUW+zjv6w7jtSRukxc=
+github.com/multiformats/go-multistream v0.4.0/go.mod h1:BS6ZSYcA4NwYEaIMeCtpJydp2Dc+fNRA6uJMSu/m8+4=
 github.com/multiformats/go-varint v0.0.1/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	basic "github.com/libp2p/go-libp2p/p2p/host/basic"
 	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
 	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
@@ -23,8 +24,8 @@ import (
 )
 
 const (
-	protoIDv1 = string(relayv1.ProtoID)
-	protoIDv2 = string(circuitv2_proto.ProtoIDv2Hop)
+	protoIDv1 = protocol.ID(relayv1.ProtoID)
+	protoIDv2 = protocol.ID(circuitv2_proto.ProtoIDv2Hop)
 )
 
 // Terminology:

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -13,7 +13,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	basic "github.com/libp2p/go-libp2p/p2p/host/basic"
 	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
 	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
@@ -24,8 +23,8 @@ import (
 )
 
 const (
-	protoIDv1 = protocol.ID(relayv1.ProtoID)
-	protoIDv2 = protocol.ID(circuitv2_proto.ProtoIDv2Hop)
+	protoIDv1 = relayv1.ProtoID
+	protoIDv2 = circuitv2_proto.ProtoIDv2Hop
 )
 
 // Terminology:

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -637,9 +637,7 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 		return nil, ctx.Err()
 	}
 
-	pidStrings := protocol.ConvertToStrings(pids)
-
-	pref, err := h.preferredProtocol(p, pidStrings)
+	pref, err := h.preferredProtocol(p, pids)
 	if err != nil {
 		_ = s.Reset()
 		return nil, err
@@ -653,6 +651,8 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 			rw:     lzcon,
 		}, nil
 	}
+
+	pidStrings := protocol.ConvertToStrings(pids)
 
 	// Negotiate the protocol in the background, obeying the context.
 	var selected string
@@ -676,11 +676,11 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 
 	selpid := protocol.ID(selected)
 	s.SetProtocol(selpid)
-	h.Peerstore().AddProtocols(p, selected)
+	h.Peerstore().AddProtocols(p, selpid)
 	return s, nil
 }
 
-func (h *BasicHost) preferredProtocol(p peer.ID, pids []string) (protocol.ID, error) {
+func (h *BasicHost) preferredProtocol(p peer.ID, pids []protocol.ID) (protocol.ID, error) {
 	supported, err := h.Peerstore().SupportsProtocols(p, pids...)
 	if err != nil {
 		return "", err

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -70,7 +70,7 @@ type BasicHost struct {
 
 	network      network.Network
 	psManager    *pstoremanager.PeerstoreManager
-	mux          *msmux.MultistreamMuxer
+	mux          *msmux.MultistreamMuxer[protocol.ID]
 	ids          identify.IDService
 	hps          *holepunch.Service
 	pings        *ping.PingService
@@ -108,7 +108,7 @@ var _ host.Host = (*BasicHost)(nil)
 // customize construction of the *BasicHost.
 type HostOpts struct {
 	// MultistreamMuxer is essential for the *BasicHost and will use a sensible default value if omitted.
-	MultistreamMuxer *msmux.MultistreamMuxer
+	MultistreamMuxer *msmux.MultistreamMuxer[protocol.ID]
 
 	// NegotiationTimeout determines the read and write timeouts on streams.
 	// If 0 or omitted, it will use DefaultNegotiationTimeout.
@@ -168,7 +168,7 @@ func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
 	h := &BasicHost{
 		network:                 n,
 		psManager:               psManager,
-		mux:                     msmux.NewMultistreamMuxer(),
+		mux:                     msmux.NewMultistreamMuxer[protocol.ID](),
 		negtimeout:              DefaultNegotiationTimeout,
 		AddrsFactory:            DefaultAddrsFactory,
 		maResolver:              madns.DefaultResolver,
@@ -407,7 +407,7 @@ func (h *BasicHost) newStreamHandler(s network.Stream) {
 		}
 	}
 
-	if err := s.SetProtocol(protocol.ID(protoID)); err != nil {
+	if err := s.SetProtocol(protoID); err != nil {
 		log.Debugf("error setting stream protocol: %s", err)
 		s.Reset()
 		return
@@ -571,9 +571,9 @@ func (h *BasicHost) EventBus() event.Bus {
 //
 // (Threadsafe)
 func (h *BasicHost) SetStreamHandler(pid protocol.ID, handler network.StreamHandler) {
-	h.Mux().AddHandler(string(pid), func(p string, rwc io.ReadWriteCloser) error {
+	h.Mux().AddHandler(pid, func(p protocol.ID, rwc io.ReadWriteCloser) error {
 		is := rwc.(network.Stream)
-		is.SetProtocol(protocol.ID(p))
+		is.SetProtocol(p)
 		handler(is)
 		return nil
 	})
@@ -584,10 +584,10 @@ func (h *BasicHost) SetStreamHandler(pid protocol.ID, handler network.StreamHand
 
 // SetStreamHandlerMatch sets the protocol handler on the Host's Mux
 // using a matching function to do protocol comparisons
-func (h *BasicHost) SetStreamHandlerMatch(pid protocol.ID, m func(string) bool, handler network.StreamHandler) {
-	h.Mux().AddHandlerWithFunc(string(pid), m, func(p string, rwc io.ReadWriteCloser) error {
+func (h *BasicHost) SetStreamHandlerMatch(pid protocol.ID, m func(protocol.ID) bool, handler network.StreamHandler) {
+	h.Mux().AddHandlerWithFunc(pid, m, func(p protocol.ID, rwc io.ReadWriteCloser) error {
 		is := rwc.(network.Stream)
-		is.SetProtocol(protocol.ID(p))
+		is.SetProtocol(p)
 		handler(is)
 		return nil
 	})
@@ -598,7 +598,7 @@ func (h *BasicHost) SetStreamHandlerMatch(pid protocol.ID, m func(string) bool, 
 
 // RemoveStreamHandler returns ..
 func (h *BasicHost) RemoveStreamHandler(pid protocol.ID) {
-	h.Mux().RemoveHandler(string(pid))
+	h.Mux().RemoveHandler(pid)
 	h.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
 		Removed: []protocol.ID{pid},
 	})
@@ -645,20 +645,18 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 
 	if pref != "" {
 		s.SetProtocol(pref)
-		lzcon := msmux.NewMSSelect(s, string(pref))
+		lzcon := msmux.NewMSSelect(s, pref)
 		return &streamWrapper{
 			Stream: s,
 			rw:     lzcon,
 		}, nil
 	}
 
-	pidStrings := protocol.ConvertToStrings(pids)
-
 	// Negotiate the protocol in the background, obeying the context.
-	var selected string
+	var selected protocol.ID
 	errCh := make(chan error, 1)
 	go func() {
-		selected, err = msmux.SelectOneOf(pidStrings, s)
+		selected, err = msmux.SelectOneOf(pids, s)
 		errCh <- err
 	}()
 	select {
@@ -674,9 +672,8 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 		return nil, ctx.Err()
 	}
 
-	selpid := protocol.ID(selected)
-	s.SetProtocol(selpid)
-	h.Peerstore().AddProtocols(p, selpid)
+	s.SetProtocol(selected)
+	h.Peerstore().AddProtocols(p, selected)
 	return s, nil
 }
 
@@ -688,7 +685,7 @@ func (h *BasicHost) preferredProtocol(p peer.ID, pids []protocol.ID) (protocol.I
 
 	var out protocol.ID
 	if len(supported) > 0 {
-		out = protocol.ID(supported[0])
+		out = supported[0]
 	}
 	return out, nil
 }

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -299,7 +299,7 @@ func TestHostProtoPreference(t *testing.T) {
 	assertWait(t, connectedOn, protoOld)
 	s.Close()
 
-	h2.SetStreamHandlerMatch(protoMinor, func(string) bool { return true }, handler)
+	h2.SetStreamHandlerMatch(protoMinor, func(protocol.ID) bool { return true }, handler)
 	// remembered preference will be chosen first, even when the other side newly supports it
 	s2, err := h1.NewStream(context.Background(), h2.ID(), protoMinor, protoNew, protoOld)
 	require.NoError(t, err)

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -158,8 +158,8 @@ func TestProtocolHandlerEvents(t *testing.T) {
 
 	h.SetStreamHandler(protocol.TestingID, func(s network.Stream) {})
 	assert([]protocol.ID{protocol.TestingID}, nil)
-	h.SetStreamHandler(protocol.ID("foo"), func(s network.Stream) {})
-	assert([]protocol.ID{protocol.ID("foo")}, nil)
+	h.SetStreamHandler("foo", func(s network.Stream) {})
+	assert([]protocol.ID{"foo"}, nil)
 	h.RemoveStreamHandler(protocol.TestingID)
 	assert(nil, []protocol.ID{protocol.TestingID})
 }
@@ -273,9 +273,9 @@ func TestHostProtoPreference(t *testing.T) {
 	defer h2.Close()
 
 	const (
-		protoOld   = protocol.ID("/testing")
-		protoNew   = protocol.ID("/testing/1.1.0")
-		protoMinor = protocol.ID("/testing/1.2.0")
+		protoOld   = "/testing"
+		protoNew   = "/testing/1.1.0"
+		protoMinor = "/testing/1.2.0"
 	)
 
 	connectedOn := make(chan protocol.ID)

--- a/p2p/host/blank/blank.go
+++ b/p2p/host/blank/blank.go
@@ -171,7 +171,7 @@ func (bh *BlankHost) NewStream(ctx context.Context, p peer.ID, protos ...protoco
 
 	selpid := protocol.ID(selected)
 	s.SetProtocol(selpid)
-	bh.Peerstore().AddProtocols(p, selected)
+	bh.Peerstore().AddProtocols(p, selpid)
 
 	return s, nil
 }

--- a/p2p/host/blank/blank.go
+++ b/p2p/host/blank/blank.go
@@ -27,7 +27,7 @@ var log = logging.Logger("blankhost")
 // BlankHost is the thinnest implementation of the host.Host interface
 type BlankHost struct {
 	n        network.Network
-	mux      *mstream.MultistreamMuxer
+	mux      *mstream.MultistreamMuxer[protocol.ID]
 	cmgr     connmgr.ConnManager
 	eventbus event.Bus
 	emitters struct {
@@ -65,7 +65,7 @@ func NewBlankHost(n network.Network, options ...Option) *BlankHost {
 	bh := &BlankHost{
 		n:    n,
 		cmgr: cfg.cmgr,
-		mux:  mstream.NewMultistreamMuxer(),
+		mux:  mstream.NewMultistreamMuxer[protocol.ID](),
 	}
 	if bh.eventbus == nil {
 		bh.eventbus = eventbus.NewBus()
@@ -158,35 +158,29 @@ func (bh *BlankHost) NewStream(ctx context.Context, p peer.ID, protos ...protoco
 		return nil, err
 	}
 
-	protoStrs := make([]string, len(protos))
-	for i, pid := range protos {
-		protoStrs[i] = string(pid)
-	}
-
-	selected, err := mstream.SelectOneOf(protoStrs, s)
+	selected, err := mstream.SelectOneOf(protos, s)
 	if err != nil {
 		s.Reset()
 		return nil, err
 	}
 
-	selpid := protocol.ID(selected)
-	s.SetProtocol(selpid)
-	bh.Peerstore().AddProtocols(p, selpid)
+	s.SetProtocol(selected)
+	bh.Peerstore().AddProtocols(p, selected)
 
 	return s, nil
 }
 
 func (bh *BlankHost) RemoveStreamHandler(pid protocol.ID) {
-	bh.Mux().RemoveHandler(string(pid))
+	bh.Mux().RemoveHandler(pid)
 	bh.emitters.evtLocalProtocolsUpdated.Emit(event.EvtLocalProtocolsUpdated{
 		Removed: []protocol.ID{pid},
 	})
 }
 
 func (bh *BlankHost) SetStreamHandler(pid protocol.ID, handler network.StreamHandler) {
-	bh.Mux().AddHandler(string(pid), func(p string, rwc io.ReadWriteCloser) error {
+	bh.Mux().AddHandler(pid, func(p protocol.ID, rwc io.ReadWriteCloser) error {
 		is := rwc.(network.Stream)
-		is.SetProtocol(protocol.ID(p))
+		is.SetProtocol(p)
 		handler(is)
 		return nil
 	})
@@ -195,10 +189,10 @@ func (bh *BlankHost) SetStreamHandler(pid protocol.ID, handler network.StreamHan
 	})
 }
 
-func (bh *BlankHost) SetStreamHandlerMatch(pid protocol.ID, m func(string) bool, handler network.StreamHandler) {
-	bh.Mux().AddHandlerWithFunc(string(pid), m, func(p string, rwc io.ReadWriteCloser) error {
+func (bh *BlankHost) SetStreamHandlerMatch(pid protocol.ID, m func(protocol.ID) bool, handler network.StreamHandler) {
+	bh.Mux().AddHandlerWithFunc(pid, m, func(p protocol.ID, rwc io.ReadWriteCloser) error {
 		is := rwc.(network.Stream)
-		is.SetProtocol(protocol.ID(p))
+		is.SetProtocol(p)
 		handler(is)
 		return nil
 	})
@@ -216,7 +210,7 @@ func (bh *BlankHost) newStreamHandler(s network.Stream) {
 		return
 	}
 
-	s.SetProtocol(protocol.ID(protoID))
+	s.SetProtocol(protoID)
 
 	go handle(protoID, s)
 }

--- a/p2p/host/peerstore/pstoreds/metadata.go
+++ b/p2p/host/peerstore/pstoreds/metadata.go
@@ -8,6 +8,7 @@ import (
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/protocol"
 
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
@@ -28,7 +29,7 @@ func init() {
 	// Gob registers basic types by default.
 	//
 	// Register complex types used by the peerstore itself.
-	gob.Register(make(map[string]struct{}))
+	gob.Register(make(map[protocol.ID]struct{}))
 }
 
 // NewPeerMetadata creates a metadata store backed by a persistent db. It uses gob for serialisation.

--- a/p2p/host/peerstore/test/peerstore_suite.go
+++ b/p2p/host/peerstore/test/peerstore_suite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/protocol"
 
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,10 @@ func TestPeerstore(t *testing.T, factory PeerstoreFactory) {
 			closeFunc()
 		}
 	}
+}
+
+func sortProtos(protos []protocol.ID) {
+	sort.Slice(protos, func(i, j int) bool { return protos[i] < protos[j] })
 }
 
 func testAddrStream(ps pstore.Peerstore) func(t *testing.T) {
@@ -209,14 +214,14 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("adding and removing protocols", func(t *testing.T) {
 			p1 := peer.ID("TESTPEER")
-			protos := []string{"a", "b", "c", "d"}
+			protos := []protocol.ID{"a", "b", "c", "d"}
 
 			require.NoError(t, ps.AddProtocols(p1, protos...))
 			out, err := ps.GetProtocols(p1)
 			require.NoError(t, err)
 			require.Len(t, out, len(protos), "got wrong number of protocols back")
 
-			sort.Strings(out)
+			sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 			for i, p := range protos {
 				if out[i] != p {
 					t.Fatal("got wrong protocol")
@@ -233,7 +238,7 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 
 			b, err := ps.FirstSupportedProtocol(p1, "q", "w", "a", "y", "b")
 			require.NoError(t, err)
-			require.Equal(t, "a", b)
+			require.Equal(t, protocol.ID("a"), b)
 
 			b, err = ps.FirstSupportedProtocol(p1, "q", "x", "z")
 			require.NoError(t, err)
@@ -241,9 +246,9 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 
 			b, err = ps.FirstSupportedProtocol(p1, "a")
 			require.NoError(t, err)
-			require.Equal(t, "a", b)
+			require.Equal(t, protocol.ID("a"), b)
 
-			protos = []string{"other", "yet another", "one more"}
+			protos = []protocol.ID{"other", "yet another", "one more"}
 			require.NoError(t, ps.SetProtocols(p1, protos...))
 
 			supported, err = ps.SupportsProtocols(p1, "q", "w", "a", "y", "b")
@@ -253,8 +258,8 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 			supported, err = ps.GetProtocols(p1)
 			require.NoError(t, err)
 
-			sort.Strings(supported)
-			sort.Strings(protos)
+			sortProtos(supported)
+			sortProtos(protos)
 			if !reflect.DeepEqual(supported, protos) {
 				t.Fatalf("expected previously set protos; expected: %v, have: %v", protos, supported)
 			}
@@ -270,7 +275,7 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 
 		t.Run("removing peer", func(t *testing.T) {
 			p := peer.ID("foobar")
-			protos := []string{"a", "b"}
+			protos := []protocol.ID{"a", "b"}
 
 			require.NoError(t, ps.SetProtocols(p, protos...))
 			out, err := ps.GetProtocols(p)
@@ -383,9 +388,9 @@ func getAddrs(t *testing.T, n int) []ma.Multiaddr {
 
 func TestPeerstoreProtoStoreLimits(t *testing.T, ps pstore.Peerstore, limit int) {
 	p := peer.ID("foobar")
-	protocols := make([]string, limit)
+	protocols := make([]protocol.ID, limit)
 	for i := 0; i < limit; i++ {
-		protocols[i] = fmt.Sprintf("protocol %d", i)
+		protocols[i] = protocol.ID(fmt.Sprintf("protocol %d", i))
 	}
 
 	t.Run("setting protocols", func(t *testing.T) {

--- a/p2p/host/peerstore/test/peerstore_suite.go
+++ b/p2p/host/peerstore/test/peerstore_suite.go
@@ -221,7 +221,7 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, out, len(protos), "got wrong number of protocols back")
 
-			sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+			sortProtos(out)
 			for i, p := range protos {
 				if out[i] != p {
 					t.Fatal("got wrong protocol")

--- a/p2p/host/pstoremanager/mock_peerstore_test.go
+++ b/p2p/host/pstoremanager/mock_peerstore_test.go
@@ -12,6 +12,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	protocol "github.com/libp2p/go-libp2p/core/protocol"
 	multiaddr "github.com/multiformats/go-multiaddr"
 )
 
@@ -77,7 +78,7 @@ func (mr *MockPeerstoreMockRecorder) AddPrivKey(arg0, arg1 interface{}) *gomock.
 }
 
 // AddProtocols mocks base method.
-func (m *MockPeerstore) AddProtocols(arg0 peer.ID, arg1 ...string) error {
+func (m *MockPeerstore) AddProtocols(arg0 peer.ID, arg1 ...protocol.ID) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -164,14 +165,14 @@ func (mr *MockPeerstoreMockRecorder) Close() *gomock.Call {
 }
 
 // FirstSupportedProtocol mocks base method.
-func (m *MockPeerstore) FirstSupportedProtocol(arg0 peer.ID, arg1 ...string) (string, error) {
+func (m *MockPeerstore) FirstSupportedProtocol(arg0 peer.ID, arg1 ...protocol.ID) (protocol.ID, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "FirstSupportedProtocol", varargs...)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(protocol.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -199,10 +200,10 @@ func (mr *MockPeerstoreMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetProtocols mocks base method.
-func (m *MockPeerstore) GetProtocols(arg0 peer.ID) ([]string, error) {
+func (m *MockPeerstore) GetProtocols(arg0 peer.ID) ([]protocol.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProtocols", arg0)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]protocol.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -350,7 +351,7 @@ func (mr *MockPeerstoreMockRecorder) RemovePeer(arg0 interface{}) *gomock.Call {
 }
 
 // RemoveProtocols mocks base method.
-func (m *MockPeerstore) RemoveProtocols(arg0 peer.ID, arg1 ...string) error {
+func (m *MockPeerstore) RemoveProtocols(arg0 peer.ID, arg1 ...protocol.ID) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -393,7 +394,7 @@ func (mr *MockPeerstoreMockRecorder) SetAddrs(arg0, arg1, arg2 interface{}) *gom
 }
 
 // SetProtocols mocks base method.
-func (m *MockPeerstore) SetProtocols(arg0 peer.ID, arg1 ...string) error {
+func (m *MockPeerstore) SetProtocols(arg0 peer.ID, arg1 ...protocol.ID) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -412,14 +413,14 @@ func (mr *MockPeerstoreMockRecorder) SetProtocols(arg0 interface{}, arg1 ...inte
 }
 
 // SupportsProtocols mocks base method.
-func (m *MockPeerstore) SupportsProtocols(arg0 peer.ID, arg1 ...string) ([]string, error) {
+func (m *MockPeerstore) SupportsProtocols(arg0 peer.ID, arg1 ...protocol.ID) ([]protocol.ID, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SupportsProtocols", varargs...)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]protocol.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/p2p/host/resource-manager/extapi.go
+++ b/p2p/host/resource-manager/extapi.go
@@ -87,7 +87,7 @@ func (r *resourceManager) ListProtocols() []protocol.ID {
 	}
 
 	sort.Slice(result, func(i, j int) bool {
-		return strings.Compare(string(result[i]), string(result[j])) < 0
+		return result[i] < result[j]
 	})
 
 	return result

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -188,7 +188,7 @@ func (rh *RoutedHost) SetStreamHandler(pid protocol.ID, handler network.StreamHa
 	rh.host.SetStreamHandler(pid, handler)
 }
 
-func (rh *RoutedHost) SetStreamHandlerMatch(pid protocol.ID, m func(string) bool, handler network.StreamHandler) {
+func (rh *RoutedHost) SetStreamHandlerMatch(pid protocol.ID, m func(protocol.ID) bool, handler network.StreamHandler) {
 	rh.host.SetStreamHandlerMatch(pid, m, handler)
 }
 

--- a/p2p/net/swarm/swarm_metrics.go
+++ b/p2p/net/swarm/swarm_metrics.go
@@ -122,12 +122,12 @@ func appendConnectionState(tags []string, cs network.ConnectionState) []string {
 		// This shouldn't happen, unless the transport doesn't properly set the Transport field in the ConnectionState.
 		tags = append(tags, "unknown")
 	} else {
-		tags = append(tags, cs.Transport)
+		tags = append(tags, string(cs.Transport))
 	}
 	// These might be empty, depending on the transport.
 	// For example, QUIC doesn't set security nor muxer.
-	tags = append(tags, cs.Security)
-	tags = append(tags, cs.StreamMultiplexer)
+	tags = append(tags, string(cs.Security))
+	tags = append(tags, string(cs.StreamMultiplexer))
 	return tags
 }
 

--- a/p2p/net/upgrader/conn.go
+++ b/p2p/net/upgrader/conn.go
@@ -56,8 +56,8 @@ func (t *transportConn) Close() error {
 
 func (t *transportConn) ConnState() network.ConnectionState {
 	return network.ConnectionState{
-		StreamMultiplexer: string(t.muxer),
-		Security:          string(t.security),
+		StreamMultiplexer: t.muxer,
+		Security:          t.security,
 		Transport:         "tcp",
 	}
 }

--- a/p2p/net/upgrader/listener_test.go
+++ b/p2p/net/upgrader/listener_test.go
@@ -405,7 +405,7 @@ func TestNoCommonSecurityProto(t *testing.T) {
 	}()
 
 	_, err = dial(t, ub, ln.Multiaddr(), idA, &network.NullScope{})
-	require.EqualError(t, err, "failed to negotiate security protocol: protocol not supported")
+	require.ErrorContains(t, err, "failed to negotiate security protocol: protocols not supported")
 	select {
 	case <-done:
 		t.Fatal("didn't expect to accept a connection")

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -254,7 +254,7 @@ func (u *upgrader) getMuxerByID(id protocol.ID) *StreamMuxer {
 }
 
 func (u *upgrader) setupMuxer(ctx context.Context, conn sec.SecureConn, server bool, scope network.PeerScope) (protocol.ID, network.MuxedConn, error) {
-	muxerSelected := protocol.ID(conn.ConnState().StreamMultiplexer)
+	muxerSelected := conn.ConnState().StreamMultiplexer
 	// Use muxer selected from security handshake if available. Otherwise fall back to multistream-selection.
 	if len(muxerSelected) > 0 {
 		m := u.getMuxerByID(muxerSelected)

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -53,13 +53,13 @@ type upgrader struct {
 	connGater connmgr.ConnectionGater
 	rcmgr     network.ResourceManager
 
-	muxerMuxer *mss.MultistreamMuxer
+	muxerMuxer *mss.MultistreamMuxer[protocol.ID]
 	muxers     []StreamMuxer
-	muxerIDs   []string
+	muxerIDs   []protocol.ID
 
 	security      []sec.SecureTransport
-	securityMuxer *mss.MultistreamMuxer
-	securityIDs   []string
+	securityMuxer *mss.MultistreamMuxer[protocol.ID]
+	securityIDs   []protocol.ID
 
 	// AcceptTimeout is the maximum duration an Accept is allowed to take.
 	// This includes the time between accepting the raw network connection,
@@ -77,10 +77,10 @@ func New(security []sec.SecureTransport, muxers []StreamMuxer, psk ipnet.PSK, rc
 		rcmgr:         rcmgr,
 		connGater:     connGater,
 		psk:           psk,
-		muxerMuxer:    mss.NewMultistreamMuxer(),
+		muxerMuxer:    mss.NewMultistreamMuxer[protocol.ID](),
 		muxers:        muxers,
 		security:      security,
-		securityMuxer: mss.NewMultistreamMuxer(),
+		securityMuxer: mss.NewMultistreamMuxer[protocol.ID](),
 	}
 	for _, opt := range opts {
 		if err := opt(u); err != nil {
@@ -90,15 +90,15 @@ func New(security []sec.SecureTransport, muxers []StreamMuxer, psk ipnet.PSK, rc
 	if u.rcmgr == nil {
 		u.rcmgr = &network.NullResourceManager{}
 	}
-	u.muxerIDs = make([]string, 0, len(muxers))
+	u.muxerIDs = make([]protocol.ID, 0, len(muxers))
 	for _, m := range muxers {
-		u.muxerMuxer.AddHandler(string(m.ID), nil)
-		u.muxerIDs = append(u.muxerIDs, string(m.ID))
+		u.muxerMuxer.AddHandler(m.ID, nil)
+		u.muxerIDs = append(u.muxerIDs, m.ID)
 	}
-	u.securityIDs = make([]string, 0, len(security))
+	u.securityIDs = make([]protocol.ID, 0, len(security))
 	for _, s := range security {
-		u.securityMuxer.AddHandler(string(s.ID()), nil)
-		u.securityIDs = append(u.securityIDs, string(s.ID()))
+		u.securityMuxer.AddHandler(s.ID(), nil)
+		u.securityIDs = append(u.securityIDs, s.ID())
 	}
 	return u, nil
 }
@@ -219,7 +219,7 @@ func (u *upgrader) negotiateMuxer(nc net.Conn, isServer bool) (*StreamMuxer, err
 		return nil, err
 	}
 
-	var proto string
+	var proto protocol.ID
 	if isServer {
 		selected, _, err := u.muxerMuxer.Negotiate(nc)
 		if err != nil {
@@ -244,9 +244,9 @@ func (u *upgrader) negotiateMuxer(nc net.Conn, isServer bool) (*StreamMuxer, err
 	return nil, fmt.Errorf("selected protocol we don't have a transport for")
 }
 
-func (u *upgrader) getMuxerByID(id string) *StreamMuxer {
+func (u *upgrader) getMuxerByID(id protocol.ID) *StreamMuxer {
 	for _, m := range u.muxers {
-		if string(m.ID) == id {
+		if m.ID == id {
 			return &m
 		}
 	}
@@ -254,7 +254,7 @@ func (u *upgrader) getMuxerByID(id string) *StreamMuxer {
 }
 
 func (u *upgrader) setupMuxer(ctx context.Context, conn sec.SecureConn, server bool, scope network.PeerScope) (protocol.ID, network.MuxedConn, error) {
-	muxerSelected := conn.ConnState().StreamMultiplexer
+	muxerSelected := protocol.ID(conn.ConnState().StreamMultiplexer)
 	// Use muxer selected from security handshake if available. Otherwise fall back to multistream-selection.
 	if len(muxerSelected) > 0 {
 		m := u.getMuxerByID(muxerSelected)
@@ -265,7 +265,7 @@ func (u *upgrader) setupMuxer(ctx context.Context, conn sec.SecureConn, server b
 		if err != nil {
 			return "", nil, err
 		}
-		return protocol.ID(muxerSelected), c, nil
+		return muxerSelected, c, nil
 	}
 
 	type result struct {
@@ -298,9 +298,9 @@ func (u *upgrader) setupMuxer(ctx context.Context, conn sec.SecureConn, server b
 	}
 }
 
-func (u *upgrader) getSecurityByID(id string) sec.SecureTransport {
+func (u *upgrader) getSecurityByID(id protocol.ID) sec.SecureTransport {
 	for _, s := range u.security {
-		if string(s.ID()) == id {
+		if s.ID() == id {
 			return s
 		}
 	}
@@ -309,7 +309,7 @@ func (u *upgrader) getSecurityByID(id string) sec.SecureTransport {
 
 func (u *upgrader) negotiateSecurity(ctx context.Context, insecure net.Conn, server bool) (sec.SecureTransport, bool, error) {
 	type result struct {
-		proto     string
+		proto     protocol.ID
 		iamserver bool
 		err       error
 	}

--- a/p2p/protocol/circuitv2/client/conn.go
+++ b/p2p/protocol/circuitv2/client/conn.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	tpt "github.com/libp2p/go-libp2p/core/transport"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -158,6 +159,6 @@ var transportName = ma.ProtocolWithCode(ma.P_CIRCUIT).Name
 
 func (c capableConn) ConnState() network.ConnectionState {
 	return network.ConnectionState{
-		Transport: transportName,
+		Transport: protocol.ID(transportName),
 	}
 }

--- a/p2p/protocol/circuitv2/client/conn.go
+++ b/p2p/protocol/circuitv2/client/conn.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	tpt "github.com/libp2p/go-libp2p/core/transport"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -159,6 +158,6 @@ var transportName = ma.ProtocolWithCode(ma.P_CIRCUIT).Name
 
 func (c capableConn) ConnState() network.ConnectionState {
 	return network.ConnectionState{
-		Transport: protocol.ID(transportName),
+		Transport: transportName,
 	}
 }

--- a/p2p/protocol/circuitv2/client/reservation_test.go
+++ b/p2p/protocol/circuitv2/client/reservation_test.go
@@ -27,7 +27,7 @@ func TestReservationFailures(t *testing.T) {
 		{
 			name:          "unsupported protocol",
 			streamHandler: nil,
-			err:           "protocol not supported",
+			err:           "protocols not supported",
 		},
 		{
 			name: "wrong message type",

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -224,7 +224,7 @@ func TestFailuresOnInitiator(t *testing.T) {
 			hps := addHolePunchService(t, h2, opts...)
 			// wait until the hole punching protocol has actually started
 			require.Eventually(t, func() bool {
-				protos, _ := h2.Peerstore().SupportsProtocols(h1.ID(), string(holepunch.Protocol))
+				protos, _ := h2.Peerstore().SupportsProtocols(h1.ID(), holepunch.Protocol)
 				return len(protos) > 0
 			}, 200*time.Millisecond, 10*time.Millisecond)
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -592,9 +592,10 @@ func diff(a, b []string) (added, removed []string) {
 func (ids *idService) consumeMessage(mes *pb.Identify, c network.Conn, isPush bool) {
 	p := c.RemotePeer()
 
+	// TODO (sukunrt): Fix this
 	supported, _ := ids.Host.Peerstore().GetProtocols(p)
-	added, removed := diff(supported, mes.Protocols)
-	ids.Host.Peerstore().SetProtocols(p, mes.Protocols...)
+	added, removed := diff(protocol.ConvertToStrings(supported), mes.Protocols)
+	ids.Host.Peerstore().SetProtocols(p, protocol.ConvertFromStrings(mes.Protocols)...)
 	if isPush {
 		ids.emitters.evtPeerProtocolsUpdated.Emit(event.EvtPeerProtocolsUpdated{
 			Peer:    p,

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -560,7 +560,7 @@ func (ids *idService) getSignedRecord(snapshot *identifySnapshot) []byte {
 }
 
 // diff takes two slices of strings (a and b) and computes which elements were added and removed in b
-func diff(a, b []string) (added, removed []string) {
+func diff(a, b []protocol.ID) (added, removed []protocol.ID) {
 	// This is O(n^2), but it's fine because the slices are small.
 	for _, x := range b {
 		var found bool
@@ -592,15 +592,15 @@ func diff(a, b []string) (added, removed []string) {
 func (ids *idService) consumeMessage(mes *pb.Identify, c network.Conn, isPush bool) {
 	p := c.RemotePeer()
 
-	// TODO (sukunrt): Fix this
 	supported, _ := ids.Host.Peerstore().GetProtocols(p)
-	added, removed := diff(protocol.ConvertToStrings(supported), mes.Protocols)
-	ids.Host.Peerstore().SetProtocols(p, protocol.ConvertFromStrings(mes.Protocols)...)
+	mesProtocols := protocol.ConvertFromStrings(mes.Protocols)
+	added, removed := diff(supported, mesProtocols)
+	ids.Host.Peerstore().SetProtocols(p, mesProtocols...)
 	if isPush {
 		ids.emitters.evtPeerProtocolsUpdated.Emit(event.EvtPeerProtocolsUpdated{
 			Peer:    p,
-			Added:   protocol.ConvertFromStrings(added),
-			Removed: protocol.ConvertFromStrings(removed),
+			Added:   added,
+			Removed: removed,
 		})
 	}
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -500,7 +500,7 @@ func (ids *idService) createBaseIdentifyResponse(
 	localAddr := conn.LocalMultiaddr()
 
 	// set protocols this node is currently handling
-	mes.Protocols = snapshot.protocols
+	mes.Protocols = protocol.ConvertToStrings(snapshot.protocols)
 
 	// observed address so other side is informed of their
 	// "public" address, at least in relation to us.

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -587,14 +587,14 @@ func TestSendPush(t *testing.T) {
 	// h1 starts listening on a new protocol and h2 finds out about that through a push
 	h1.SetStreamHandler("rand", func(network.Stream) {})
 	require.Eventually(t, func() bool {
-		sup, err := h2.Peerstore().SupportsProtocols(h1.ID(), []string{"rand"}...)
+		sup, err := h2.Peerstore().SupportsProtocols(h1.ID(), []protocol.ID{"rand"}...)
 		return err == nil && len(sup) == 1 && sup[0] == "rand"
 	}, time.Second, 10*time.Millisecond)
 
 	// h1 stops listening on a protocol and h2 finds out about it via a push
 	h1.RemoveStreamHandler("rand")
 	require.Eventually(t, func() bool {
-		sup, err := h2.Peerstore().SupportsProtocols(h1.ID(), []string{"rand"}...)
+		sup, err := h2.Peerstore().SupportsProtocols(h1.ID(), []protocol.ID{"rand"}...)
 		return err == nil && len(sup) == 0
 	}, time.Second, 10*time.Millisecond)
 }

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -383,7 +383,7 @@ func TestIdentifyPushWhileIdentifyingConn(t *testing.T) {
 	handler := func(s network.Stream) {
 		<-block
 		w := pbio.NewDelimitedWriter(s)
-		w.WriteMsg(&pb.Identify{Protocols: h1.Mux().Protocols()})
+		w.WriteMsg(&pb.Identify{Protocols:protocol.ConvertToStrings(h1.Mux().Protocols())})
 		s.Close()
 	}
 	h1.RemoveStreamHandler(identify.ID)

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -383,7 +383,7 @@ func TestIdentifyPushWhileIdentifyingConn(t *testing.T) {
 	handler := func(s network.Stream) {
 		<-block
 		w := pbio.NewDelimitedWriter(s)
-		w.WriteMsg(&pb.Identify{Protocols:protocol.ConvertToStrings(h1.Mux().Protocols())})
+		w.WriteMsg(&pb.Identify{Protocols: protocol.ConvertToStrings(h1.Mux().Protocols())})
 		s.Close()
 	}
 	h1.RemoveStreamHandler(identify.ID)
@@ -613,9 +613,9 @@ func TestLargeIdentifyMessage(t *testing.T) {
 	// add protocol strings to make the message larger
 	// about 2K of protocol strings
 	for i := 0; i < 500; i++ {
-		r := fmt.Sprintf("rand%d", i)
-		h1.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
-		h2.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
+		r := protocol.ID(fmt.Sprintf("rand%d", i))
+		h1.SetStreamHandler(r, func(network.Stream) {})
+		h2.SetStreamHandler(r, func(network.Stream) {})
 	}
 
 	h1p := h1.ID()
@@ -719,9 +719,9 @@ func TestLargePushMessage(t *testing.T) {
 	// add protocol strings to make the message larger
 	// about 2K of protocol strings
 	for i := 0; i < 500; i++ {
-		r := fmt.Sprintf("rand%d", i)
-		h1.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
-		h2.SetStreamHandler(protocol.ID(r), func(network.Stream) {})
+		r := protocol.ID(fmt.Sprintf("rand%d", i))
+		h1.SetStreamHandler(r, func(network.Stream) {})
+		h2.SetStreamHandler(r, func(network.Stream) {})
 	}
 
 	h1p := h1.ID()

--- a/p2p/protocol/identify/peer_loop.go
+++ b/p2p/protocol/identify/peer_loop.go
@@ -116,7 +116,7 @@ func (ph *peerHandler) openStream(ctx context.Context, proto string) (network.St
 		}
 	}
 
-	if sup, err := ph.ids.Host.Peerstore().SupportsProtocols(ph.pid, proto); err != nil || len(sup) == 0 {
+	if sup, err := ph.ids.Host.Peerstore().SupportsProtocols(ph.pid, protocol.ID(proto)); err != nil || len(sup) == 0 {
 		return nil, errProtocolNotSupported
 	}
 	ph.ids.pushSemaphore <- struct{}{}

--- a/p2p/protocol/identify/peer_loop.go
+++ b/p2p/protocol/identify/peer_loop.go
@@ -16,7 +16,7 @@ import (
 var errProtocolNotSupported = errors.New("protocol not supported")
 
 type identifySnapshot struct {
-	protocols []string
+	protocols []protocol.ID
 	addrs     []ma.Multiaddr
 	record    *record.Envelope
 }
@@ -103,7 +103,7 @@ func (ph *peerHandler) sendPush(ctx context.Context) error {
 	return nil
 }
 
-func (ph *peerHandler) openStream(ctx context.Context, proto string) (network.Stream, error) {
+func (ph *peerHandler) openStream(ctx context.Context, proto protocol.ID) (network.Stream, error) {
 	// wait for the other peer to send us an Identify response on "all" connections we have with it
 	// so we can look at it's supported protocols and avoid a multistream-select roundtrip to negotiate the protocol
 	// if we know for a fact that it doesn't support the protocol.
@@ -116,7 +116,7 @@ func (ph *peerHandler) openStream(ctx context.Context, proto string) (network.St
 		}
 	}
 
-	if sup, err := ph.ids.Host.Peerstore().SupportsProtocols(ph.pid, protocol.ID(proto)); err != nil || len(sup) == 0 {
+	if sup, err := ph.ids.Host.Peerstore().SupportsProtocols(ph.pid, proto); err != nil || len(sup) == 0 {
 		return nil, errProtocolNotSupported
 	}
 	ph.ids.pushSemaphore <- struct{}{}

--- a/p2p/protocol/identify/peer_loop.go
+++ b/p2p/protocol/identify/peer_loop.go
@@ -127,5 +127,5 @@ func (ph *peerHandler) openStream(ctx context.Context, proto protocol.ID) (netwo
 	// negotiate a stream without opening a new connection as we "should" already have a connection.
 	ctx, cancel := context.WithTimeout(network.WithNoDial(ctx, "should already have connection"), 30*time.Second)
 	defer cancel()
-	return ph.ids.Host.NewStream(ctx, ph.pid, protocol.ID(proto))
+	return ph.ids.Host.NewStream(ctx, ph.pid, proto)
 }

--- a/p2p/security/noise/session.go
+++ b/p2p/security/noise/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 )
 
 type secureSession struct {
@@ -134,7 +135,7 @@ func (s *secureSession) Close() error {
 	return s.insecureConn.Close()
 }
 
-func SessionWithConnState(s *secureSession, muxer string) *secureSession {
+func SessionWithConnState(s *secureSession, muxer protocol.ID) *secureSession {
 	if s != nil {
 		s.connectionState.StreamMultiplexer = muxer
 	}

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/sec"
 	"github.com/libp2p/go-libp2p/p2p/security/noise/pb"
 
@@ -37,7 +38,7 @@ func newTestTransport(t *testing.T, typ, bits int) *Transport {
 	}
 }
 
-func newTestTransportWithMuxers(t *testing.T, typ, bits int, muxers []string) *Transport {
+func newTestTransportWithMuxers(t *testing.T, typ, bits int, muxers []protocol.ID) *Transport {
 	transport := newTestTransport(t, typ, bits)
 	transport.muxers = muxers
 	return transport
@@ -632,9 +633,9 @@ func TestEarlyfffDataAcceptedWithNoHandler(t *testing.T) {
 }
 
 type noiseEarlyDataTestCase struct {
-	clientProtos   []string
-	serverProtos   []string
-	expectedResult string
+	clientProtos   []protocol.ID
+	serverProtos   []protocol.ID
+	expectedResult protocol.ID
 }
 
 func TestHandshakeWithTransportEarlyData(t *testing.T) {
@@ -645,43 +646,43 @@ func TestHandshakeWithTransportEarlyData(t *testing.T) {
 			expectedResult: "",
 		},
 		{
-			clientProtos:   []string{"muxer1"},
-			serverProtos:   []string{"muxer1"},
+			clientProtos:   []protocol.ID{"muxer1"},
+			serverProtos:   []protocol.ID{"muxer1"},
 			expectedResult: "muxer1",
 		},
 		{
-			clientProtos:   []string{"muxer1"},
-			serverProtos:   []string{},
+			clientProtos:   []protocol.ID{"muxer1"},
+			serverProtos:   []protocol.ID{},
 			expectedResult: "",
 		},
 		{
-			clientProtos:   []string{},
-			serverProtos:   []string{"muxer2"},
+			clientProtos:   []protocol.ID{},
+			serverProtos:   []protocol.ID{"muxer2"},
 			expectedResult: "",
 		},
 		{
-			clientProtos:   []string{"muxer2"},
-			serverProtos:   []string{"muxer1"},
+			clientProtos:   []protocol.ID{"muxer2"},
+			serverProtos:   []protocol.ID{"muxer1"},
 			expectedResult: "",
 		},
 		{
-			clientProtos:   []string{"muxer1", "muxer2"},
-			serverProtos:   []string{"muxer2", "muxer1"},
+			clientProtos:   []protocol.ID{"muxer1", "muxer2"},
+			serverProtos:   []protocol.ID{"muxer2", "muxer1"},
 			expectedResult: "muxer1",
 		},
 		{
-			clientProtos:   []string{"muxer3", "muxer2", "muxer1"},
-			serverProtos:   []string{"muxer2", "muxer1"},
+			clientProtos:   []protocol.ID{"muxer3", "muxer2", "muxer1"},
+			serverProtos:   []protocol.ID{"muxer2", "muxer1"},
 			expectedResult: "muxer2",
 		},
 		{
-			clientProtos:   []string{"muxer1", "muxer2"},
-			serverProtos:   []string{"muxer3"},
+			clientProtos:   []protocol.ID{"muxer1", "muxer2"},
+			serverProtos:   []protocol.ID{"muxer3"},
 			expectedResult: "",
 		},
 	}
 
-	noiseHandshake := func(t *testing.T, initProtos, respProtos []string, expectedProto string) {
+	noiseHandshake := func(t *testing.T, initProtos, respProtos []protocol.ID, expectedProto protocol.ID) {
 		initTransport := newTestTransportWithMuxers(t, crypto.Ed25519, 2048, initProtos)
 		respTransport := newTestTransportWithMuxers(t, crypto.Ed25519, 2048, respProtos)
 

--- a/p2p/security/tls/transport.go
+++ b/p2p/security/tls/transport.go
@@ -171,7 +171,7 @@ func (t *Transport) setupConn(tlsConn *tls.Conn, remotePubKey ci.PubKey) (sec.Se
 		privKey:         t.privKey,
 		remotePeer:      remotePeerID,
 		remotePubKey:    remotePubKey,
-		connectionState: network.ConnectionState{StreamMultiplexer: nextProto},
+		connectionState: network.ConnectionState{StreamMultiplexer: protocol.ID(nextProto)},
 	}, nil
 }
 

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -188,37 +188,37 @@ func TestHandshakeWithNextProtoSucceeds(t *testing.T) {
 		{
 			clientProtos:   []protocol.ID{"muxer1", "muxer2"},
 			serverProtos:   []protocol.ID{"muxer2", "muxer1"},
-			expectedResult: protocol.ID("muxer1"),
+			expectedResult: "muxer1",
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer1", "muxer2", "libp2p"},
 			serverProtos:   []protocol.ID{"muxer2", "muxer1", "libp2p"},
-			expectedResult: protocol.ID("muxer1"),
+			expectedResult: "muxer1",
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer1", "libp2p"},
 			serverProtos:   []protocol.ID{"libp2p"},
-			expectedResult: protocol.ID(""),
+			expectedResult: "",
 		},
 		{
 			clientProtos:   []protocol.ID{"libp2p"},
 			serverProtos:   []protocol.ID{"libp2p"},
-			expectedResult: protocol.ID(""),
+			expectedResult: "",
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer1"},
 			serverProtos:   []protocol.ID{},
-			expectedResult: protocol.ID(""),
+			expectedResult: "",
 		},
 		{
 			clientProtos:   []protocol.ID{},
 			serverProtos:   []protocol.ID{"muxer1"},
-			expectedResult: protocol.ID(""),
+			expectedResult: "",
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer2"},
 			serverProtos:   []protocol.ID{"muxer1"},
-			expectedResult: protocol.ID(""),
+			expectedResult: "",
 		},
 	}
 

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -180,7 +180,7 @@ func TestHandshakeSucceeds(t *testing.T) {
 type testcase struct {
 	clientProtos   []protocol.ID
 	serverProtos   []protocol.ID
-	expectedResult string
+	expectedResult protocol.ID
 }
 
 func TestHandshakeWithNextProtoSucceeds(t *testing.T) {
@@ -188,44 +188,44 @@ func TestHandshakeWithNextProtoSucceeds(t *testing.T) {
 		{
 			clientProtos:   []protocol.ID{"muxer1", "muxer2"},
 			serverProtos:   []protocol.ID{"muxer2", "muxer1"},
-			expectedResult: "muxer1",
+			expectedResult: protocol.ID("muxer1"),
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer1", "muxer2", "libp2p"},
 			serverProtos:   []protocol.ID{"muxer2", "muxer1", "libp2p"},
-			expectedResult: "muxer1",
+			expectedResult: protocol.ID("muxer1"),
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer1", "libp2p"},
 			serverProtos:   []protocol.ID{"libp2p"},
-			expectedResult: "",
+			expectedResult: protocol.ID(""),
 		},
 		{
 			clientProtos:   []protocol.ID{"libp2p"},
 			serverProtos:   []protocol.ID{"libp2p"},
-			expectedResult: "",
+			expectedResult: protocol.ID(""),
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer1"},
 			serverProtos:   []protocol.ID{},
-			expectedResult: "",
+			expectedResult: protocol.ID(""),
 		},
 		{
 			clientProtos:   []protocol.ID{},
 			serverProtos:   []protocol.ID{"muxer1"},
-			expectedResult: "",
+			expectedResult: protocol.ID(""),
 		},
 		{
 			clientProtos:   []protocol.ID{"muxer2"},
 			serverProtos:   []protocol.ID{"muxer1"},
-			expectedResult: "",
+			expectedResult: protocol.ID(""),
 		},
 	}
 
 	clientID, clientKey := createPeer(t)
 	serverID, serverKey := createPeer(t)
 
-	handshake := func(t *testing.T, clientTransport *Transport, serverTransport *Transport, expectedMuxer string) {
+	handshake := func(t *testing.T, clientTransport *Transport, serverTransport *Transport, expectedMuxer protocol.ID) {
 		clientInsecureConn, serverInsecureConn := connect(t)
 
 		serverConnChan := make(chan sec.SecureConn)

--- a/p2p/test/negotiation/muxer_test.go
+++ b/p2p/test/negotiation/muxer_test.go
@@ -119,7 +119,7 @@ func TestMuxerNegotiation(t *testing.T) {
 				require.NoError(t, err)
 				conns := client.Network().ConnsToPeer(server.ID())
 				require.Len(t, conns, 1, "expected exactly one connection")
-				require.Equal(t, tc.Expected, protocol.ID(conns[0].ConnState().StreamMultiplexer))
+				require.Equal(t, tc.Expected, conns[0].ConnState().StreamMultiplexer)
 			})
 		}
 	}

--- a/p2p/test/negotiation/muxer_test.go
+++ b/p2p/test/negotiation/muxer_test.go
@@ -69,7 +69,7 @@ func TestMuxerNegotiation(t *testing.T) {
 			Name:             "no preference overlap",
 			ServerPreference: []libp2p.Option{yamuxOpt},
 			ClientPreference: []libp2p.Option{mplexOpt},
-			Error:            "failed to negotiate stream multiplexer: protocol not supported",
+			Error:            "failed to negotiate stream multiplexer: protocols not supported",
 		},
 	}
 

--- a/p2p/test/negotiation/security_test.go
+++ b/p2p/test/negotiation/security_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
@@ -84,7 +83,7 @@ func TestSecurityNegotiation(t *testing.T) {
 			require.NoError(t, err)
 			conns := client.Network().ConnsToPeer(server.ID())
 			require.Len(t, conns, 1, "expected exactly one connection")
-			require.Equal(t, tc.Expected, protocol.ID(conns[0].ConnState().Security))
+			require.Equal(t, tc.Expected, conns[0].ConnState().Security)
 		})
 	}
 }

--- a/p2p/test/negotiation/security_test.go
+++ b/p2p/test/negotiation/security_test.go
@@ -45,7 +45,7 @@ func TestSecurityNegotiation(t *testing.T) {
 			Name:             "no  overlap",
 			ServerPreference: []libp2p.Option{noiseOpt},
 			ClientPreference: []libp2p.Option{tlsOpt},
-			Error:            "failed to negotiate security protocol: protocol not supported",
+			Error:            "failed to negotiate security protocol: protocols not supported",
 		},
 	}
 

--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -6,7 +6,6 @@ import (
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	tpt "github.com/libp2p/go-libp2p/core/transport"
 
 	"github.com/lucas-clemente/quic-go"
@@ -88,5 +87,5 @@ func (c *conn) ConnState() network.ConnectionState {
 	if _, err := c.LocalMultiaddr().ValueForProtocol(ma.P_QUIC); err == nil {
 		t = "quic"
 	}
-	return network.ConnectionState{Transport: protocol.ID(t)}
+	return network.ConnectionState{Transport: t}
 }

--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -6,6 +6,7 @@ import (
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	tpt "github.com/libp2p/go-libp2p/core/transport"
 
 	"github.com/lucas-clemente/quic-go"
@@ -87,5 +88,5 @@ func (c *conn) ConnState() network.ConnectionState {
 	if _, err := c.LocalMultiaddr().ValueForProtocol(ma.P_QUIC); err == nil {
 		t = "quic"
 	}
-	return network.ConnectionState{Transport: t}
+	return network.ConnectionState{Transport: protocol.ID(t)}
 }

--- a/test-plans/go.mod
+++ b/test-plans/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/multiformats/go-multibase v0.1.1 // indirect
 	github.com/multiformats/go-multicodec v0.7.0 // indirect
 	github.com/multiformats/go-multihash v0.2.1 // indirect
-	github.com/multiformats/go-multistream v0.3.3 // indirect
+	github.com/multiformats/go-multistream v0.4.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/onsi/ginkgo/v2 v2.5.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2 // indirect

--- a/test-plans/go.sum
+++ b/test-plans/go.sum
@@ -335,8 +335,8 @@ github.com/multiformats/go-multicodec v0.7.0/go.mod h1:GUC8upxSBE4oG+q3kWZRw/+6y
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d16Vve9l108=
 github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
-github.com/multiformats/go-multistream v0.3.3 h1:d5PZpjwRgVlbwfdTDjife7XszfZd8KYWfROYFlGcR8o=
-github.com/multiformats/go-multistream v0.3.3/go.mod h1:ODRoqamLUsETKS9BNcII4gcRsJBU5VAwRIv7O39cEXg=
+github.com/multiformats/go-multistream v0.4.0 h1:5i4JbawClkbuaX+mIVXiHQYVPxUW+zjv6w7jtSRukxc=
+github.com/multiformats/go-multistream v0.4.0/go.mod h1:BS6ZSYcA4NwYEaIMeCtpJydp2Dc+fNRA6uJMSu/m8+4=
 github.com/multiformats/go-varint v0.0.1/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=


### PR DESCRIPTION
This reduces the string to protocol.ID translations happening at various places in the code


Fixes https://github.com/libp2p/go-libp2p/issues/1886