### PR TITLE
peerstore: make it possible to use an empty peer ID

### DIFF
--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -46,7 +46,10 @@ type addrSegment struct {
 }
 
 func (segments *addrSegments) get(p peer.ID) *addrSegment {
-	return segments[byte(p[len(p)-1])]
+	if len(p) == 0 { // it's not terribly useful to use an empty peer ID, but at least we should not panic
+		return segments[0]
+	}
+	return segments[uint8(p[len(p)-1])]
 }
 
 type clock interface {

--- a/p2p/host/peerstore/test/addr_book_suite.go
+++ b/p2p/host/peerstore/test/addr_book_suite.go
@@ -135,6 +135,12 @@ func testAddAddress(ab pstore.AddrBook, clk *mockClock.Mock) func(*testing.T) {
 			ab.UpdateAddrs(id, 4*time.Second, 0)
 			AssertAddressesEqual(t, nil, ab.Addrs(id))
 		})
+
+		t.Run("accessing an empty peer ID", func(t *testing.T) {
+			addrs := GenerateAddrs(5)
+			ab.AddAddrs("", addrs, time.Hour)
+			AssertAddressesEqual(t, addrs, ab.Addrs(""))
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #2005.

You can now use the peerstore with an empty peer ID. It's treated like any regular peer ID, which means that it's possible to save and retrieve addresses for that empty peer ID.

You most likely don't want to do this. Any peer _should_ have a real peer ID.