### PR TITLE
feat: rcmgr: Export resource manager errors

### DIFF
--- a/p2p/host/resource-manager/error.go
+++ b/p2p/host/resource-manager/error.go
@@ -6,13 +6,13 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 )
 
-type errStreamOrConnLimitExceeded struct {
+type ErrStreamOrConnLimitExceeded struct {
 	current, attempted, limit int
 	err                       error
 }
 
-func (e *errStreamOrConnLimitExceeded) Error() string { return e.err.Error() }
-func (e *errStreamOrConnLimitExceeded) Unwrap() error { return e.err }
+func (e *ErrStreamOrConnLimitExceeded) Error() string { return e.err.Error() }
+func (e *ErrStreamOrConnLimitExceeded) Unwrap() error { return e.err }
 
 // edge may be "" if this is not an edge error
 func logValuesStreamLimit(scope, edge string, dir network.Direction, stat network.ScopeStat, err error) []interface{} {
@@ -22,7 +22,7 @@ func logValuesStreamLimit(scope, edge string, dir network.Direction, stat networ
 		logValues = append(logValues, "edge", edge)
 	}
 	logValues = append(logValues, "direction", dir)
-	var e *errStreamOrConnLimitExceeded
+	var e *ErrStreamOrConnLimitExceeded
 	if errors.As(err, &e) {
 		logValues = append(logValues,
 			"current", e.current,
@@ -41,7 +41,7 @@ func logValuesConnLimit(scope, edge string, dir network.Direction, usefd bool, s
 		logValues = append(logValues, "edge", edge)
 	}
 	logValues = append(logValues, "direction", dir, "usefd", usefd)
-	var e *errStreamOrConnLimitExceeded
+	var e *ErrStreamOrConnLimitExceeded
 	if errors.As(err, &e) {
 		logValues = append(logValues,
 			"current", e.current,
@@ -52,14 +52,14 @@ func logValuesConnLimit(scope, edge string, dir network.Direction, usefd bool, s
 	return append(logValues, "stat", stat, "error", err)
 }
 
-type errMemoryLimitExceeded struct {
+type ErrMemoryLimitExceeded struct {
 	current, attempted, limit int64
 	priority                  uint8
 	err                       error
 }
 
-func (e *errMemoryLimitExceeded) Error() string { return e.err.Error() }
-func (e *errMemoryLimitExceeded) Unwrap() error { return e.err }
+func (e *ErrMemoryLimitExceeded) Error() string { return e.err.Error() }
+func (e *ErrMemoryLimitExceeded) Unwrap() error { return e.err }
 
 // edge may be "" if this is not an edge error
 func logValuesMemoryLimit(scope, edge string, stat network.ScopeStat, err error) []interface{} {
@@ -68,7 +68,7 @@ func logValuesMemoryLimit(scope, edge string, stat network.ScopeStat, err error)
 	if edge != "" {
 		logValues = append(logValues, "edge", edge)
 	}
-	var e *errMemoryLimitExceeded
+	var e *ErrMemoryLimitExceeded
 	if errors.As(err, &e) {
 		logValues = append(logValues,
 			"current", e.current,

--- a/p2p/host/resource-manager/scope.go
+++ b/p2p/host/resource-manager/scope.go
@@ -130,7 +130,7 @@ func (rc *resources) checkMemory(rsvp int64, prio uint8) error {
 	}
 
 	if !addOk || newmem > threshold {
-		return &errMemoryLimitExceeded{
+		return &ErrMemoryLimitExceeded{
 			current:   rc.memory,
 			attempted: rsvp,
 			limit:     limit,
@@ -171,7 +171,7 @@ func (rc *resources) addStreams(incount, outcount int) error {
 	if incount > 0 {
 		limit := rc.limit.GetStreamLimit(network.DirInbound)
 		if rc.nstreamsIn+incount > limit {
-			return &errStreamOrConnLimitExceeded{
+			return &ErrStreamOrConnLimitExceeded{
 				current:   rc.nstreamsIn,
 				attempted: incount,
 				limit:     limit,
@@ -182,7 +182,7 @@ func (rc *resources) addStreams(incount, outcount int) error {
 	if outcount > 0 {
 		limit := rc.limit.GetStreamLimit(network.DirOutbound)
 		if rc.nstreamsOut+outcount > limit {
-			return &errStreamOrConnLimitExceeded{
+			return &ErrStreamOrConnLimitExceeded{
 				current:   rc.nstreamsOut,
 				attempted: outcount,
 				limit:     limit,
@@ -192,7 +192,7 @@ func (rc *resources) addStreams(incount, outcount int) error {
 	}
 
 	if limit := rc.limit.GetStreamTotalLimit(); rc.nstreamsIn+incount+rc.nstreamsOut+outcount > limit {
-		return &errStreamOrConnLimitExceeded{
+		return &ErrStreamOrConnLimitExceeded{
 			current:   rc.nstreamsIn + rc.nstreamsOut,
 			attempted: incount + outcount,
 			limit:     limit,
@@ -244,7 +244,7 @@ func (rc *resources) addConns(incount, outcount, fdcount int) error {
 	if incount > 0 {
 		limit := rc.limit.GetConnLimit(network.DirInbound)
 		if rc.nconnsIn+incount > limit {
-			return &errStreamOrConnLimitExceeded{
+			return &ErrStreamOrConnLimitExceeded{
 				current:   rc.nconnsIn,
 				attempted: incount,
 				limit:     limit,
@@ -255,7 +255,7 @@ func (rc *resources) addConns(incount, outcount, fdcount int) error {
 	if outcount > 0 {
 		limit := rc.limit.GetConnLimit(network.DirOutbound)
 		if rc.nconnsOut+outcount > limit {
-			return &errStreamOrConnLimitExceeded{
+			return &ErrStreamOrConnLimitExceeded{
 				current:   rc.nconnsOut,
 				attempted: outcount,
 				limit:     limit,
@@ -265,7 +265,7 @@ func (rc *resources) addConns(incount, outcount, fdcount int) error {
 	}
 
 	if connLimit := rc.limit.GetConnTotalLimit(); rc.nconnsIn+incount+rc.nconnsOut+outcount > connLimit {
-		return &errStreamOrConnLimitExceeded{
+		return &ErrStreamOrConnLimitExceeded{
 			current:   rc.nconnsIn + rc.nconnsOut,
 			attempted: incount + outcount,
 			limit:     connLimit,
@@ -275,7 +275,7 @@ func (rc *resources) addConns(incount, outcount, fdcount int) error {
 	if fdcount > 0 {
 		limit := rc.limit.GetFDLimit()
 		if rc.nfd+fdcount > limit {
-			return &errStreamOrConnLimitExceeded{
+			return &ErrStreamOrConnLimitExceeded{
 				current:   rc.nfd,
 				attempted: fdcount,
 				limit:     limit,


### PR DESCRIPTION
This lets users match against these errors with `.Is()`.