### PR TITLE
Expose muxer ids

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -34,7 +34,7 @@ var DefaultSecurity = ChainOptions(
 //
 // Use this option when you want to *extend* the set of multiplexers used by
 // libp2p instead of replacing them.
-var DefaultMuxers = Muxer("/yamux/1.0.0", yamux.DefaultTransport)
+var DefaultMuxers = Muxer(yamux.ID, yamux.DefaultTransport)
 
 // DefaultTransports are the default libp2p transports.
 //

--- a/libp2p.go
+++ b/libp2p.go
@@ -37,7 +37,7 @@ func ChainOptions(opts ...Option) Option {
 // transport protocols;
 //
 // - If no multiplexer configuration is provided, the node is configured by
-// default to use the "yamux/1.0.0" stream connection multiplexer;
+// default to use yamux;
 //
 // - If no security transport is provided, the host uses the go-libp2p's noise
 // and/or tls encrypted transport to encrypt all traffic;

--- a/libp2p.go
+++ b/libp2p.go
@@ -37,8 +37,7 @@ func ChainOptions(opts ...Option) Option {
 // transport protocols;
 //
 // - If no multiplexer configuration is provided, the node is configured by
-// default to use the "yamux/1.0.0" and "mplux/6.7.0" stream connection
-// multiplexers;
+// default to use the "yamux/1.0.0" stream connection multiplexer;
 //
 // - If no security transport is provided, the host uses the go-libp2p's noise
 // and/or tls encrypted transport to encrypt all traffic;

--- a/p2p/muxer/mplex/transport.go
+++ b/p2p/muxer/mplex/transport.go
@@ -11,6 +11,8 @@ import (
 // DefaultTransport has default settings for Transport
 var DefaultTransport = &Transport{}
 
+const ID = "/mplex/6.7.0"
+
 var _ network.Multiplexer = &Transport{}
 
 // Transport implements mux.Multiplexer that constructs

--- a/p2p/muxer/yamux/transport.go
+++ b/p2p/muxer/yamux/transport.go
@@ -12,6 +12,8 @@ import (
 
 var DefaultTransport *Transport
 
+const ID = "/yamux/1.0.0"
+
 func init() {
 	config := yamux.DefaultConfig()
 	// We've bumped this to 16MiB as this critically limits throughput.

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -82,7 +82,7 @@ func makeUpgrader(t *testing.T, n *Swarm) transport.Upgrader {
 	pk := n.Peerstore().PrivKey(id)
 	st := insecure.NewWithIdentity(insecure.ID, id, pk)
 
-	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: "/yamux/1.0.0", Muxer: yamux.DefaultTransport}}, nil, nil, nil)
+	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: yamux.ID, Muxer: yamux.DefaultTransport}}, nil, nil, nil)
 	require.NoError(t, err)
 	return u
 }

--- a/p2p/net/swarm/testing/testing.go
+++ b/p2p/net/swarm/testing/testing.go
@@ -105,7 +105,7 @@ func GenUpgrader(t *testing.T, n *swarm.Swarm, connGater connmgr.ConnectionGater
 	pk := n.Peerstore().PrivKey(id)
 	st := insecure.NewWithIdentity(insecure.ID, id, pk)
 
-	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: "/yamux/1.0.0", Muxer: yamux.DefaultTransport}}, nil, nil, connGater, opts...)
+	u, err := tptu.New([]sec.SecureTransport{st}, []tptu.StreamMuxer{{ID: yamux.ID, Muxer: yamux.DefaultTransport}}, nil, nil, connGater, opts...)
 	require.NoError(t, err)
 	return u
 }

--- a/test-plans/cmd/ping/main.go
+++ b/test-plans/cmd/ping/main.go
@@ -94,7 +94,7 @@ func main() {
 	case "yamux":
 		options = append(options, libp2p.Muxer(yamux.ID, yamux.DefaultTransport))
 	case "mplex":
-		options = append(options, libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport))
+		options = append(options, libp2p.Muxer(mplex.ID, mplex.DefaultTransport))
 	case "quic":
 	default:
 		log.Fatalf("Unsupported muxer: %s", muxer)

--- a/test-plans/cmd/ping/main.go
+++ b/test-plans/cmd/ping/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	switch muxer {
 	case "yamux":
-		options = append(options, libp2p.Muxer("/yamux/1.0.0", yamux.DefaultTransport))
+		options = append(options, libp2p.Muxer(yamux.ID, yamux.DefaultTransport))
 	case "mplex":
 		options = append(options, libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport))
 	case "quic":


### PR DESCRIPTION
The protocol IDs of the stream multiplexers are not exposed as constants, which makes using them a pretty miserable experience since you have to hunt through the code to find them. This is particularly true for mplex which, while still being the only multiplexer used in parts of the libp2p ecosystem, does not have its protocol ID referenced in go-libp2p outside of tests anymore (also the constructor documentation said `mplux` instead of `mplex`).

This exposes the protocol IDs with an exported constant `ID` as is done for Noise and TLS.

Also, fixes a documentation bug indicating that mplex was used by default.

Note: the various ipfs-camp-2019 examples can be updated as well post-release so that the constants are only defined once within go-libp2p.