### PR TITLE
autorelay: Split libp2p.EnableAutoRelay into 2 functions

### DIFF
--- a/options.go
+++ b/options.go
@@ -320,7 +320,7 @@ func EnableAutoRelay(opts ...autorelay.Option) Option {
 }
 
 // EnableAutoRelayWithStaticRelays configures libp2p to enable the AutoRelay subsystem using
-// the provided slice of relays as relay candidates
+// the provided relays as relay candidates.
 // This subsystem performs automatic address rewriting to advertise relay addresses when it
 // detects that the node is publicly unreachable (e.g. behind a NAT).
 func EnableAutoRelayWithStaticRelays(static []peer.AddrInfo, opts ...autorelay.Option) Option {
@@ -332,14 +332,14 @@ func EnableAutoRelayWithStaticRelays(static []peer.AddrInfo, opts ...autorelay.O
 }
 
 // EnableAutoRelayWithPeerSource configures libp2p to enable the AutoRelay subsystem using
-// the provided peerSource callback to get more relay candidates
+// the provided peerSource callback to get more relay candidates.
 // This subsystem performs automatic address rewriting to advertise relay addresses when it
 // detects that the node is publicly unreachable (e.g. behind a NAT).
 func EnableAutoRelayWithPeerSource(peerSource func(context.Context, int) <-chan peer.AddrInfo,
 	opts ...autorelay.Option) Option {
 	return func(cfg *Config) error {
 		cfg.EnableAutoRelay = true
-		cfg.AutoRelayOpts = append([]autorelay.Option{autorelay.WithPeerSource(peerSource, 30*time.Second)}, opts...)
+		cfg.AutoRelayOpts = append([]autorelay.Option{autorelay.WithPeerSource(peerSource)}, opts...)
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -4,7 +4,6 @@ package libp2p
 // those are in defaults.go).
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -331,12 +330,12 @@ func EnableAutoRelayWithStaticRelays(static []peer.AddrInfo, opts ...autorelay.O
 	}
 }
 
-// EnableAutoRelayWithPeerSource configures libp2p to enable the AutoRelay subsystem using
-// the provided peerSource callback to get more relay candidates.
-// This subsystem performs automatic address rewriting to advertise relay addresses when it
-// detects that the node is publicly unreachable (e.g. behind a NAT).
-func EnableAutoRelayWithPeerSource(peerSource func(context.Context, int) <-chan peer.AddrInfo,
-	opts ...autorelay.Option) Option {
+// EnableAutoRelayWithPeerSource configures libp2p to enable the AutoRelay
+// subsystem using the provided PeerSource callback to get more relay
+// candidates.  This subsystem performs automatic address rewriting to advertise
+// relay addresses when it detects that the node is publicly unreachable (e.g.
+// behind a NAT).
+func EnableAutoRelayWithPeerSource(peerSource autorelay.PeerSource, opts ...autorelay.Option) Option {
 	return func(cfg *Config) error {
 		cfg.EnableAutoRelay = true
 		cfg.AutoRelayOpts = append([]autorelay.Option{autorelay.WithPeerSource(peerSource)}, opts...)

--- a/options.go
+++ b/options.go
@@ -4,6 +4,7 @@ package libp2p
 // those are in defaults.go).
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/pnet"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -307,10 +309,37 @@ func EnableRelayService(opts ...relayv2.Option) Option {
 //
 // This subsystem performs automatic address rewriting to advertise relay addresses when it
 // detects that the node is publicly unreachable (e.g. behind a NAT).
+//
+// Deprecated: Use EnableAutoRelayWithStaticRelays or EnableAutoRelayWithPeerSource
 func EnableAutoRelay(opts ...autorelay.Option) Option {
 	return func(cfg *Config) error {
 		cfg.EnableAutoRelay = true
 		cfg.AutoRelayOpts = opts
+		return nil
+	}
+}
+
+// EnableAutoRelayWithStaticRelays configures libp2p to enable the AutoRelay subsystem using
+// the provided slice of relays as relay candidates
+// This subsystem performs automatic address rewriting to advertise relay addresses when it
+// detects that the node is publicly unreachable (e.g. behind a NAT).
+func EnableAutoRelayWithStaticRelays(static []peer.AddrInfo, opts ...autorelay.Option) Option {
+	return func(cfg *Config) error {
+		cfg.EnableAutoRelay = true
+		cfg.AutoRelayOpts = append([]autorelay.Option{autorelay.WithStaticRelays(static)}, opts...)
+		return nil
+	}
+}
+
+// EnableAutoRelayWithPeerSource configures libp2p to enable the AutoRelay subsystem using
+// the provided peerSource callback to get more relay candidates
+// This subsystem performs automatic address rewriting to advertise relay addresses when it
+// detects that the node is publicly unreachable (e.g. behind a NAT).
+func EnableAutoRelayWithPeerSource(peerSource func(context.Context, int) <-chan peer.AddrInfo,
+	opts ...autorelay.Option) Option {
+	return func(cfg *Config) error {
+		cfg.EnableAutoRelay = true
+		cfg.AutoRelayOpts = append([]autorelay.Option{autorelay.WithPeerSource(peerSource, 30*time.Second)}, opts...)
 		return nil
 	}
 }

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -62,6 +62,27 @@ func newPrivateNode(t *testing.T, opts ...autorelay.Option) host.Host {
 	return h
 }
 
+func newPrivateNodeWithPeerSource(t *testing.T, peerSource func(context.Context, int) <-chan peer.AddrInfo,
+	opts ...autorelay.Option) host.Host {
+	t.Helper()
+	h, err := libp2p.New(
+		libp2p.ForceReachabilityPrivate(),
+		libp2p.EnableAutoRelayWithPeerSource(peerSource, opts...),
+	)
+	require.NoError(t, err)
+	return h
+}
+
+func newPrivateNodeWithStaticRelays(t *testing.T, static []peer.AddrInfo, opts ...autorelay.Option) host.Host {
+	t.Helper()
+	h, err := libp2p.New(
+		libp2p.ForceReachabilityPrivate(),
+		libp2p.EnableAutoRelayWithStaticRelays(static, opts...),
+	)
+	require.NoError(t, err)
+	return h
+}
+
 func newRelay(t *testing.T) host.Host {
 	t.Helper()
 	h, err := libp2p.New(
@@ -116,8 +137,8 @@ func newRelayV1(t *testing.T) host.Host {
 
 func TestSingleCandidate(t *testing.T) {
 	var counter int
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(_ context.Context, num int) <-chan peer.AddrInfo {
+	h := newPrivateNodeWithPeerSource(t,
+		func(_ context.Context, num int) <-chan peer.AddrInfo {
 			counter++
 			require.Equal(t, 1, num)
 			peerChan := make(chan peer.AddrInfo, num)
@@ -126,10 +147,11 @@ func TestSingleCandidate(t *testing.T) {
 			t.Cleanup(func() { r.Close() })
 			peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
 			return peerChan
-		}, time.Hour),
+		},
 		autorelay.WithMaxCandidates(1),
 		autorelay.WithNumRelays(99999),
 		autorelay.WithBootDelay(0),
+		autorelay.WithMinInterval(time.Hour),
 	)
 	defer h.Close()
 
@@ -150,16 +172,17 @@ func TestSingleRelay(t *testing.T) {
 	}
 	close(peerChan)
 
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(_ context.Context, num int) <-chan peer.AddrInfo {
+	h := newPrivateNodeWithPeerSource(t,
+		func(_ context.Context, num int) <-chan peer.AddrInfo {
 			require.False(t, called, "expected the peer source callback to only have been called once")
 			called = true
 			require.Equal(t, numCandidates, num)
 			return peerChan
-		}, time.Hour),
+		},
 		autorelay.WithMaxCandidates(numCandidates),
 		autorelay.WithNumRelays(1),
 		autorelay.WithBootDelay(0),
+		autorelay.WithMinInterval(time.Hour),
 	)
 	defer h.Close()
 
@@ -177,16 +200,17 @@ func TestPreferRelayV2(t *testing.T) {
 		t.Fatal("used relay v1")
 	})
 
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo {
+	h := newPrivateNodeWithPeerSource(t,
+		func(context.Context, int) <-chan peer.AddrInfo {
 			peerChan := make(chan peer.AddrInfo, 1)
 			defer close(peerChan)
 			peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
 			return peerChan
-		}, time.Hour),
+		},
 		autorelay.WithMaxCandidates(1),
 		autorelay.WithNumRelays(99999),
 		autorelay.WithBootDelay(0),
+		autorelay.WithMinInterval(time.Hour),
 	)
 	defer h.Close()
 
@@ -195,11 +219,12 @@ func TestPreferRelayV2(t *testing.T) {
 
 func TestWaitForCandidates(t *testing.T) {
 	peerChan := make(chan peer.AddrInfo)
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo { return peerChan }, time.Hour),
+	h := newPrivateNodeWithPeerSource(t,
+		func(context.Context, int) <-chan peer.AddrInfo { return peerChan },
 		autorelay.WithMinCandidates(2),
 		autorelay.WithNumRelays(1),
 		autorelay.WithBootDelay(time.Hour),
+		autorelay.WithMinInterval(time.Hour),
 	)
 	defer h.Close()
 
@@ -243,19 +268,20 @@ func TestBackoff(t *testing.T) {
 	})
 
 	var counter int32 // to be used atomically
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo {
+	h := newPrivateNodeWithPeerSource(t,
+		func(context.Context, int) <-chan peer.AddrInfo {
 			// always return the same node, and make sure we don't try to connect to it too frequently
 			atomic.AddInt32(&counter, 1)
 			peerChan := make(chan peer.AddrInfo, 1)
 			peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
 			close(peerChan)
 			return peerChan
-		}, time.Second),
+		},
 		autorelay.WithNumRelays(1),
 		autorelay.WithBootDelay(0),
 		autorelay.WithBackoff(backoff),
 		autorelay.WithClock(cl),
+		autorelay.WithMinInterval(time.Second),
 	)
 	defer h.Close()
 
@@ -280,8 +306,8 @@ func TestStaticRelays(t *testing.T) {
 		staticRelays = append(staticRelays, peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()})
 	}
 
-	h := newPrivateNode(t,
-		autorelay.WithStaticRelays(staticRelays),
+	h := newPrivateNodeWithStaticRelays(t,
+		staticRelays,
 		autorelay.WithNumRelays(1),
 	)
 	defer h.Close()
@@ -297,9 +323,10 @@ func TestRelayV1(t *testing.T) {
 		peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
 		close(peerChan)
 
-		h := newPrivateNode(t,
-			autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo { return peerChan }, time.Hour),
+		h := newPrivateNodeWithPeerSource(t,
+			func(context.Context, int) <-chan peer.AddrInfo { return peerChan },
 			autorelay.WithBootDelay(0),
+			autorelay.WithMinInterval(time.Hour),
 		)
 		defer h.Close()
 
@@ -313,10 +340,11 @@ func TestRelayV1(t *testing.T) {
 		peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
 		close(peerChan)
 
-		h := newPrivateNode(t,
-			autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo { return peerChan }, time.Hour),
+		h := newPrivateNodeWithPeerSource(t,
+			func(context.Context, int) <-chan peer.AddrInfo { return peerChan },
 			autorelay.WithBootDelay(0),
 			autorelay.WithCircuitV1Support(),
+			autorelay.WithMinInterval(time.Hour),
 		)
 		defer h.Close()
 
@@ -337,12 +365,13 @@ func TestConnectOnDisconnect(t *testing.T) {
 		peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
 		relays = append(relays, r)
 	}
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo { return peerChan }, time.Hour),
+	h := newPrivateNodeWithPeerSource(t,
+		func(context.Context, int) <-chan peer.AddrInfo { return peerChan },
 		autorelay.WithMinCandidates(1),
 		autorelay.WithMaxCandidates(num),
 		autorelay.WithNumRelays(1),
 		autorelay.WithBootDelay(0),
+		autorelay.WithMinInterval(time.Hour),
 	)
 	defer h.Close()
 
@@ -386,19 +415,20 @@ func TestMaxAge(t *testing.T) {
 	peerChans <- peerChan2
 	close(peerChans)
 
-	h := newPrivateNode(t,
-		autorelay.WithPeerSource(func(context.Context, int) <-chan peer.AddrInfo {
+	h := newPrivateNodeWithPeerSource(t,
+		func(context.Context, int) <-chan peer.AddrInfo {
 			c, ok := <-peerChans
 			if !ok {
 				t.Fatal("unexpected call to PeerSource")
 			}
 			return c
-		}, time.Second),
+		},
 		autorelay.WithNumRelays(1),
 		autorelay.WithMaxCandidates(100),
 		autorelay.WithBootDelay(0),
 		autorelay.WithMaxCandidateAge(20*time.Minute),
 		autorelay.WithClock(cl),
+		autorelay.WithMinInterval(time.Second),
 	)
 	defer h.Close()
 
@@ -507,8 +537,8 @@ func TestReconnectToStaticRelays(t *testing.T) {
 		staticRelays = append(staticRelays, peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()})
 	}
 
-	h := newPrivateNode(t,
-		autorelay.WithStaticRelays(staticRelays),
+	h := newPrivateNodeWithStaticRelays(t,
+		staticRelays,
 		autorelay.WithClock(cl),
 	)
 
@@ -531,4 +561,26 @@ func TestReconnectToStaticRelays(t *testing.T) {
 
 	cl.Add(time.Hour)
 	expectDeltaInAddrUpdated(t, addrUpdated, -1)
+}
+
+func TestMinInterval(t *testing.T) {
+	h := newPrivateNodeWithPeerSource(t,
+		func(context.Context, int) <-chan peer.AddrInfo {
+			peerChan := make(chan peer.AddrInfo, 1)
+			defer close(peerChan)
+			r1 := newRelay(t)
+			t.Cleanup(func() { r1.Close() })
+			peerChan <- peer.AddrInfo{ID: r1.ID(), Addrs: r1.Addrs()}
+			return peerChan
+		},
+		autorelay.WithMinCandidates(2),
+		autorelay.WithNumRelays(1),
+		autorelay.WithBootDelay(time.Hour),
+		autorelay.WithMinInterval(1*time.Second),
+	)
+	defer h.Close()
+
+	// The second call to peerSource should happen after 1 second
+	require.Never(t, func() bool { return numRelays(h) > 0 }, 1*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return numRelays(h) > 0 }, 2*time.Second, 100*time.Millisecond)
 }

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -91,7 +91,7 @@ func WithPeerSource(f func(ctx context.Context, numPeers int) <-chan peer.AddrIn
 			return errAlreadyHavePeerSource
 		}
 		c.peerSource = f
-		c.minInterval = minInterval
+		WithMinInterval(minInterval)(c)
 		return nil
 	}
 }
@@ -171,6 +171,15 @@ func WithMaxCandidateAge(d time.Duration) Option {
 func WithClock(cl clock.Clock) Option {
 	return func(c *config) error {
 		c.clock = cl
+		return nil
+	}
+}
+
+// WithMinInterval sets the minimum interval after which peerSource callback will be called for more
+// candidates even if AutoRelay needs new candidates
+func WithMinInterval(interval time.Duration) Option {
+	return func(c *config) error {
+		c.minInterval = interval
 		return nil
 	}
 }

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -18,7 +18,7 @@ import (
 // send new peers, but may send peers they sent before. AutoRelay implements a
 // per-peer backoff (see WithBackoff). See WithMinInterval for setting the
 // minimum interval between calls to the callback. The context.Context passed
-// MAY be canceled when AutoRelay feels satisfied, it will be canceled when the
+// may be canceled when AutoRelay feels satisfied, it will be canceled when the
 // node is shutting down. If the context is canceled you MUST close the output
 // channel at some point.
 type PeerSource func(ctx context.Context, num int) <-chan peer.AddrInfo

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -19,7 +19,7 @@ import (
 // per-peer backoff (see WithBackoff). See WithMinInterval for setting the
 // minimum interval between calls to the callback. The context.Context passed
 // MAY be canceled when AutoRelay feels satisfied, it will be canceled when the
-// node is shutting down. If the channel is canceled you MUST close the output
+// node is shutting down. If the context is canceled you MUST close the output
 // channel at some point.
 type PeerSource func(ctx context.Context, num int) <-chan peer.AddrInfo
 

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -59,7 +59,7 @@ type relayFinder struct {
 	ctxCancel   context.CancelFunc
 	ctxCancelMx sync.Mutex
 
-	peerSource func(context.Context, int) <-chan peer.AddrInfo
+	peerSource PeerSource
 
 	candidateFound             chan struct{} // receives every time we find a new relay candidate
 	candidateMx                sync.Mutex
@@ -82,7 +82,7 @@ type relayFinder struct {
 	cachedAddrsExpiry time.Time
 }
 
-func newRelayFinder(host *basic.BasicHost, peerSource func(context.Context, int) <-chan peer.AddrInfo, conf *config) *relayFinder {
+func newRelayFinder(host *basic.BasicHost, peerSource PeerSource, conf *config) *relayFinder {
 	if peerSource == nil {
 		panic("Can not create a new relayFinder. Need a Peer Source fn or a list of static relays. Refer to the documentation around `libp2p.EnableAutoRelay`")
 	}

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -418,9 +418,9 @@ func mkHostWithStaticAutoRelay(t *testing.T, relay host.Host) host.Host {
 	h, err := libp2p.New(
 		libp2p.ListenAddrs(ma.StringCast("/ip4/127.0.0.1/tcp/0")),
 		libp2p.EnableRelay(),
-		libp2p.EnableAutoRelay(
+		libp2p.EnableAutoRelayWithStaticRelays(
+			[]peer.AddrInfo{pi},
 			autorelay.WithCircuitV1Support(),
-			autorelay.WithStaticRelays([]peer.AddrInfo{pi}),
 		),
 		libp2p.ForceReachabilityPrivate(),
 		libp2p.ResourceManager(&network.NullResourceManager{}),


### PR DESCRIPTION
Provide two specific ways to enable the autorelay subsystem libp2p.EnableAutoRelayWithStaticRelays
libp2p.EnableAutoRelayWithPeerSource

fixes: https://github.com/libp2p/go-libp2p/issues/1866