### PR TITLE
quic: rcmgr: Fix connection accounting

### DIFF
--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -32,8 +32,12 @@ var _ tpt.CapableConn = &conn{}
 // It must be called even if the peer closed the connection in order for
 // garbage collection to properly work in this package.
 func (c *conn) Close() error {
+	return c.closeWithError(0, "")
+}
+
+func (c *conn) closeWithError(errCode quic.ApplicationErrorCode, errString string) error {
 	c.transport.removeConn(c.quicConn)
-	err := c.quicConn.CloseWithError(0, "")
+	err := c.quicConn.CloseWithError(errCode, errString)
 	c.scope.Done()
 	return err
 }

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -56,15 +56,13 @@ func (l *listener) Accept() (tpt.CapableConn, error) {
 		}
 		c, err := l.setupConn(qconn)
 		if err != nil {
-			qconn.CloseWithError(1, err.Error())
-			continue
-		}
-		if l.transport.gater != nil && !(l.transport.gater.InterceptAccept(c) && l.transport.gater.InterceptSecured(network.DirInbound, c.remotePeerID, c)) {
-			c.scope.Done()
-			qconn.CloseWithError(errorCodeConnectionGating, "connection gated")
 			continue
 		}
 		l.transport.addConn(qconn, c)
+		if l.transport.gater != nil && !(l.transport.gater.InterceptAccept(c) && l.transport.gater.InterceptSecured(network.DirInbound, c.remotePeerID, c)) {
+			c.closeWithError(errorCodeConnectionGating, "connection gated")
+			continue
+		}
 
 		// return through active hole punching if any
 		key := holePunchKey{addr: qconn.RemoteAddr().String(), peer: c.remotePeerID}
@@ -84,7 +82,7 @@ func (l *listener) Accept() (tpt.CapableConn, error) {
 	}
 }
 
-func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
+func (l *listener) setupConn(qconn quic.Connection) (_c *conn, _err error) {
 	remoteMultiaddr, err := quicreuse.ToQuicMultiaddr(qconn.RemoteAddr(), qconn.ConnectionState().Version)
 	if err != nil {
 		return nil, err
@@ -95,23 +93,28 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 		log.Debugw("resource manager blocked incoming connection", "addr", qconn.RemoteAddr(), "error", err)
 		return nil, err
 	}
+	// err defer
+	defer func() {
+		if _err != nil {
+			qconn.CloseWithError(1, _err.Error())
+			connScope.Done()
+		}
+	}()
+
 	// The tls.Config used to establish this connection already verified the certificate chain.
 	// Since we don't have any way of knowing which tls.Config was used though,
 	// we have to re-determine the peer's identity here.
 	// Therefore, this is expected to never fail.
 	remotePubKey, err := p2ptls.PubKeyFromCertChain(qconn.ConnectionState().TLS.PeerCertificates)
 	if err != nil {
-		connScope.Done()
 		return nil, err
 	}
 	remotePeerID, err := peer.IDFromPublicKey(remotePubKey)
 	if err != nil {
-		connScope.Done()
 		return nil, err
 	}
 	if err := connScope.SetPeer(remotePeerID); err != nil {
 		log.Debugw("resource manager blocked incoming connection for peer", "peer", remotePeerID, "addr", qconn.RemoteAddr(), "error", err)
-		connScope.Done()
 		return nil, err
 	}
 


### PR DESCRIPTION
The quic transport didn't end the connection reservation in some error cases. The fix here is to use the "err defer" pattern to handle all error cases by checking for errors in a defer statement and finishing the scope then. This pattern is more resilient to future changes since future code doesn't have to remember to free resources on every err return statement.

Tested by having Kubo run for a while.

Before:
<img width="1268" alt="Screenshot 2023-01-27 at 10 09 03 AM" src="https://user-images.githubusercontent.com/594035/215196935-cc4c4555-11b3-4771-9dd9-f2b5b16e0271.png">


After:
<img width="1265" alt="Screenshot 2023-01-27 at 12 30 16 PM" src="https://user-images.githubusercontent.com/594035/215197090-33cca836-d65f-4337-856d-7550b11be27d.png">

This was debugged with this [commit](https://github.com/libp2p/go-libp2p/commit/016861124a5ee0c6f7207ddeabe9bf1321ff04bf). It would give some memory to the connections in the swarm and then print out any connection scopes that didn't have memory and were not done. This meant that they were created but not passed down to the swarm and not finished.