### PR TITLE
fix(basichost): Emit Connected events asynchronously

### DIFF
--- a/p2p/host/basic/peer_connectedness.go
+++ b/p2p/host/basic/peer_connectedness.go
@@ -31,7 +31,7 @@ func (w *peerConnectWatcher) ListenClose(network.Network, ma.Multiaddr) {}
 
 func (w *peerConnectWatcher) Connected(n network.Network, conn network.Conn) {
 	p := conn.RemotePeer()
-	w.handleTransition(p, n.Connectedness(p))
+	go w.handleTransition(p, n.Connectedness(p))
 }
 
 func (w *peerConnectWatcher) Disconnected(n network.Network, conn network.Conn) {


### PR DESCRIPTION
This is more of a proposal at this point; for additional context, please look at #2026.

I am aware of the discussions in https://github.com/libp2p/go-libp2p-swarm/pull/295 and https://github.com/libp2p/go-libp2p-swarm/pull/104, but I still see that emitting specifically `EvtConnectednessChanged` and specifically on a new connection is reasonable enough, so let me explain:
* I really like how @Kubuxu was able to phrase this in [here](https://github.com/libp2p/go-libp2p-swarm/pull/104#issuecomment-465095630): "_because one misbehaving consuming system affects the performance of the whole application_"
	* This is precisely what happened to me and my team in celestia-node. One hidden creeper bug exploded in our code. It's a rare case that requires a unique network setup. This bug prevented] reading out the events, which completely stops accepting new streams, halting the whole application. There were literally no other manifestations of the bug besides the client's inability to open any new streams to the buggy server, including the vital `identify` one, which was a source of our doubts initially, also considering @marten-seemann 's recent reasonable complaints about its complexity. 
	* On the other hand, it's improbable that we would find this bug so soon if events were sent asynchronously. However, this will be fixed by #2026.
* Why specifically `Connected`? Because `Disconnected` is already spawned in a new routine in [here](https://github.com/libp2p/go-libp2p/blob/34dc11547a10e7abe0a3fc615dbf839818554cab/p2p/net/swarm/swarm_conn.go#L84-L93).
	* This PR spawns a routine specifically for event submission, which is a new canonical way to handle libp2p events, but registering a malicious/buggy `Notifies.Connected` is still possible so that the fix might be moved directly to the swamp code in [here](https://github.com/libp2p/go-libp2p/blob/master/p2p/net/swarm/swarm.go#L329-L337).
* As per https://github.com/libp2p/go-libp2p-swarm/pull/295, the motivation for synchronous notifications was performance. The `Connected` event seems to be the most prevailing in the libp2p world, and launching them async again may cancel all the original goals. So here we have a classic tradeoff between performance and API safety/hygiene, and it's up to project maintainers to decide what's the best.
	* From one point of view #2026 should solve the issue. In case of malicious/buggy callback deployed, the application devs depend on node operators to report the issue if it happens in runtime, so interactively, the issue is fixed just by that PR, keeping performance gains.
	* On the other hand, by sacrificing a bit of performance, the system will continue operating without halts, althoug still expecting  node operators to report the issue.