### PR TITLE
rcmgr: *: Always close connscope

### DIFF
--- a/p2p/protocol/circuitv2/client/transport.go
+++ b/p2p/protocol/circuitv2/client/transport.go
@@ -53,13 +53,20 @@ func (c *Client) Dial(ctx context.Context, a ma.Multiaddr, p peer.ID) (transport
 	if err != nil {
 		return nil, err
 	}
-	if err := connScope.SetPeer(p); err != nil {
+	conn, err := c.dialAndUpgrade(ctx, a, p, connScope)
+	if err != nil {
 		connScope.Done()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *Client) dialAndUpgrade(ctx context.Context, a ma.Multiaddr, p peer.ID, connScope network.ConnManagementScope) (transport.CapableConn, error) {
+	if err := connScope.SetPeer(p); err != nil {
 		return nil, err
 	}
 	conn, err := c.dial(ctx, a, p)
 	if err != nil {
-		connScope.Done()
 		return nil, err
 	}
 	conn.tagHop()

--- a/p2p/transport/quic/conn.go
+++ b/p2p/transport/quic/conn.go
@@ -32,8 +32,12 @@ var _ tpt.CapableConn = &conn{}
 // It must be called even if the peer closed the connection in order for
 // garbage collection to properly work in this package.
 func (c *conn) Close() error {
+	return c.closeWithError(0, "")
+}
+
+func (c *conn) closeWithError(errCode quic.ApplicationErrorCode, errString string) error {
 	c.transport.removeConn(c.quicConn)
-	err := c.quicConn.CloseWithError(0, "")
+	err := c.quicConn.CloseWithError(errCode, errString)
 	c.scope.Done()
 	return err
 }

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -56,15 +56,13 @@ func (l *listener) Accept() (tpt.CapableConn, error) {
 		}
 		c, err := l.setupConn(qconn)
 		if err != nil {
-			qconn.CloseWithError(1, err.Error())
-			continue
-		}
-		if l.transport.gater != nil && !(l.transport.gater.InterceptAccept(c) && l.transport.gater.InterceptSecured(network.DirInbound, c.remotePeerID, c)) {
-			c.scope.Done()
-			qconn.CloseWithError(errorCodeConnectionGating, "connection gated")
 			continue
 		}
 		l.transport.addConn(qconn, c)
+		if l.transport.gater != nil && !(l.transport.gater.InterceptAccept(c) && l.transport.gater.InterceptSecured(network.DirInbound, c.remotePeerID, c)) {
+			c.closeWithError(errorCodeConnectionGating, "connection gated")
+			continue
+		}
 
 		// return through active hole punching if any
 		key := holePunchKey{addr: qconn.RemoteAddr().String(), peer: c.remotePeerID}
@@ -84,7 +82,7 @@ func (l *listener) Accept() (tpt.CapableConn, error) {
 	}
 }
 
-func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
+func (l *listener) setupConn(qconn quic.Connection) (_c *conn, _err error) {
 	remoteMultiaddr, err := quicreuse.ToQuicMultiaddr(qconn.RemoteAddr(), qconn.ConnectionState().Version)
 	if err != nil {
 		return nil, err
@@ -95,23 +93,28 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 		log.Debugw("resource manager blocked incoming connection", "addr", qconn.RemoteAddr(), "error", err)
 		return nil, err
 	}
+	// err defer
+	defer func() {
+		if _err != nil {
+			qconn.CloseWithError(1, _err.Error())
+			connScope.Done()
+		}
+	}()
+
 	// The tls.Config used to establish this connection already verified the certificate chain.
 	// Since we don't have any way of knowing which tls.Config was used though,
 	// we have to re-determine the peer's identity here.
 	// Therefore, this is expected to never fail.
 	remotePubKey, err := p2ptls.PubKeyFromCertChain(qconn.ConnectionState().TLS.PeerCertificates)
 	if err != nil {
-		connScope.Done()
 		return nil, err
 	}
 	remotePeerID, err := peer.IDFromPublicKey(remotePubKey)
 	if err != nil {
-		connScope.Done()
 		return nil, err
 	}
 	if err := connScope.SetPeer(remotePeerID); err != nil {
 		log.Debugw("resource manager blocked incoming connection for peer", "peer", remotePeerID, "addr", qconn.RemoteAddr(), "error", err)
-		connScope.Done()
 		return nil, err
 	}
 

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -181,14 +181,22 @@ func (t *TcpTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) 
 		log.Debugw("resource manager blocked outgoing connection", "peer", p, "addr", raddr, "error", err)
 		return nil, err
 	}
+
+	c, err := t.dialWithScope(ctx, raddr, p, connScope)
+	if err != nil {
+		connScope.Done()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (t *TcpTransport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p peer.ID, connScope network.ConnManagementScope) (transport.CapableConn, error) {
 	if err := connScope.SetPeer(p); err != nil {
 		log.Debugw("resource manager blocked outgoing connection for peer", "peer", p, "addr", raddr, "error", err)
-		connScope.Done()
 		return nil, err
 	}
 	conn, err := t.maDial(ctx, raddr)
 	if err != nil {
-		connScope.Done()
 		return nil, err
 	}
 	// Set linger to 0 so we never get stuck in the TIME-WAIT state. When
@@ -201,7 +209,6 @@ func (t *TcpTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) 
 		var err error
 		c, err = newTracingConn(conn, true)
 		if err != nil {
-			connScope.Done()
 			return nil, err
 		}
 	}

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -161,9 +161,17 @@ func (t *WebsocketTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p pee
 	if err != nil {
 		return nil, err
 	}
-	macon, err := t.maDial(ctx, raddr)
+	c, err := t.dialWithScope(ctx, raddr, p, connScope)
 	if err != nil {
 		connScope.Done()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (t *WebsocketTransport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p peer.ID, connScope network.ConnManagementScope) (transport.CapableConn, error) {
+	macon, err := t.maDial(ctx, raddr)
+	if err != nil {
 		return nil, err
 	}
 	conn, err := t.upgrader.Upgrade(ctx, t, macon, network.DirOutbound, p, connScope)


### PR DESCRIPTION
Fixes #2033.

Closes #2025  and closes #2031 .

The general pattern here is replacing 

```
func ...Dial() {
  connScope := ...
  
  err := ...
  if err != nil {
    connScope.Done()
  }
  
    err := ...
  if err != nil {
    connScope.Done()
  }
  
    err := ...
  if err != nil {
    connScope.Done()
  }
}
```

With: 

```
func ...Dial() {
  connScope := ...
  
  c, err := dialWithScope
  
  if err != nil {
    connScope.Done()
    return nil, err
  }
  
  return c, nil
}

func dialWithScope(..., connScope) {
  if err != nil {
     return nil, err
  }
}
```