### PR TITLE
notifications: fix TestListenAddressNotif

### DIFF
--- a/p2p/test/notifications/notification_test.go
+++ b/p2p/test/notifications/notification_test.go
@@ -61,6 +61,9 @@ func TestListenAddressNotif(t *testing.T) {
 		ev := e.(event.EvtLocalAddressesUpdated)
 		require.Empty(t, ev.Removed)
 		require.Len(t, ev.Current, 2)
+		if ev.Current[0].Action == event.Added {
+			ev.Current[0], ev.Current[1] = ev.Current[1], ev.Current[0]
+		}
 		require.Equal(t, ev.Current[0], event.UpdatedAddress{Address: initialAddr, Action: event.Maintained})
 		require.Equal(t, ev.Current[1].Action, event.Added)
 		newAddr = ev.Current[1].Address


### PR DESCRIPTION
The order of the received addresses isn't fixed. It's received from Swarm.listenAddressesNoLock which is iterating over a map. 