### PR TITLE
metrics: use a single slice pool for all metrics tracer

### DIFF
--- a/p2p/host/eventbus/basic_metrics.go
+++ b/p2p/host/eventbus/basic_metrics.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/libp2p/go-libp2p/p2p/metricshelper"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -107,23 +109,43 @@ func NewMetricsTracer(opts ...MetricsTracerOption) MetricsTracer {
 }
 
 func (m *metricsTracer) EventEmitted(typ reflect.Type) {
-	eventsEmitted.WithLabelValues(strings.TrimPrefix(typ.String(), "event.")).Inc()
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, strings.TrimPrefix(typ.String(), "event."))
+	eventsEmitted.WithLabelValues(*tags...).Inc()
 }
 
 func (m *metricsTracer) AddSubscriber(typ reflect.Type) {
-	totalSubscribers.WithLabelValues(strings.TrimPrefix(typ.String(), "event.")).Inc()
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, strings.TrimPrefix(typ.String(), "event."))
+	totalSubscribers.WithLabelValues(*tags...).Inc()
 }
 
 func (m *metricsTracer) RemoveSubscriber(typ reflect.Type) {
-	totalSubscribers.WithLabelValues(strings.TrimPrefix(typ.String(), "event.")).Dec()
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, strings.TrimPrefix(typ.String(), "event."))
+	totalSubscribers.WithLabelValues(*tags...).Dec()
 }
 
 func (m *metricsTracer) SubscriberQueueLength(name string, n int) {
-	subscriberQueueLength.WithLabelValues(name).Set(float64(n))
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, name)
+	subscriberQueueLength.WithLabelValues(*tags...).Set(float64(n))
 }
 
 func (m *metricsTracer) SubscriberQueueFull(name string, isFull bool) {
-	observer := subscriberQueueFull.WithLabelValues(name)
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, name)
+	observer := subscriberQueueFull.WithLabelValues(*tags...)
 	if isFull {
 		observer.Set(1)
 	} else {
@@ -132,5 +154,9 @@ func (m *metricsTracer) SubscriberQueueFull(name string, isFull bool) {
 }
 
 func (m *metricsTracer) SubscriberEventQueued(name string) {
-	subscriberEventQueued.WithLabelValues(name).Inc()
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, name)
+	subscriberEventQueued.WithLabelValues(*tags...).Inc()
 }

--- a/p2p/host/eventbus/basic_metrics_test.go
+++ b/p2p/host/eventbus/basic_metrics_test.go
@@ -9,8 +9,11 @@ import (
 
 func BenchmarkEventEmitted(b *testing.B) {
 	b.ReportAllocs()
-	types := []reflect.Type{reflect.TypeOf(new(event.EvtLocalAddressesUpdated)), reflect.TypeOf(new(event.EvtNATDeviceTypeChanged)),
-		reflect.TypeOf(new(event.EvtLocalProtocolsUpdated))}
+	types := []reflect.Type{
+		reflect.TypeOf(new(event.EvtLocalAddressesUpdated)),
+		reflect.TypeOf(new(event.EvtNATDeviceTypeChanged)),
+		reflect.TypeOf(new(event.EvtLocalProtocolsUpdated)),
+	}
 	mt := NewMetricsTracer()
 	for i := 0; i < b.N; i++ {
 		mt.EventEmitted(types[i%len(types)])

--- a/p2p/metricshelper/pool.go
+++ b/p2p/metricshelper/pool.go
@@ -1,0 +1,26 @@
+package metricshelper
+
+import (
+	"fmt"
+	"sync"
+)
+
+const capacity = 8
+
+var stringPool = sync.Pool{New: func() any {
+	s := make([]string, 0, capacity)
+	return &s
+}}
+
+func GetStringSlice() *[]string {
+	s := stringPool.Get().(*[]string)
+	*s = (*s)[:0]
+	return s
+}
+
+func PutStringSlice(s *[]string) {
+	if c := cap(*s); c < capacity {
+		panic(fmt.Sprintf("expected a string slice with capacity 8 or greater, got %d", c))
+	}
+	stringPool.Put(s)
+}

--- a/p2p/metricshelper/pool_test.go
+++ b/p2p/metricshelper/pool_test.go
@@ -1,0 +1,21 @@
+package metricshelper
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringSlicePool(t *testing.T) {
+	for i := 0; i < 1e5; i++ {
+		s := GetStringSlice()
+		require.Empty(t, *s)
+		require.Equal(t, 8, cap(*s))
+		*s = append(*s, "foo")
+		*s = append(*s, "bar")
+		if rand.Int()%3 == 0 {
+			PutStringSlice(s)
+		}
+	}
+}


### PR DESCRIPTION
This PR:
1. Adds a global string slice pool, to be used by all of our metrics collectors. Using a single pool reduces code duplication and makes the `sync.Pool` more efficient.
2. Makes use of this pool for the event bus metrics, bringing down the number of allocs for events from 1 to 0.

cc @sukunrt You can use this for the AutoNAT metrics.