### PR TITLE
identify: add some basic metrics

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -230,12 +230,14 @@ func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
 			identify.UserAgent(opts.UserAgent),
 			identify.ProtocolVersion(opts.ProtocolVersion),
 			identify.DisableSignedPeerRecord(),
+			identify.WithMetricsTracer(identify.NewMetricsTracer()),
 		)
 	} else {
 		h.ids, err = identify.NewIDService(
 			h,
 			identify.UserAgent(opts.UserAgent),
 			identify.ProtocolVersion(opts.ProtocolVersion),
+			identify.WithMetricsTracer(identify.NewMetricsTracer()),
 		)
 	}
 	if err != nil {

--- a/p2p/host/resource-manager/obs/stats.go
+++ b/p2p/host/resource-manager/obs/stats.go
@@ -8,8 +8,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const metricNamespace = "libp2p_rcmgr"
+
 var (
-	metricNamespace = "libp2p_rcmgr"
 
 	// Conns
 	conns = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/p2p/metricshelper/dir.go
+++ b/p2p/metricshelper/dir.go
@@ -1,0 +1,14 @@
+package metricshelper
+
+import "github.com/libp2p/go-libp2p/core/network"
+
+func GetDirection(dir network.Direction) string {
+	switch dir {
+	case network.DirOutbound:
+		return "outbound"
+	case network.DirInbound:
+		return "inbound"
+	default:
+		return "unknown"
+	}
+}

--- a/p2p/net/swarm/swarm_metrics.go
+++ b/p2p/net/swarm/swarm_metrics.go
@@ -94,17 +94,6 @@ func NewMetricsTracer() *metricsTracer {
 	return &metricsTracer{}
 }
 
-func getDirection(dir network.Direction) string {
-	switch dir {
-	case network.DirOutbound:
-		return "outbound"
-	case network.DirInbound:
-		return "inbound"
-	default:
-		return "unknown"
-	}
-}
-
 func appendConnectionState(tags []string, cs network.ConnectionState) []string {
 	if cs.Transport == "" {
 		// This shouldn't happen, unless the transport doesn't properly set the Transport field in the ConnectionState.
@@ -123,12 +112,12 @@ func (m *metricsTracer) OpenedConnection(dir network.Direction, p crypto.PubKey,
 	tags := metricshelper.GetStringSlice()
 	defer metricshelper.PutStringSlice(tags)
 
-	*tags = append(*tags, getDirection(dir))
+	*tags = append(*tags, metricshelper.GetDirection(dir))
 	*tags = appendConnectionState(*tags, cs)
 	connsOpened.WithLabelValues(*tags...).Inc()
 
 	*tags = (*tags)[:0]
-	*tags = append(*tags, getDirection(dir))
+	*tags = append(*tags, metricshelper.GetDirection(dir))
 	*tags = append(*tags, p.Type().String())
 	keyTypes.WithLabelValues(*tags...).Inc()
 }
@@ -137,12 +126,12 @@ func (m *metricsTracer) ClosedConnection(dir network.Direction, duration time.Du
 	tags := metricshelper.GetStringSlice()
 	defer metricshelper.PutStringSlice(tags)
 
-	*tags = append(*tags, getDirection(dir))
+	*tags = append(*tags, metricshelper.GetDirection(dir))
 	*tags = appendConnectionState(*tags, cs)
 	connsClosed.WithLabelValues(*tags...).Inc()
 
 	*tags = (*tags)[:0]
-	*tags = append(*tags, getDirection(dir))
+	*tags = append(*tags, metricshelper.GetDirection(dir))
 	*tags = appendConnectionState(*tags, cs)
 	connDuration.WithLabelValues(*tags...).Observe(duration.Seconds())
 }

--- a/p2p/protocol/identify/grafana-dashboards/dashboard.json
+++ b/p2p/protocol/identify/grafana-dashboards/dashboard.json
@@ -1,0 +1,355 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.3.6"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(libp2p_identify_identify_total[$__rate_interval])",
+          "legendFormat": "{{dir}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Identify Messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(libp2p_identify_identify_push_total[$__rate_interval])",
+          "legendFormat": "{{dir}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Identify Push Messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(libp2p_identify_identify_pushes_triggered_total[$__rate_interval])",
+          "legendFormat": "{{trigger}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pushes triggered",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "libp2p Identify",
+  "uid": "0NDzQQ0Vz",
+  "version": 4,
+  "weekStart": ""
+}

--- a/p2p/protocol/identify/metrics.go
+++ b/p2p/protocol/identify/metrics.go
@@ -1,0 +1,92 @@
+package identify
+
+import (
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/metricshelper"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricNamespace = "libp2p_identify"
+
+var (
+	pushesTriggered = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Name:      "identify_pushes_triggered_total",
+			Help:      "Pushes Triggered",
+		},
+		[]string{"trigger"},
+	)
+	identify = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Name:      "identify_total",
+			Help:      "Identify",
+		},
+		[]string{"dir"},
+	)
+	identifyPush = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Name:      "identify_push_total",
+			Help:      "Identify Push",
+		},
+		[]string{"dir"},
+	)
+)
+
+var initMetricsOnce sync.Once
+
+func initMetrics() {
+	prometheus.MustRegister(pushesTriggered, identify, identifyPush)
+}
+
+type MetricsTracer interface {
+	TriggeredPushes(event any)
+	Identify(network.Direction)
+	IdentifyPush(network.Direction)
+}
+
+type metricsTracer struct{}
+
+var _ MetricsTracer = &metricsTracer{}
+
+func NewMetricsTracer() MetricsTracer {
+	initMetricsOnce.Do(initMetrics)
+	return &metricsTracer{}
+}
+
+func (t *metricsTracer) TriggeredPushes(ev any) {
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	typ := "unknown"
+	switch ev.(type) {
+	case event.EvtLocalProtocolsUpdated:
+		typ = "protocols_updated"
+	case event.EvtLocalAddressesUpdated:
+		typ = "addresses_updated"
+	}
+	*tags = append(*tags, typ)
+	pushesTriggered.WithLabelValues(*tags...).Inc()
+}
+
+func (t *metricsTracer) Identify(dir network.Direction) {
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, metricshelper.GetDirection(dir))
+	identify.WithLabelValues(*tags...).Inc()
+}
+
+func (t *metricsTracer) IdentifyPush(dir network.Direction) {
+	tags := metricshelper.GetStringSlice()
+	defer metricshelper.PutStringSlice(tags)
+
+	*tags = append(*tags, metricshelper.GetDirection(dir))
+	identifyPush.WithLabelValues(*tags...).Inc()
+}

--- a/p2p/protocol/identify/opts.go
+++ b/p2p/protocol/identify/opts.go
@@ -4,6 +4,7 @@ type config struct {
 	protocolVersion         string
 	userAgent               string
 	disableSignedPeerRecord bool
+	metricsTracer           MetricsTracer
 }
 
 // Option is an option function for identify.
@@ -29,5 +30,11 @@ func UserAgent(ua string) Option {
 func DisableSignedPeerRecord() Option {
 	return func(cfg *config) {
 		cfg.disableSignedPeerRecord = true
+	}
+}
+
+func WithMetricsTracer(tr MetricsTracer) Option {
+	return func(cfg *config) {
+		cfg.metricsTracer = tr
 	}
 }


### PR DESCRIPTION
We're introducing some pretty substantial changes to the Identify protocol. It would be good to have some basic metrics.
We can probably do a lot more here, but this is a beginning so we're not flying completely blind.

Part of #2019.