### PR TITLE
interop-tests: use new action with s3 caching

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build image
         run: docker build -t go-libp2p-head -f test-plans/PingDockerfile .
-      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@482e8ac2e5d91c69d7f432d325337e2ddca39cf9
+      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@master
         with:
           test-filter: go-libp2p-head
           extra-versions: ${{ github.workspace }}/test-plans/ping-version.json

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -13,7 +13,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build image
         run: docker build -t go-libp2p-head -f test-plans/PingDockerfile .
-      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@c9130e425d266e5b222636d61348c0f8d6b978e4
+      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@482e8ac2e5d91c69d7f432d325337e2ddca39cf9
         with:
           test-filter: go-libp2p-head
           extra-versions: ${{ github.workspace }}/test-plans/ping-version.json
+          s3-cache-bucket: libp2p-by-tf-aws-bootstrap
+          s3-access-key-id: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}


### PR DESCRIPTION
Uses the new action from https://github.com/libp2p/test-plans/pull/121