### PR TITLE
mocknet: Start host in mocknet

### DIFF
--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -122,6 +122,7 @@ func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps peerstore.Peerstore) (host
 	if err != nil {
 		return nil, err
 	}
+	h.Start()
 
 	mn.Lock()
 	mn.nets[n.peer] = n


### PR DESCRIPTION
#1984 introduced a `.Start` method for the identify service. And this is started when you call `host.Start`. Mocknet, perhaps incorrectly, did not call host.Start after creating the host. This fixes that.