### PR TITLE
holepunch: flaky test: Try increasing timeout only

### DIFF
--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -469,7 +469,7 @@ func makeRelayedHosts(t *testing.T, h1opt, h2opt []holepunch.Option, addHolePunc
 	require.Eventually(t, func() bool {
 		supported, err := h.Peerstore().SupportsProtocols(relay.ID(), proto.ProtoIDv2Hop, relayv1.ProtoID)
 		return err == nil && len(supported) > 0
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	h2 = mkHostWithStaticAutoRelay(t, relay)
 	if addHolePuncher {


### PR DESCRIPTION
We've seen a couple failures here. I want to try increasing the timeout first before investing more time here.

Not sure why 3 seconds isn't enough *after* we have a connection to get the protocol info. We could block on an event from the eventbus, but we'd probably want a timeout there as well so it seems like we'd run into the same issue.