### PR TITLE
use atomic.Bool instead of int32 operations

### DIFF
--- a/p2p/net/swarm/dial_sync_test.go
+++ b/p2p/net/swarm/dial_sync_test.go
@@ -162,7 +162,7 @@ func TestDialSyncAllCancel(t *testing.T) {
 }
 
 func TestFailFirst(t *testing.T) {
-	var count int32
+	var handledFirst atomic.Bool
 	dialErr := fmt.Errorf("gophers ate the modem")
 	f := func(p peer.ID, reqch <-chan dialRequest) {
 		go func() {
@@ -172,7 +172,7 @@ func TestFailFirst(t *testing.T) {
 					return
 				}
 
-				if atomic.CompareAndSwapInt32(&count, 0, 1) {
+				if handledFirst.CompareAndSwap(false, true) {
 					req.resch <- dialResponse{err: dialErr}
 				} else {
 					req.resch <- dialResponse{conn: new(Conn)}

--- a/p2p/protocol/circuitv1/relay/relay.go
+++ b/p2p/protocol/circuitv1/relay/relay.go
@@ -37,7 +37,7 @@ const (
 )
 
 type Relay struct {
-	closed int32
+	closed atomic.Bool
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -83,7 +83,7 @@ func NewRelay(h host.Host, opts ...Option) (*Relay, error) {
 }
 
 func (r *Relay) Close() error {
-	if atomic.CompareAndSwapInt32(&r.closed, 0, 1) {
+	if r.closed.CompareAndSwap(false, true) {
 		r.host.RemoveStreamHandler(ProtoID)
 		r.scope.Done()
 		r.cancel()

--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -41,7 +41,7 @@ var log = logging.Logger("relay")
 
 // Relay is the (limited) relay service object.
 type Relay struct {
-	closed uint32
+	closed atomic.Bool
 	ctx    context.Context
 	cancel func()
 
@@ -104,7 +104,7 @@ func New(h host.Host, opts ...Option) (*Relay, error) {
 }
 
 func (r *Relay) Close() error {
-	if atomic.CompareAndSwapUint32(&r.closed, 0, 1) {
+	if r.closed.CompareAndSwap(false, true) {
 		r.host.RemoveStreamHandler(proto.ProtoIDv2Hop)
 		r.scope.Done()
 		r.cancel()


### PR DESCRIPTION
Fixes: https://github.com/libp2p/go-libp2p/issues/2043

@marten-seemann 
There are a bunch of uses of int32 and int64 as atomic counters with atomic.AddInt32 or atomic.AddInt64. We can replace those with atomic.Int32 and atomic.Int64. Should I change those too? 