### PR TITLE
autonat: don't emit reachability changed events on address change

### DIFF
--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -287,11 +287,6 @@ func (as *AmbientAutoNAT) scheduleProbe() time.Duration {
 func (as *AmbientAutoNAT) recordObservation(observation autoNATResult) {
 	currentStatus := as.status.Load()
 
-	// Ignore public observations with no address
-	if observation.Reachability == network.ReachabilityPublic && observation.address == nil {
-		return
-	}
-
 	if observation.Reachability == network.ReachabilityPublic {
 		log.Debugf("NAT status is public")
 		changed := false

--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -286,10 +286,18 @@ func (as *AmbientAutoNAT) scheduleProbe() time.Duration {
 // Update the current status based on an observed result.
 func (as *AmbientAutoNAT) recordObservation(observation autoNATResult) {
 	currentStatus := as.status.Load()
+
+	// Ignore public observations with no address
+	if observation.Reachability == network.ReachabilityPublic && observation.address == nil {
+		return
+	}
+
 	if observation.Reachability == network.ReachabilityPublic {
 		log.Debugf("NAT status is public")
 		changed := false
 		if currentStatus.Reachability != network.ReachabilityPublic {
+			// Aggressively switch to public from other states ignoring confidence
+
 			// we are flipping our NATStatus, so confidence drops to 0
 			as.confidence = 0
 			if as.service != nil {
@@ -299,21 +307,13 @@ func (as *AmbientAutoNAT) recordObservation(observation autoNATResult) {
 		} else if as.confidence < 3 {
 			as.confidence++
 		}
-		if observation.address != nil {
-			if !changed && currentStatus.address != nil && !observation.address.Equal(currentStatus.address) {
-				as.confidence--
-			}
-			if currentStatus.address == nil || !observation.address.Equal(currentStatus.address) {
-				changed = true
-			}
-			as.status.Store(&observation)
-		}
-		if observation.address != nil && changed {
+		as.status.Store(&observation)
+		if changed {
 			as.emitStatus()
 		}
 	} else if observation.Reachability == network.ReachabilityPrivate {
 		log.Debugf("NAT status is private")
-		if currentStatus.Reachability == network.ReachabilityPublic {
+		if currentStatus.Reachability != network.ReachabilityPrivate {
 			if as.confidence > 0 {
 				as.confidence--
 			} else {
@@ -328,9 +328,6 @@ func (as *AmbientAutoNAT) recordObservation(observation autoNATResult) {
 		} else if as.confidence < 3 {
 			as.confidence++
 			as.status.Store(&observation)
-			if currentStatus.Reachability != network.ReachabilityPrivate {
-				as.emitStatus()
-			}
 		}
 	} else if as.confidence > 0 {
 		// don't just flip to unknown, reduce confidence first

--- a/p2p/host/autonat/autonat_test.go
+++ b/p2p/host/autonat/autonat_test.go
@@ -252,6 +252,21 @@ func TestAutoNATObservationRecording(t *testing.T) {
 		t.Fatalf("too-extreme private transition.")
 	}
 
+	// don't emit events on observed address change
+	newAddr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/udp/12345")
+	an.recordObservation(autoNATResult{network.ReachabilityPublic, newAddr})
+	if an.Status() != network.ReachabilityPublic {
+		t.Fatalf("reachability should stay public")
+	}
+	select {
+	case e := <-s.Out():
+		_, ok := e.(event.EvtLocalReachabilityChanged)
+		if ok {
+			t.Fatal("received event without state transition")
+		}
+
+	case <-time.After(1 * time.Second):
+	}
 }
 
 func TestStaticNat(t *testing.T) {

--- a/p2p/host/autonat/autonat_test.go
+++ b/p2p/host/autonat/autonat_test.go
@@ -246,12 +246,8 @@ func TestAutoNATObservationRecording(t *testing.T) {
 		t.Fatalf("reachability should stay public")
 	}
 	select {
-	case e := <-s.Out():
-		_, ok := e.(event.EvtLocalReachabilityChanged)
-		if ok {
-			t.Fatal("received event without state transition")
-		}
-
+	case <-s.Out():
+		t.Fatal("received event without state transition")
 	case <-time.After(1 * time.Second):
 	}
 }

--- a/p2p/host/autonat/autonat_test.go
+++ b/p2p/host/autonat/autonat_test.go
@@ -248,7 +248,7 @@ func TestAutoNATObservationRecording(t *testing.T) {
 	select {
 	case <-s.Out():
 		t.Fatal("received event without state transition")
-	case <-time.After(1 * time.Second):
+	case <-time.After(300 * time.Millisecond):
 	}
 }
 

--- a/p2p/host/autonat/autonat_test.go
+++ b/p2p/host/autonat/autonat_test.go
@@ -209,19 +209,6 @@ func TestAutoNATObservationRecording(t *testing.T) {
 		t.Fatalf("failed to subscribe to event EvtLocalRoutabilityPublic, err=%s", err)
 	}
 
-	// pubic observation without address should be ignored.
-	an.recordObservation(autoNATResult{network.ReachabilityPublic, nil})
-	if an.Status() != network.ReachabilityUnknown {
-		t.Fatalf("unexpected transition")
-	}
-
-	select {
-	case <-s.Out():
-		t.Fatal("not expecting a public reachability event")
-	default:
-		// expected
-	}
-
 	addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/udp/1234")
 	an.recordObservation(autoNATResult{network.ReachabilityPublic, addr})
 	if an.Status() != network.ReachabilityPublic {


### PR DESCRIPTION
fixes: https://github.com/libp2p/go-libp2p/issues/2046

@marten-seemann I've changed:

1. No events are emitted if only the observed address is changed.
2. All observations with reachability = Public and addr = nil are ignored. 
    - previously this caused an increase in confidence.
3. transition from unknown to private now begins with confidence = 0. 
    - previously this begin with confidence = 1 