### PR TITLE
relaymanager: do not start new relay if one already exists

### DIFF
--- a/p2p/host/relaysvc/relay.go
+++ b/p2p/host/relaysvc/relay.go
@@ -65,14 +65,18 @@ func (m *RelayManager) background(ctx context.Context) {
 func (m *RelayManager) reachabilityChanged(r network.Reachability) error {
 	switch r {
 	case network.ReachabilityPublic:
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+		// ignore events with no reachability change
+		if m.relay != nil {
+			return nil
+		}
 		relay, err := relayv2.New(m.host, m.opts...)
 		if err != nil {
 			return err
 		}
-		m.mutex.Lock()
-		defer m.mutex.Unlock()
 		m.relay = relay
-	case network.ReachabilityPrivate:
+	default:
 		m.mutex.Lock()
 		defer m.mutex.Unlock()
 		if m.relay != nil {

--- a/p2p/host/relaysvc/relay.go
+++ b/p2p/host/relaysvc/relay.go
@@ -67,7 +67,8 @@ func (m *RelayManager) reachabilityChanged(r network.Reachability) error {
 	case network.ReachabilityPublic:
 		m.mutex.Lock()
 		defer m.mutex.Unlock()
-		// ignore events with no reachability change
+		// This could happen if two consecutive EvtLocalReachabilityChanged report the same reachability.
+		// This shouldn't happen, but it's safer to double-check.
 		if m.relay != nil {
 			return nil
 		}

--- a/p2p/host/relaysvc/relay_test.go
+++ b/p2p/host/relaysvc/relay_test.go
@@ -25,7 +25,7 @@ func TestReachabilityChangeEvent(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool { rmgr.mutex.Lock(); defer rmgr.mutex.Unlock(); return rmgr.relay != nil },
-		200*time.Millisecond,
+		1*time.Second,
 		100*time.Millisecond,
 		"relay should be set on public reachability")
 
@@ -34,7 +34,7 @@ func TestReachabilityChangeEvent(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool { rmgr.mutex.Lock(); defer rmgr.mutex.Unlock(); return rmgr.relay == nil },
-		200*time.Millisecond,
+		1*time.Second,
 		100*time.Millisecond,
 		"relay should be nil on private reachability")
 
@@ -45,7 +45,7 @@ func TestReachabilityChangeEvent(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool { rmgr.mutex.Lock(); defer rmgr.mutex.Unlock(); return rmgr.relay == nil },
-		200*time.Millisecond,
+		1*time.Second,
 		100*time.Millisecond,
 		"relay should be nil on unknown reachability")
 
@@ -55,13 +55,13 @@ func TestReachabilityChangeEvent(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool { rmgr.mutex.Lock(); defer rmgr.mutex.Unlock(); relay = rmgr.relay; return relay != nil },
+		1*time.Second,
 		100*time.Millisecond,
-		10*time.Millisecond,
 		"relay should be set on public event")
 	emitter.Emit(evt)
 	require.Never(t,
 		func() bool { rmgr.mutex.Lock(); defer rmgr.mutex.Unlock(); return relay != rmgr.relay },
-		200*time.Millisecond,
+		1*time.Second,
 		100*time.Millisecond,
 		"relay should not be updated on receiving the same event")
 }

--- a/p2p/host/relaysvc/relay_test.go
+++ b/p2p/host/relaysvc/relay_test.go
@@ -1,0 +1,29 @@
+package relaysvc
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	bhost "github.com/libp2p/go-libp2p/p2p/host/blank"
+	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReachabilityChangeEvent(t *testing.T) {
+	h := bhost.NewBlankHost(swarmt.GenSwarm(t))
+	rmgr := NewRelayManager(h)
+	rmgr.reachabilityChanged(network.ReachabilityPublic)
+	require.NotNil(t, rmgr.relay, "relay should be set on public reachability")
+
+	rmgr.reachabilityChanged(network.ReachabilityPrivate)
+	require.Nil(t, rmgr.relay, "relay should be nil on private reachability")
+
+	rmgr.reachabilityChanged(network.ReachabilityPublic)
+	rmgr.reachabilityChanged(network.ReachabilityUnknown)
+	require.Nil(t, rmgr.relay, "relay should be nil on unknown reachability")
+
+	rmgr.reachabilityChanged(network.ReachabilityPublic)
+	relay := rmgr.relay
+	rmgr.reachabilityChanged(network.ReachabilityPublic)
+	require.Equal(t, relay, rmgr.relay, "relay should not be started on receiving the same event")
+}


### PR DESCRIPTION
fixes: https://github.com/libp2p/go-libp2p/issues/2091