### PR TITLE
identify: deduplicate Identify snapshots

### DIFF
--- a/p2p/protocol/identify/snapshot.go
+++ b/p2p/protocol/identify/snapshot.go
@@ -1,0 +1,40 @@
+package identify
+
+import (
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/record"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+type identifySnapshot struct {
+	Sequence  uint64
+	Protocols []protocol.ID
+	Addrs     []ma.Multiaddr
+	Record    *record.Envelope
+}
+
+// Equal tells if two snapshots are identical.
+// It *does not* check for equality of the sequence number.
+func (s identifySnapshot) Equal(s2 *identifySnapshot) bool {
+	if len(s.Protocols) != len(s2.Protocols) || len(s.Addrs) != len(s2.Addrs) {
+		return false
+	}
+	if (s.Record == nil && s2.Record != nil) || (s.Record != nil && s2.Record == nil) {
+		return false
+	}
+	if s.Record != nil && !s.Record.Equal(s2.Record) {
+		return false
+	}
+	for i, p := range s.Protocols {
+		if p != s2.Protocols[i] {
+			return false
+		}
+	}
+	for i, a := range s.Addrs {
+		if !a.Equal(s2.Addrs[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/p2p/protocol/identify/snapshot_test.go
+++ b/p2p/protocol/identify/snapshot_test.go
@@ -1,0 +1,33 @@
+package identify
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/record"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotEqual(t *testing.T) {
+	_, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	addr1 := ma.StringCast("/ip4/127.0.0.1/tcp/1234")
+	addr2 := ma.StringCast("/ip4/127.0.0.1/tcp/1235")
+	env1 := &record.Envelope{PublicKey: pub, RawPayload: []byte("foo")}
+	env2 := &record.Envelope{PublicKey: pub, RawPayload: []byte("bar")}
+	require.True(t, identifySnapshot{}.Equal(&identifySnapshot{}))
+	require.True(t, identifySnapshot{Sequence: 1}.Equal(&identifySnapshot{Sequence: 2}))
+	require.True(t, identifySnapshot{Protocols: []protocol.ID{"a"}}.Equal(&identifySnapshot{Protocols: []protocol.ID{"a"}}))
+	require.False(t, identifySnapshot{Protocols: []protocol.ID{"a"}}.Equal(&identifySnapshot{Protocols: []protocol.ID{"b"}}))
+	require.False(t, identifySnapshot{}.Equal(&identifySnapshot{Protocols: []protocol.ID{"b"}}))
+	require.True(t, identifySnapshot{Addrs: []ma.Multiaddr{addr1}}.Equal(&identifySnapshot{Addrs: []ma.Multiaddr{addr1}}))
+	require.False(t, identifySnapshot{Addrs: []ma.Multiaddr{addr1}}.Equal(&identifySnapshot{Addrs: []ma.Multiaddr{addr2}}))
+	require.False(t, identifySnapshot{Record: env1}.Equal(&identifySnapshot{}))
+	require.False(t, identifySnapshot{Record: env1}.Equal(&identifySnapshot{Record: env2}))
+	require.False(t, identifySnapshot{}.Equal(&identifySnapshot{Record: env2}))
+	require.True(t, identifySnapshot{Record: env2}.Equal(&identifySnapshot{Record: env2}))
+}


### PR DESCRIPTION
As a result of (the now fixed) https://github.com/libp2p/go-libp2p/issues/2046, we were sending a lot of Identify Push messages into the network that were exactly identical to the previous message.

Since sending pushes is relatively expensive (we contact every peer we're connected to) it pays off to be a bit more careful. This PR now adds an explicit check that the new snapshot actually changes protocols, addresses or record.