### PR TITLE
quic: don't send detailed error messages when closing connections

### DIFF
--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -96,7 +96,7 @@ func (l *listener) setupConn(qconn quic.Connection) (*conn, error) {
 	c, err := l.setupConnWithScope(qconn, connScope, remoteMultiaddr)
 	if err != nil {
 		connScope.Done()
-		qconn.CloseWithError(1, err.Error())
+		qconn.CloseWithError(1, "")
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #1928.

I know this PR will make some people unhappy, but we really shouldn't send the peer a detailed error message here, as this might allow an attacker to gain a lot of insight into how a node under attack is coping with the attack. This error message has proved useful in debugging recent incidents on the IPFS network, but ultimately it's the wrong solution to the problem.
For example:
* it only works on QUIC
* and only for errors that occur during connection setup

Instead, we should have error codes: https://github.com/libp2p/specs/issues/479