### PR TITLE
quic: fix stalled virtual listener

### DIFF
--- a/p2p/transport/quic/virtuallistener.go
+++ b/p2p/transport/quic/virtuallistener.go
@@ -146,9 +146,19 @@ func (r *acceptLoopRunner) innerAccept(l *listener, expectedVersion quic.Version
 
 func (r *acceptLoopRunner) Accept(l *listener, expectedVersion quic.VersionNumber, bufferedConnChan chan acceptVal) (tpt.CapableConn, error) {
 	for {
-		r.acceptSem <- struct{}{}
-		conn, err := r.innerAccept(l, expectedVersion, bufferedConnChan)
-		<-r.acceptSem
+		var conn tpt.CapableConn
+		var err error
+		select {
+		case r.acceptSem <- struct{}{}:
+			conn, err = r.innerAccept(l, expectedVersion, bufferedConnChan)
+			<-r.acceptSem
+		case v, ok := <-bufferedConnChan:
+			if !ok {
+				return nil, errors.New("listener closed")
+			}
+			conn = v.conn
+			err = v.err
+		}
 
 		if conn == nil && err == nil {
 			// Didn't find a conn for the expected version and there was no error, lets try again

--- a/p2p/transport/quic/virtuallistener.go
+++ b/p2p/transport/quic/virtuallistener.go
@@ -152,17 +152,17 @@ func (r *acceptLoopRunner) Accept(l *listener, expectedVersion quic.VersionNumbe
 		case r.acceptSem <- struct{}{}:
 			conn, err = r.innerAccept(l, expectedVersion, bufferedConnChan)
 			<-r.acceptSem
+
+			if conn == nil && err == nil {
+				// Didn't find a conn for the expected version and there was no error, lets try again
+				continue
+			}
 		case v, ok := <-bufferedConnChan:
 			if !ok {
 				return nil, errors.New("listener closed")
 			}
 			conn = v.conn
 			err = v.err
-		}
-
-		if conn == nil && err == nil {
-			// Didn't find a conn for the expected version and there was no error, lets try again
-			continue
 		}
 		return conn, err
 	}

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -110,7 +110,8 @@ func (r *reuse) gc() {
 		select {
 		case <-r.closeChan:
 			return
-		case now := <-ticker.C:
+		case <-ticker.C:
+			now := time.Now()
 			r.mutex.Lock()
 			for key, conn := range r.global {
 				if conn.ShouldGarbageCollect(now) {

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -110,8 +110,7 @@ func (r *reuse) gc() {
 		select {
 		case <-r.closeChan:
 			return
-		case <-ticker.C:
-			now := time.Now()
+		case now := <-ticker.C:
 			r.mutex.Lock()
 			for key, conn := range r.global {
 				if conn.ShouldGarbageCollect(now) {


### PR DESCRIPTION
Fixes a case that only really shows up in CI where a listener can be stalled. This lead to some test flakiness.