### PR TITLE
don't use the time value from the time.Ticker channel

### DIFF
--- a/p2p/host/pstoremanager/pstoremanager.go
+++ b/p2p/host/pstoremanager/pstoremanager.go
@@ -109,7 +109,8 @@ func (m *PeerstoreManager) background(ctx context.Context, sub event.Subscriptio
 				// If we reconnect to the peer before we've cleared the information, keep it.
 				delete(disconnected, p)
 			}
-		case now := <-ticker.C:
+		case <-ticker.C:
+			now := time.Now()
 			for p, disconnectTime := range disconnected {
 				if disconnectTime.Add(m.gracePeriod).Before(now) {
 					m.pstore.RemovePeer(p)

--- a/p2p/net/connmgr/decay.go
+++ b/p2p/net/connmgr/decay.go
@@ -157,15 +157,14 @@ func (d *decayer) process() {
 
 	var (
 		bmp   bumpCmd
-		now   time.Time
 		visit = make(map[*decayingTag]struct{})
 	)
 
 	for {
 		select {
-		case now = <-ticker.C:
-			nn := now
-			d.lastTick.Store(&nn)
+		case <-ticker.C:
+			now := d.clock.Now()
+			d.lastTick.Store(&now)
 
 			d.tagsMu.Lock()
 			for _, tag := range d.knownTags {

--- a/p2p/protocol/holepunch/tracer.go
+++ b/p2p/protocol/holepunch/tracer.go
@@ -227,7 +227,8 @@ func (t *tracer) gc() {
 
 	for {
 		select {
-		case now := <-timer.C:
+		case <-timer.C:
+			now := time.Now()
 			t.mutex.Lock()
 			for id, entry := range t.peers {
 				if entry.last.Before(now.Add(-tracerCacheDuration)) {

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -110,7 +110,8 @@ func (r *reuse) gc() {
 		select {
 		case <-r.closeChan:
 			return
-		case now := <-ticker.C:
+		case <-ticker.C:
+			now := time.Now()
 			r.mutex.Lock()
 			for key, conn := range r.global {
 				if conn.ShouldGarbageCollect(now) {

--- a/p2p/transport/webtransport/cert_manager.go
+++ b/p2p/transport/webtransport/cert_manager.go
@@ -138,7 +138,8 @@ func (m *certManager) background(hostKey ic.PrivKey) {
 			select {
 			case <-m.ctx.Done():
 				return
-			case now := <-t.C:
+			case <-t.C:
+				now := m.clock.Now()
 				m.mx.Lock()
 				if err := m.rollConfig(hostKey); err != nil {
 					log.Errorw("rolling config failed", "error", err)


### PR DESCRIPTION
Generally doing something like `now := <-ticker.C` is wrong. The time in the channel is the time when the ticker was triggered, but may not be the current time when you pull from the channel. In a fast runtime these two are pretty close. In a slow runtime they aren't. This becomes a problem when we drop tick events, so the receiver will only get the old event and not the new one, thus breaking the logic that relies on the current time.

Changes this to make an explicit call to get the current time.