### PR TITLE
examples: chat-with-rendezvous: Bootstrap after connecting to bootstrappers

### DIFF
--- a/examples/chat-with-rendezvous/chat.go
+++ b/examples/chat-with-rendezvous/chat.go
@@ -119,13 +119,6 @@ func main() {
 		panic(err)
 	}
 
-	// Bootstrap the DHT. In the default configuration, this spawns a Background
-	// thread that will refresh the peer table every five minutes.
-	logger.Debug("Bootstrapping the DHT")
-	if err = kademliaDHT.Bootstrap(ctx); err != nil {
-		panic(err)
-	}
-
 	// Let's connect to the bootstrap nodes first. They will tell us about the
 	// other nodes in the network.
 	var wg sync.WaitGroup
@@ -142,6 +135,13 @@ func main() {
 		}()
 	}
 	wg.Wait()
+
+	// Bootstrap the DHT. In the default configuration, this spawns a Background
+	// thread that will refresh the peer table every five minutes.
+	logger.Debug("Bootstrapping the DHT")
+	if err = kademliaDHT.Bootstrap(ctx); err != nil {
+		panic(err)
+	}
 
 	// We use a rendezvous point "meet me here" to announce our location.
 	// This is like telling your friends to meet you at the Eiffel Tower.


### PR DESCRIPTION
I think this is the right thing to do? The other way would work eventually because of the background timer.