### PR TITLE
swarm: Check context once more before dialing

### DIFF
--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -482,6 +482,11 @@ func (s *Swarm) dialAddr(ctx context.Context, p peer.ID, addr ma.Multiaddr) (tra
 	if s.local == p {
 		return nil, ErrDialToSelf
 	}
+	// Check before we start work
+	if err := ctx.Err(); err != nil {
+		log.Debugf("%s swarm not dialing. Context cancelled: %v. %s %s", s.local, err, p, addr)
+		return nil, err
+	}
 	log.Debugf("%s swarm dialing %s %s", s.local, p, addr)
 
 	tpt := s.TransportForDialing(addr)


### PR DESCRIPTION
We may as well check the context before asking the transport to do any work. In some cases the saves us work since the transport may be doing things before checking the context. You my argue that's an issue with the transport, and that's fair and correct. But it's easy and cheap to check here once before involving the transport.