### PR TITLE
swarm: no parallel dials in CI

### DIFF
--- a/p2p/host/autonat/autonat_test.go
+++ b/p2p/host/autonat/autonat_test.go
@@ -193,7 +193,7 @@ func TestAutoNATIncomingEvents(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return an.Status() != network.ReachabilityUnknown
-	}, 500*time.Millisecond, 10*time.Millisecond, "Expected probe due to identification of autonat service")
+	}, 5*time.Second, 100*time.Millisecond, "Expected probe due to identification of autonat service")
 }
 
 func TestAutoNATObservationRecording(t *testing.T) {

--- a/p2p/host/autonat/svc_test.go
+++ b/p2p/host/autonat/svc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/blank"
+	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -44,6 +45,7 @@ func makeAutoNATClient(t *testing.T) (host.Host, Client) {
 
 // Note: these tests assume that the host has only private network addresses!
 func TestAutoNATServiceDialRefused(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -69,6 +71,7 @@ func TestAutoNATServiceDialRefused(t *testing.T) {
 }
 
 func TestAutoNATServiceDialSuccess(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -89,6 +92,7 @@ func TestAutoNATServiceDialSuccess(t *testing.T) {
 }
 
 func TestAutoNATServiceDialRateLimiter(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -129,6 +133,7 @@ func TestAutoNATServiceDialRateLimiter(t *testing.T) {
 }
 
 func TestAutoNATServiceGlobalLimiter(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -169,6 +174,7 @@ func TestAutoNATServiceGlobalLimiter(t *testing.T) {
 }
 
 func TestAutoNATServiceRateLimitJitter(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	c := makeAutoNATConfig(t)
 	defer c.host.Close()
 	defer c.dialer.Close()
@@ -194,6 +200,7 @@ func TestAutoNATServiceRateLimitJitter(t *testing.T) {
 }
 
 func TestAutoNATServiceStartup(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	h := bhost.NewBlankHost(swarmt.GenSwarm(t))
 	defer h.Close()
 	dh := bhost.NewBlankHost(swarmt.GenSwarm(t))

--- a/p2p/host/autonat/svc_test.go
+++ b/p2p/host/autonat/svc_test.go
@@ -96,8 +96,8 @@ func TestAutoNATServiceDialRateLimiter(t *testing.T) {
 	defer c.host.Close()
 	defer c.dialer.Close()
 
-	c.dialTimeout = 200 * time.Millisecond
-	c.throttleResetPeriod = 200 * time.Millisecond
+	c.dialTimeout = 5 * time.Second
+	c.throttleResetPeriod = 1 * time.Second
 	c.throttleResetJitter = 0
 	c.throttlePeerMax = 1
 	_ = makeAutoNATService(t, c)
@@ -122,10 +122,10 @@ func TestAutoNATServiceDialRateLimiter(t *testing.T) {
 
 	time.Sleep(400 * time.Millisecond)
 
-	_, err = ac.DialBack(ctx, c.host.ID())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Eventually(t, func() bool {
+		_, err = ac.DialBack(ctx, c.host.ID())
+		return err == nil
+	}, 5*time.Second, time.Second)
 }
 
 func TestAutoNATServiceGlobalLimiter(t *testing.T) {
@@ -136,7 +136,7 @@ func TestAutoNATServiceGlobalLimiter(t *testing.T) {
 	defer c.host.Close()
 	defer c.dialer.Close()
 
-	c.dialTimeout = time.Second
+	c.dialTimeout = 3 * time.Second
 	c.throttleResetPeriod = 10 * time.Second
 	c.throttleResetJitter = 0
 	c.throttlePeerMax = 1

--- a/p2p/net/swarm/dial_test.go
+++ b/p2p/net/swarm/dial_test.go
@@ -426,6 +426,8 @@ func TestDialBackoff(t *testing.T) {
 }
 
 func TestDialBackoffClears(t *testing.T) {
+	// This test relies on parallel dials
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	const dialTimeout = 3 * time.Second
 	swarms := makeSwarms(t, 2, swarmt.WithSwarmOpts(swarm.WithDialTimeout(dialTimeout)))
 	defer closeSwarms(swarms)
@@ -538,6 +540,8 @@ func newSilentListener(t *testing.T) ([]ma.Multiaddr, net.Listener) {
 }
 
 func TestDialSimultaneousJoin(t *testing.T) {
+	// This test relies on concurrent dials
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	const dialTimeout = 3 * time.Second
 
 	swarms := makeSwarms(t, 2, swarmt.WithSwarmOpts(swarm.WithDialTimeout(dialTimeout)))

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -292,6 +292,8 @@ func TestDialWorkerLoopConcurrentMix(t *testing.T) {
 }
 
 func TestDialWorkerLoopConcurrentFailureStress(t *testing.T) {
+	defer SwapDefaultPerPeerRateLimit(SwapDefaultPerPeerRateLimit(8))
+
 	s1 := makeSwarm(t)
 	defer s1.Close()
 

--- a/p2p/net/swarm/limiter.go
+++ b/p2p/net/swarm/limiter.go
@@ -54,7 +54,7 @@ func newDialLimiter(df dialfunc) *dialLimiter {
 			fd = int(n)
 		}
 	}
-	return newDialLimiterWithParams(df, fd, DefaultPerPeerRateLimit)
+	return newDialLimiterWithParams(df, fd, GetDefaultPerPeerRateLimit())
 }
 
 func newDialLimiterWithParams(df dialfunc, fdLimit, perPeerLimit int) *dialLimiter {

--- a/p2p/net/swarm/limiter_test.go
+++ b/p2p/net/swarm/limiter_test.go
@@ -227,7 +227,7 @@ func TestTokenRedistribution(t *testing.T) {
 	select {
 	case <-resch:
 		t.Fatal("no dials should have completed!")
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 	}
 
 	// unblock one dial for peer 0
@@ -238,14 +238,14 @@ func TestTokenRedistribution(t *testing.T) {
 		if res.Err == nil {
 			t.Fatal("should have only been a failure here")
 		}
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 		t.Fatal("expected a dial failure here")
 	}
 
 	select {
 	case <-resch:
 		t.Fatal("no more dials should have completed!")
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 	}
 
 	// add a bad dial job to peer 0 to fill their rate limiter
@@ -266,7 +266,7 @@ func TestTokenRedistribution(t *testing.T) {
 		if res.Err == nil {
 			t.Fatal("should have only been a failure here")
 		}
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 		t.Fatal("expected a dial failure here")
 	}
 
@@ -275,7 +275,7 @@ func TestTokenRedistribution(t *testing.T) {
 		if res.Err != nil {
 			t.Fatal("should have succeeded!")
 		}
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 		t.Fatal("should have gotten successful dial")
 	}
 }

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -190,7 +191,11 @@ func NewSwarm(local peer.ID, peers peerstore.Peerstore, opts ...Option) (*Swarm,
 	}
 
 	s.dsync = newDialSync(s.dialWorkerLoop)
-	s.limiter = newDialLimiter(s.dialAddr)
+	if os.Getenv("CI") != "" {
+		s.limiter = newDialLimiter(s.dialAddrForCI)
+	} else {
+		s.limiter = newDialLimiter(s.dialAddr)
+	}
 	s.backf.init(s.ctx)
 	return s, nil
 }

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -23,15 +23,19 @@ import (
 	madns "github.com/multiformats/go-multiaddr-dns"
 )
 
-const (
-	defaultDialTimeout = 15 * time.Second
+const defaultDialTimeout = 15 * time.Second
 
-	// defaultDialTimeoutLocal is the maximum duration a Dial to local network address
-	// is allowed to take.
-	// This includes the time between dialing the raw network connection,
-	// protocol selection as well the handshake, if applicable.
-	defaultDialTimeoutLocal = 5 * time.Second
-)
+// defaultDialTimeoutLocal is the maximum duration a Dial to local network address
+// is allowed to take.
+// This includes the time between dialing the raw network connection,
+// protocol selection as well the handshake, if applicable.
+var defaultDialTimeoutLocal = 5 * time.Second
+
+func init() {
+	if os.Getenv("CI") != "" {
+		defaultDialTimeoutLocal = 30 * time.Second
+	}
+}
 
 var log = logging.Logger("swarm2")
 

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -476,6 +476,22 @@ func (s *Swarm) limitedDial(ctx context.Context, p peer.ID, a ma.Multiaddr, resp
 	})
 }
 
+var pacer = map[peer.ID]int{}
+var pacerMu *sync.Mutex = &sync.Mutex{}
+
+// dialAddrForCI same as dialAddr but adds some sleep between dials so that we
+// don't concurrent dials at the same time. Note that the
+// DefaultPerPeerRateLimit doesn't solve this for us since it's possible that
+// the second (serial) dial finishes before the context is cancelled
+func (s *Swarm) dialAddrForCI(ctx context.Context, p peer.ID, addr ma.Multiaddr) (transport.CapableConn, error) {
+	pacerMu.Lock()
+	val := pacer[p]
+	pacer[p] = val + 1
+	pacerMu.Unlock()
+	time.Sleep((time.Duration(val) * 50 * time.Millisecond) % (time.Duration(GetDefaultPerPeerRateLimit()+1) * 50 * time.Millisecond))
+	return s.dialAddr(ctx, p, addr)
+}
+
 // dialAddr is the actual dial for an addr, indirectly invoked through the limiter
 func (s *Swarm) dialAddr(ctx context.Context, p peer.ID, addr ma.Multiaddr) (transport.CapableConn, error) {
 	// Just to double check. Costs nothing.

--- a/p2p/net/swarm/swarm_net_test.go
+++ b/p2p/net/swarm/swarm_net_test.go
@@ -35,11 +35,6 @@ func TestConnectednessCorrect(t *testing.T) {
 	dial(nets[1], nets[2])
 	dial(nets[3], nets[2])
 
-	// The notifications for new connections get sent out asynchronously.
-	// There is the potential for a race condition here, so we sleep to ensure
-	// that they have been received.
-	time.Sleep(time.Millisecond * 100)
-
 	// test those connected show up correctly
 
 	// test connected
@@ -57,7 +52,6 @@ func TestConnectednessCorrect(t *testing.T) {
 	require.NotZerof(t, nets[1].ConnsToPeer(nets[3].LocalPeer()), "net 1 should have no connections to net 3")
 	require.NoError(t, nets[2].ClosePeer(nets[1].LocalPeer()))
 
-	time.Sleep(time.Millisecond * 50)
 	expectConnectedness(t, nets[2], nets[1], network.NotConnected)
 
 	for _, n := range nets {
@@ -66,17 +60,11 @@ func TestConnectednessCorrect(t *testing.T) {
 }
 
 func expectConnectedness(t *testing.T, a, b network.Network, expected network.Connectedness) {
-	es := "%s is connected to %s, but Connectedness incorrect. %s %s %s"
-	atob := a.Connectedness(b.LocalPeer())
-	btoa := b.Connectedness(a.LocalPeer())
-	if atob != expected {
-		t.Errorf(es, a, b, printConns(a), printConns(b), atob)
-	}
-
-	// test symmetric case
-	if btoa != expected {
-		t.Errorf(es, b, a, printConns(b), printConns(a), btoa)
-	}
+	require.Eventually(t, func() bool {
+		atob := a.Connectedness(b.LocalPeer())
+		btoa := b.Connectedness(a.LocalPeer())
+		return atob == expected && btoa == expected
+	}, 10*time.Second, 100*time.Millisecond, "Expected %s to be %s to %s.\nA: %s \nB: %s", a, expected, b, printConns(a), printConns(b))
 }
 
 func printConns(n network.Network) string {

--- a/p2p/protocol/circuitv2/relay/relay_test.go
+++ b/p2p/protocol/circuitv2/relay/relay_test.go
@@ -197,7 +197,7 @@ func TestRelayLimitTime(t *testing.T) {
 	})
 
 	rc := relay.DefaultResources()
-	rc.Limit.Duration = time.Second
+	rc.Limit.Duration = 4 * time.Second
 
 	r, err := relay.New(hosts[1], relay.WithResources(rc))
 	if err != nil {
@@ -237,7 +237,7 @@ func TestRelayLimitTime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(8 * time.Second)
 	n, err := s.Write([]byte("should be closed"))
 	if n > 0 {
 		t.Fatalf("expected to write 0 bytes, wrote %d", n)

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/proto"
 	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
@@ -80,6 +81,7 @@ func (s *mockIDService) OwnObservedAddrs() []ma.Multiaddr {
 }
 
 func TestNoHolePunchIfDirectConnExists(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	tr := &mockEventTracer{}
 	h1, hps := mkHostWithHolePunchSvc(t, holepunch.WithTracer(tr))
 	defer h1.Close()
@@ -102,6 +104,7 @@ func TestNoHolePunchIfDirectConnExists(t *testing.T) {
 }
 
 func TestDirectDialWorks(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	// mark all addresses as public
 	cpy := manet.Private4
 	manet.Private4 = []*net.IPNet{}
@@ -126,6 +129,7 @@ func TestDirectDialWorks(t *testing.T) {
 }
 
 func TestEndToEndSimConnect(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	h1tr := &mockEventTracer{}
 	h2tr := &mockEventTracer{}
 	h1, h2, relay, _ := makeRelayedHosts(t, []holepunch.Option{holepunch.WithTracer(h1tr)}, []holepunch.Option{holepunch.WithTracer(h2tr)}, true)
@@ -165,6 +169,7 @@ func TestEndToEndSimConnect(t *testing.T) {
 }
 
 func TestFailuresOnInitiator(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	tcs := map[string]struct {
 		rhandler         func(s network.Stream)
 		errMsg           string
@@ -256,6 +261,7 @@ func addrsToBytes(as []ma.Multiaddr) [][]byte {
 }
 
 func TestFailuresOnResponder(t *testing.T) {
+	defer swarm.SwapDefaultPerPeerRateLimit(swarm.SwapDefaultPerPeerRateLimit(8))
 	tcs := map[string]struct {
 		initiator        func(s network.Stream)
 		errMsg           string

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -143,7 +143,7 @@ func TestEndToEndSimConnect(t *testing.T) {
 			h2Events = h2tr.getEvents()
 			return len(h2Events) == 3
 		},
-		time.Second,
+		3*time.Second,
 		10*time.Millisecond,
 	)
 	require.Equal(t, holepunch.StartHolePunchEvtT, h2Events[0].Type)
@@ -229,7 +229,7 @@ func TestFailuresOnInitiator(t *testing.T) {
 			require.Eventually(t, func() bool {
 				protos, _ := h2.Peerstore().SupportsProtocols(h1.ID(), holepunch.Protocol)
 				return len(protos) > 0
-			}, 200*time.Millisecond, 10*time.Millisecond)
+			}, 5*time.Second, 10*time.Millisecond)
 
 			if tc.rhandler != nil {
 				h1.SetStreamHandler(holepunch.Protocol, tc.rhandler)


### PR DESCRIPTION
Leaving this in draft until we decide we need this.

The pros:
1. Dialing in CI becomes more deterministic. I'm not sure it's fully deterministic since addresses aren't strictly sorted before being dialed. 
2. We don't worry about race conditions around two connections showing up at the same time. This solves a whole class of racey flakes.
3. We do less work overall which makes the runtime faster and avoids the class of bugs around slow runtimes.

The cons:
1. It's a slightly different dial path than what users use. It would be better to make the stock dial path work here.
  a. The counter argument is that unless users are constantly dialing localhost, the network latency will mean that in practice it's uncommon to get multiple connections succeeding in parallel.
2. Some tests relay on parallel dials. While I think I've identified them all, it still requires an extra line of code to make them work.