### PR TITLE
rcmgr: fix JSON marshalling of ResourceManagerStat peer map

### DIFF
--- a/p2p/host/resource-manager/extapi.go
+++ b/p2p/host/resource-manager/extapi.go
@@ -2,6 +2,7 @@ package rcmgr
 
 import (
 	"bytes"
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -33,6 +34,23 @@ type ResourceManagerStat struct {
 	Services  map[string]network.ScopeStat
 	Protocols map[protocol.ID]network.ScopeStat
 	Peers     map[peer.ID]network.ScopeStat
+}
+
+func (s ResourceManagerStat) MarshalJSON() ([]byte, error) {
+	// we want to marshal the encoded peer id
+	encodedPeerMap := make(map[string]network.ScopeStat, len(s.Peers))
+	for p, v := range s.Peers {
+		encodedPeerMap[p.String()] = v
+	}
+
+	type Alias ResourceManagerStat
+	return json.Marshal(&struct {
+		*Alias
+		Peers map[string]network.ScopeStat `json:",omitempty"`
+	}{
+		Alias: (*Alias)(&s),
+		Peers: encodedPeerMap,
+	})
 }
 
 var _ ResourceManagerState = (*resourceManager)(nil)

--- a/p2p/host/resource-manager/extapi_test.go
+++ b/p2p/host/resource-manager/extapi_test.go
@@ -1,0 +1,26 @@
+package rcmgr
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceManagerStatRoundTrip(t *testing.T) {
+	validPeerID, err := peer.Decode("QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
+	require.NoError(t, err)
+
+	n := ResourceManagerStat{
+		Peers: map[peer.ID]network.ScopeStat{validPeerID: {}},
+	}
+	b, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	rt := ResourceManagerStat{}
+	require.NoError(t, json.Unmarshal(b, &rt))
+
+	require.Equal(t, n, rt)
+}


### PR DESCRIPTION
Fixes #2155 

We need a better solution here. Some alternative solutions are here: https://github.com/libp2p/go-libp2p-resource-manager/pull/67#issuecomment-1176820561.

I think we should get a quick fix in here to unblock Kubo folks, but would be good to solve this more generally.