### PR TITLE
Create a new type for peer id

### DIFF
--- a/core/metrics/bandwidth_test.go
+++ b/core/metrics/bandwidth_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/test"
 
 	"github.com/libp2p/go-flow-metrics"
 
@@ -36,7 +36,7 @@ func round(bwc *BandwidthCounter, b *testing.B) {
 	var wg sync.WaitGroup
 	wg.Add(10000)
 	for i := 0; i < 1000; i++ {
-		p := peer.ID(fmt.Sprintf("peer-%d", i))
+		p := test.MustPeerIDFromSeed(fmt.Sprintf("peer-%d", i))
 		for j := 0; j < 10; j++ {
 			proto := protocol.ID(fmt.Sprintf("bitswap-%d", j))
 			go func() {
@@ -62,7 +62,7 @@ func TestBandwidthCounter(t *testing.T) {
 	bwc := NewBandwidthCounter()
 	for i := 0; i < 40; i++ {
 		for i := 0; i < 100; i++ {
-			p := peer.ID(fmt.Sprintf("peer-%d", i))
+			p := test.MustPeerIDFromSeed(fmt.Sprintf("peer-%d", i))
 			for j := 0; j < 2; j++ {
 				proto := protocol.ID(fmt.Sprintf("proto-%d", j))
 
@@ -93,7 +93,7 @@ func TestBandwidthCounter(t *testing.T) {
 		byPeer := bwc.GetBandwidthByPeer()
 		require.Len(t, byPeer, 100, "expected 100 peers")
 		for i := 0; i < 100; i++ {
-			p := peer.ID(fmt.Sprintf("peer-%d", i))
+			p := test.MustPeerIDFromSeed(fmt.Sprintf("peer-%d", i))
 			for _, stats := range [...]Stats{bwc.GetBandwidthForPeer(p), byPeer[p]} {
 				check(stats)
 			}
@@ -118,7 +118,7 @@ func TestBandwidthCounter(t *testing.T) {
 func TestResetBandwidthCounter(t *testing.T) {
 	bwc := NewBandwidthCounter()
 
-	p := peer.ID("peer-0")
+	p := test.MustPeerIDFromSeed("peer-0")
 	proto := protocol.ID("proto-0")
 
 	// We don't calculate bandwidth till we've been active for a second.

--- a/core/network/rcmgr.go
+++ b/core/network/rcmgr.go
@@ -318,7 +318,7 @@ func (n *NullScope) BeginSpan() (ResourceScopeSpan, error)    { return &NullScop
 func (n *NullScope) Done()                                    {}
 func (n *NullScope) Name() string                             { return "" }
 func (n *NullScope) Protocol() protocol.ID                    { return "" }
-func (n *NullScope) Peer() peer.ID                            { return "" }
+func (n *NullScope) Peer() peer.ID                            { return peer.EmptyID }
 func (n *NullScope) PeerScope() PeerScope                     { return &NullScope{} }
 func (n *NullScope) SetPeer(peer.ID) error                    { return nil }
 func (n *NullScope) ProtocolScope() ProtocolScope             { return &NullScope{} }

--- a/core/peer/addrinfo.go
+++ b/core/peer/addrinfo.go
@@ -26,7 +26,7 @@ func AddrInfosFromP2pAddrs(maddrs ...ma.Multiaddr) ([]AddrInfo, error) {
 	m := make(map[ID][]ma.Multiaddr)
 	for _, maddr := range maddrs {
 		transport, id := SplitAddr(maddr)
-		if id == "" {
+		if id == EmptyID {
 			return nil, ErrInvalidAddr
 		}
 		if transport == nil {
@@ -50,14 +50,14 @@ func AddrInfosFromP2pAddrs(maddrs ...ma.Multiaddr) ([]AddrInfo, error) {
 // * Returns a empty peer ID if the address doesn't contain a /p2p part.
 func SplitAddr(m ma.Multiaddr) (transport ma.Multiaddr, id ID) {
 	if m == nil {
-		return nil, ""
+		return nil, EmptyID
 	}
 
 	transport, p2ppart := ma.SplitLast(m)
 	if p2ppart == nil || p2ppart.Protocol().Code != ma.P_P2P {
-		return m, ""
+		return m, EmptyID
 	}
-	id = ID(p2ppart.RawValue()) // already validated by the multiaddr library.
+	id = ID{idBytes: string(p2ppart.RawValue())} // already validated by the multiaddr library.
 	return transport, id
 }
 
@@ -74,7 +74,7 @@ func AddrInfoFromString(s string) (*AddrInfo, error) {
 // AddrInfoFromP2pAddr converts a Multiaddr to an AddrInfo.
 func AddrInfoFromP2pAddr(m ma.Multiaddr) (*AddrInfo, error) {
 	transport, id := SplitAddr(m)
-	if id == "" {
+	if id == EmptyID {
 		return nil, ErrInvalidAddr
 	}
 	info := &AddrInfo{ID: id}

--- a/core/peer/addrinfo_test.go
+++ b/core/peer/addrinfo_test.go
@@ -45,7 +45,7 @@ func TestSplitAddr(t *testing.T) {
 	if !tpt.Equal(maddrTpt) {
 		t.Fatal("expected a transport")
 	}
-	if id != "" {
+	if id != EmptyID {
 		t.Fatal("expected no peer ID")
 	}
 }

--- a/core/peer/peer_serde.go
+++ b/core/peer/peer_serde.go
@@ -18,7 +18,7 @@ var _ encoding.TextMarshaler = (*ID)(nil)
 var _ encoding.TextUnmarshaler = (*ID)(nil)
 
 func (id ID) Marshal() ([]byte, error) {
-	return []byte(id), nil
+	return []byte(id.idBytes), nil
 }
 
 // MarshalBinary returns the byte representation of the peer ID.
@@ -26,8 +26,13 @@ func (id ID) MarshalBinary() ([]byte, error) {
 	return id.Marshal()
 }
 
+// MustMarshalBinary returns the byte representation of the peer ID.
+func (id ID) MustMarshalBinary() []byte {
+	return []byte(id.idBytes)
+}
+
 func (id ID) MarshalTo(data []byte) (n int, err error) {
-	return copy(data, []byte(id)), nil
+	return copy(data, []byte(id.idBytes)), nil
 }
 
 func (id *ID) Unmarshal(data []byte) (err error) {
@@ -41,7 +46,7 @@ func (id *ID) UnmarshalBinary(data []byte) error {
 }
 
 func (id ID) Size() int {
-	return len([]byte(id))
+	return len([]byte(id.idBytes))
 }
 
 func (id ID) MarshalJSON() ([]byte, error) {

--- a/core/peer/peer_test.go
+++ b/core/peer/peer_test.go
@@ -94,7 +94,7 @@ func TestIDMatchesPublicKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if ks.hpk != string(p1) {
+		if ks.hpk != string(p1.MustMarshalBinary()) {
 			t.Error("p1 and hpk differ")
 		}
 
@@ -129,7 +129,7 @@ func TestIDMatchesPrivateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if ks.hpk != string(p1) {
+		if ks.hpk != string(p1.MustMarshalBinary()) {
 			t.Error("p1 and hpk differ")
 		}
 
@@ -159,7 +159,7 @@ func TestIDEncoding(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if ks.hpk != string(p1) {
+		if ks.hpk != string(p1.MustMarshalBinary()) {
 			t.Error("p1 and hpk differ")
 		}
 
@@ -191,7 +191,7 @@ func TestIDEncoding(t *testing.T) {
 		t.Fatal("should refuse to decode a non-peer ID CID")
 	}
 
-	c := ToCid("")
+	c := ToCid(EmptyID)
 	if c.Defined() {
 		t.Fatal("cid of empty peer ID should have been undefined")
 	}
@@ -222,7 +222,7 @@ func TestPublicKeyExtraction(t *testing.T) {
 	}
 
 	// Test invalid multihash (invariant of the type of public key)
-	pk, err := ID("").ExtractPublicKey()
+	pk, err := EmptyID.ExtractPublicKey()
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -251,7 +251,7 @@ func TestPublicKeyExtraction(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	// Empty peer ID invalidates
-	err := ID("").Validate()
+	err := EmptyID.Validate()
 	if err == nil {
 		t.Error("expected error")
 	} else if err != ErrEmptyPeerID {

--- a/core/routing/routing.go
+++ b/core/routing/routing.go
@@ -94,7 +94,7 @@ type PubKeyFetcher interface {
 // KeyForPublicKey returns the key used to retrieve public keys
 // from a value store.
 func KeyForPublicKey(id peer.ID) string {
-	return "/pk/" + string(id)
+	return "/pk/" + id.String()
 }
 
 // GetPublicKey retrieves the public key associated with the given peer ID from

--- a/core/sec/insecure/insecure.go
+++ b/core/sec/insecure/insecure.go
@@ -82,7 +82,7 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer
 		return nil, err
 	}
 
-	if t.key != nil && p != "" && p != conn.remote {
+	if t.key != nil && p != peer.EmptyID && p != conn.remote {
 		return nil, fmt.Errorf("remote peer sent unexpected peer ID. expected=%s received=%s", p, conn.remote)
 	}
 
@@ -143,7 +143,7 @@ func makeExchangeMessage(pubkey ci.PubKey) (*pb.Exchange, error) {
 	}
 
 	return &pb.Exchange{
-		Id:     []byte(id),
+		Id:     id.MustMarshalBinary(),
 		Pubkey: keyMsg,
 	}, nil
 }

--- a/core/sec/insecure/insecure_test.go
+++ b/core/sec/insecure/insecure_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/sec"
+	"github.com/libp2p/go-libp2p/core/test"
+	testutil "github.com/libp2p/go-libp2p/core/test"
 
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +20,7 @@ func TestConnections(t *testing.T) {
 	clientTpt := newTestTransport(t, crypto.RSA, 2048)
 	serverTpt := newTestTransport(t, crypto.Ed25519, 1024)
 
-	clientConn, serverConn, clientErr, serverErr := connect(t, clientTpt, serverTpt, serverTpt.LocalPeer(), "")
+	clientConn, serverConn, clientErr, serverErr := connect(t, clientTpt, serverTpt, serverTpt.LocalPeer(), peer.EmptyID)
 	require.NoError(t, clientErr)
 	require.NoError(t, serverErr)
 	testIDs(t, clientTpt, serverTpt, clientConn, serverConn)
@@ -42,7 +44,7 @@ func TestPeerIDMismatchInbound(t *testing.T) {
 	clientTpt := newTestTransport(t, crypto.RSA, 2048)
 	serverTpt := newTestTransport(t, crypto.Ed25519, 1024)
 
-	_, _, _, serverErr := connect(t, clientTpt, serverTpt, serverTpt.LocalPeer(), "a-random-peer")
+	_, _, _, serverErr := connect(t, clientTpt, serverTpt, serverTpt.LocalPeer(), test.MustPeerIDFromSeed("a-random-peer"))
 	require.Error(t, serverErr)
 	require.Contains(t, serverErr.Error(), "remote peer sent unexpected peer ID")
 }
@@ -51,7 +53,7 @@ func TestPeerIDMismatchOutbound(t *testing.T) {
 	clientTpt := newTestTransport(t, crypto.RSA, 2048)
 	serverTpt := newTestTransport(t, crypto.Ed25519, 1024)
 
-	_, _, clientErr, _ := connect(t, clientTpt, serverTpt, "a random peer", "")
+	_, _, clientErr, _ := connect(t, clientTpt, serverTpt, testutil.MustPeerIDFromSeed("a-random-peer"), peer.EmptyID)
 	require.Error(t, clientErr)
 	require.Contains(t, clientErr.Error(), "remote peer sent unexpected peer ID")
 }

--- a/core/test/peer.go
+++ b/core/test/peer.go
@@ -13,7 +13,24 @@ func RandPeerID() (peer.ID, error) {
 	buf := make([]byte, 16)
 	rand.Read(buf)
 	h, _ := mh.Sum(buf, mh.SHA2_256, -1)
-	return peer.ID(h), nil
+	return peer.IDFromBytes(h)
+}
+
+func MustPeerIDFromSeed(seed string) peer.ID {
+	h, _ := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	p, err := peer.IDFromBytes(h)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func MustRandPeerID() peer.ID {
+	p, err := RandPeerID()
+	if err != nil {
+		panic(err)
+	}
+	return p
 }
 
 func RandPeerIDFatal(t testing.TB) peer.ID {

--- a/p2p/discovery/backoff/backoffconnector.go
+++ b/p2p/discovery/backoff/backoffconnector.go
@@ -54,7 +54,7 @@ func (c *BackoffConnector) Connect(ctx context.Context, peerCh <-chan peer.AddrI
 				return
 			}
 
-			if pi.ID == c.host.ID() || pi.ID == "" {
+			if pi.ID == c.host.ID() || pi.ID == peer.EmptyID {
 				continue
 			}
 

--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -382,7 +382,7 @@ func (as *AmbientAutoNAT) probe(pi *peer.AddrInfo) {
 func (as *AmbientAutoNAT) getPeerToProbe() peer.ID {
 	peers := as.host.Network().Peers()
 	if len(peers) == 0 {
-		return ""
+		return peer.EmptyID
 	}
 
 	candidates := make([]peer.ID, 0, len(peers))
@@ -408,7 +408,7 @@ func (as *AmbientAutoNAT) getPeerToProbe() peer.ID {
 	}
 
 	if len(candidates) == 0 {
-		return ""
+		return peer.EmptyID
 	}
 
 	shufflePeers(candidates)

--- a/p2p/host/autonat/proto.go
+++ b/p2p/host/autonat/proto.go
@@ -17,7 +17,7 @@ func newDialMessage(pi peer.AddrInfo) *pb.Message {
 	msg.Type = pb.Message_DIAL.Enum()
 	msg.Dial = new(pb.Message_Dial)
 	msg.Dial.Peer = new(pb.Message_PeerInfo)
-	msg.Dial.Peer.Id = []byte(pi.ID)
+	msg.Dial.Peer.Id = pi.ID.MustMarshalBinary()
 	msg.Dial.Peer.Addrs = make([][]byte, len(pi.Addrs))
 	for i, addr := range pi.Addrs {
 		msg.Dial.Peer.Addrs[i] = addr.Bytes()

--- a/p2p/host/peerstore/pstoreds/addr_book.go
+++ b/p2p/host/peerstore/pstoreds/addr_book.go
@@ -241,13 +241,13 @@ func (ab *dsAddrBook) loadRecord(id peer.ID, cache bool, update bool) (pr *addrs
 	}
 
 	pr = &addrsRecord{AddrBookRecord: &pb.AddrBookRecord{}}
-	key := addrBookBase.ChildString(b32.RawStdEncoding.EncodeToString([]byte(id)))
+	key := addrBookBase.ChildString(b32.RawStdEncoding.EncodeToString(id.MustMarshalBinary()))
 	data, err := ab.ds.Get(context.TODO(), key)
 
 	switch err {
 	case ds.ErrNotFound:
 		err = nil
-		pr.Id = []byte(id)
+		pr.Id = id.MustMarshalBinary()
 	case nil:
 		if err := proto.Unmarshal(data, pr); err != nil {
 			return nil, err
@@ -464,7 +464,7 @@ func (ab *dsAddrBook) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Multi
 func (ab *dsAddrBook) ClearAddrs(p peer.ID) {
 	ab.cache.Remove(p)
 
-	key := addrBookBase.ChildString(b32.RawStdEncoding.EncodeToString([]byte(p)))
+	key := addrBookBase.ChildString(b32.RawStdEncoding.EncodeToString(p.MustMarshalBinary()))
 	if err := ab.ds.Delete(context.TODO(), key); err != nil {
 		log.Errorf("failed to clear addresses for peer %s: %v", p.Pretty(), err)
 	}
@@ -607,7 +607,7 @@ func cleanAddrs(addrs []ma.Multiaddr, pid peer.ID) []ma.Multiaddr {
 			log.Warnw("Was passed a nil multiaddr", "peer", pid)
 			continue
 		}
-		if addrPid != "" && addrPid != pid {
+		if addrPid != peer.EmptyID && addrPid != pid {
 			log.Warnf("Was passed p2p address with a different peerId. found: %s, expected: %s", addrPid, pid)
 			continue
 		}

--- a/p2p/host/peerstore/pstoreds/addr_book_gc.go
+++ b/p2p/host/peerstore/pstoreds/addr_book_gc.go
@@ -290,7 +290,12 @@ func (gc *dsAddrBookGc) purgeStore() {
 		if err := record.flush(batch); err != nil {
 			log.Warnf("failed to flush entry modified by GC for peer: &v, err: %v", id, err)
 		}
-		gc.ab.cache.Remove(peer.ID(id))
+		p, err := peer.IDFromBytes(id)
+		if err != nil {
+			log.Warnf("failed to parse peer from bytes: bytes=%v err=%v", id, err)
+			continue
+		}
+		gc.ab.cache.Remove(peer.ID(p))
 	}
 
 	if err = batch.Commit(context.TODO()); err != nil {

--- a/p2p/host/peerstore/pstoreds/keybook.go
+++ b/p2p/host/peerstore/pstoreds/keybook.go
@@ -132,5 +132,5 @@ func (kb *dsKeyBook) RemovePeer(p peer.ID) {
 }
 
 func peerToKey(p peer.ID, suffix ds.Key) ds.Key {
-	return kbBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).Child(suffix)
+	return kbBase.ChildString(base32.RawStdEncoding.EncodeToString(p.MustMarshalBinary())).Child(suffix)
 }

--- a/p2p/host/peerstore/pstoreds/metadata.go
+++ b/p2p/host/peerstore/pstoreds/metadata.go
@@ -42,7 +42,7 @@ func NewPeerMetadata(_ context.Context, store ds.Datastore, _ Options) (*dsPeerM
 }
 
 func (pm *dsPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
-	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).ChildString(key)
+	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString(p.MustMarshalBinary())).ChildString(key)
 	value, err := pm.ds.Get(context.TODO(), k)
 	if err != nil {
 		if err == ds.ErrNotFound {
@@ -59,7 +59,7 @@ func (pm *dsPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
 }
 
 func (pm *dsPeerMetadata) Put(p peer.ID, key string, val interface{}) error {
-	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).ChildString(key)
+	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString(p.MustMarshalBinary())).ChildString(key)
 	var buf pool.Buffer
 	if err := gob.NewEncoder(&buf).Encode(&val); err != nil {
 		return err
@@ -69,7 +69,7 @@ func (pm *dsPeerMetadata) Put(p peer.ID, key string, val interface{}) error {
 
 func (pm *dsPeerMetadata) RemovePeer(p peer.ID) {
 	result, err := pm.ds.Query(context.TODO(), query.Query{
-		Prefix:   pmBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).String(),
+		Prefix:   pmBase.ChildString(base32.RawStdEncoding.EncodeToString(p.MustMarshalBinary())).String(),
 		KeysOnly: true,
 	})
 	if err != nil {

--- a/p2p/host/peerstore/pstoreds/protobook.go
+++ b/p2p/host/peerstore/pstoreds/protobook.go
@@ -16,7 +16,8 @@ type protoSegment struct {
 
 type protoSegments [256]*protoSegment
 
-func (s *protoSegments) get(p peer.ID) *protoSegment {
+func (s *protoSegments) get(peer peer.ID) *protoSegment {
+	p := peer.MustMarshalBinary()
 	return s[byte(p[len(p)-1])]
 }
 

--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -46,10 +46,11 @@ type addrSegment struct {
 }
 
 func (segments *addrSegments) get(p peer.ID) *addrSegment {
-	if len(p) == 0 { // it's not terribly useful to use an empty peer ID, but at least we should not panic
+	pBytes, err := p.MustMarshalBinary()
+	if len(pBytes) == 0 { // it's not terribly useful to use an empty peer ID, but at least we should not panic
 		return segments[0]
 	}
-	return segments[uint8(p[len(p)-1])]
+	return segments[uint8(pBytes[len(pBytes)-1])]
 }
 
 type clock interface {
@@ -244,7 +245,7 @@ func (mab *memoryAddrBook) addAddrsUnlocked(s *addrSegment, p peer.ID, addrs []m
 			log.Warnw("Was passed nil multiaddr", "peer", p)
 			continue
 		}
-		if addrPid != "" && addrPid != p {
+		if addrPid != peer.EmptyID && addrPid != p {
 			log.Warnf("Was passed p2p address with a different peerId. found: %s, expected: %s", addrPid, p)
 			continue
 		}
@@ -293,7 +294,7 @@ func (mab *memoryAddrBook) SetAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Du
 			log.Warnw("was passed nil multiaddr", "peer", p)
 			continue
 		}
-		if addrPid != "" && addrPid != p {
+		if addrPid != peer.EmptyID && addrPid != p {
 			log.Warnf("was passed p2p address with a different peerId, found: %s wanted: %s", addrPid, p)
 			continue
 		}

--- a/p2p/host/peerstore/pstoremem/protobook.go
+++ b/p2p/host/peerstore/pstoremem/protobook.go
@@ -17,7 +17,7 @@ type protoSegment struct {
 type protoSegments [256]*protoSegment
 
 func (s *protoSegments) get(p peer.ID) *protoSegment {
-	return s[byte(p[len(p)-1])]
+	return s[byte(p.MustMarshalBinary()[len(p.MustMarshalBinary())-1])]
 }
 
 var errTooManyProtocols = errors.New("too many protocols")

--- a/p2p/host/peerstore/test/addr_book_suite.go
+++ b/p2p/host/peerstore/test/addr_book_suite.go
@@ -138,8 +138,8 @@ func testAddAddress(ab pstore.AddrBook, clk *mockClock.Mock) func(*testing.T) {
 
 		t.Run("accessing an empty peer ID", func(t *testing.T) {
 			addrs := GenerateAddrs(5)
-			ab.AddAddrs("", addrs, time.Hour)
-			AssertAddressesEqual(t, addrs, ab.Addrs(""))
+			ab.AddAddrs(peer.EmptyID, addrs, time.Hour)
+			AssertAddressesEqual(t, addrs, ab.Addrs(peer.EmptyID))
 		})
 
 		t.Run("add a /p2p address with valid peerid", func(t *testing.T) {

--- a/p2p/host/peerstore/test/peerstore_suite.go
+++ b/p2p/host/peerstore/test/peerstore_suite.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	testutils "github.com/libp2p/go-libp2p/core/test"
+
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
@@ -51,7 +53,7 @@ func sortProtos(protos []protocol.ID) {
 
 func testAddrStream(ps pstore.Peerstore) func(t *testing.T) {
 	return func(t *testing.T) {
-		addrs, pid := getAddrs(t, 100), peer.ID("testpeer")
+		addrs, pid := getAddrs(t, 100), testutils.MustPeerIDFromSeed("testpeer")
 		ps.AddAddrs(pid, addrs[:10], time.Hour)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -125,7 +127,7 @@ func testAddrStream(ps pstore.Peerstore) func(t *testing.T) {
 
 func testGetStreamBeforePeerAdded(ps pstore.Peerstore) func(t *testing.T) {
 	return func(t *testing.T) {
-		addrs, pid := getAddrs(t, 10), peer.ID("testpeer")
+		addrs, pid := getAddrs(t, 10), testutils.MustPeerIDFromSeed("testpeer")
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -174,7 +176,7 @@ func testGetStreamBeforePeerAdded(ps pstore.Peerstore) func(t *testing.T) {
 
 func testAddrStreamDuplicates(ps pstore.Peerstore) func(t *testing.T) {
 	return func(t *testing.T) {
-		addrs, pid := getAddrs(t, 10), peer.ID("testpeer")
+		addrs, pid := getAddrs(t, 10), testutils.MustPeerIDFromSeed("testpeer")
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -213,7 +215,7 @@ func testAddrStreamDuplicates(ps pstore.Peerstore) func(t *testing.T) {
 func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("adding and removing protocols", func(t *testing.T) {
-			p1 := peer.ID("TESTPEER")
+			p1 := testutils.MustPeerIDFromSeed("TESTPEER")
 			protos := []protocol.ID{"a", "b", "c", "d"}
 
 			require.NoError(t, ps.AddProtocols(p1, protos...))
@@ -274,7 +276,7 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 		})
 
 		t.Run("removing peer", func(t *testing.T) {
-			p := peer.ID("foobar")
+			p := testutils.MustPeerIDFromSeed("foobar")
 			protos := []protocol.ID{"a", "b"}
 
 			require.NoError(t, ps.SetProtocols(p, protos...))
@@ -346,8 +348,8 @@ func testMetadata(ps pstore.Peerstore) func(t *testing.T) {
 		})
 
 		t.Run("removing a peer", func(t *testing.T) {
-			p := peer.ID("foo")
-			otherP := peer.ID("foobar")
+			p := testutils.MustPeerIDFromSeed("foo")
+			otherP := testutils.MustPeerIDFromSeed("foobar")
 			require.NoError(t, ps.Put(otherP, "AgentVersion", "v1"))
 			require.NoError(t, ps.Put(p, "AgentVersion", "v1"))
 			require.NoError(t, ps.Put(p, "bar", 1))
@@ -387,7 +389,7 @@ func getAddrs(t *testing.T, n int) []ma.Multiaddr {
 }
 
 func TestPeerstoreProtoStoreLimits(t *testing.T, ps pstore.Peerstore, limit int) {
-	p := peer.ID("foobar")
+	p := testutils.MustPeerIDFromSeed("foobar")
 	protocols := make([]protocol.ID, limit)
 	for i := 0; i < limit; i++ {
 		protocols[i] = protocol.ID(fmt.Sprintf("protocol %d", i))

--- a/p2p/host/resource-manager/allowlist.go
+++ b/p2p/host/resource-manager/allowlist.go
@@ -112,7 +112,7 @@ func (al *Allowlist) Add(ma multiaddr.Multiaddr) error {
 	al.mu.Lock()
 	defer al.mu.Unlock()
 
-	if allowedPeer != peer.ID("") {
+	if allowedPeer != peer.EmptyID {
 		// We have a peerID constraint
 		if al.allowedPeerByNetwork == nil {
 			al.allowedPeerByNetwork = make(map[peer.ID][]*net.IPNet)
@@ -134,7 +134,7 @@ func (al *Allowlist) Remove(ma multiaddr.Multiaddr) error {
 
 	ipNetList := al.allowedNetworks
 
-	if allowedPeer != "" {
+	if allowedPeer != peer.EmptyID {
 		// We have a peerID constraint
 		ipNetList = al.allowedPeerByNetwork[allowedPeer]
 	}
@@ -155,7 +155,7 @@ func (al *Allowlist) Remove(ma multiaddr.Multiaddr) error {
 		}
 	}
 
-	if allowedPeer != "" {
+	if allowedPeer != peer.EmptyID {
 		al.allowedPeerByNetwork[allowedPeer] = ipNetList
 	} else {
 		al.allowedNetworks = ipNetList

--- a/p2p/host/resource-manager/extapi.go
+++ b/p2p/host/resource-manager/extapi.go
@@ -103,7 +103,7 @@ func (r *resourceManager) ListPeers() []peer.ID {
 	}
 
 	sort.Slice(result, func(i, j int) bool {
-		return bytes.Compare([]byte(result[i]), []byte(result[j])) < 0
+		return bytes.Compare(result[i].MustMarshalBinary(), result[j].MustMarshalBinary()) < 0
 	})
 
 	return result

--- a/p2p/host/resource-manager/rcmgr_test.go
+++ b/p2p/host/resource-manager/rcmgr_test.go
@@ -14,8 +14,8 @@ import (
 var dummyMA = multiaddr.StringCast("/ip4/1.2.3.4/tcp/1234")
 
 func TestResourceManager(t *testing.T) {
-	peerA := peer.ID("A")
-	peerB := peer.ID("B")
+	peerA := test.MustPeerIDFromSeed("A")
+	peerB := test.MustPeerIDFromSeed("B")
 	protoA := protocol.ID("/A")
 	protoB := protocol.ID("/B")
 	svcA := "A.svc"

--- a/p2p/net/conngater/conngater.go
+++ b/p2p/net/conngater/conngater.go
@@ -75,7 +75,11 @@ func (cg *BasicConnectionGater) loadRules(ctx context.Context) error {
 			return err
 		}
 
-		p := peer.ID(r.Entry.Value)
+		p, err := peer.IDFromBytes(r.Entry.Value)
+		if err != nil {
+			log.Errorf("parse peer error: %s", err)
+			continue
+		}
 		cg.blockedPeers[p] = struct{}{}
 	}
 
@@ -125,7 +129,7 @@ func (cg *BasicConnectionGater) loadRules(ctx context.Context) error {
 // Note: active connections to the peer are not automatically closed.
 func (cg *BasicConnectionGater) BlockPeer(p peer.ID) error {
 	if cg.ds != nil {
-		err := cg.ds.Put(context.Background(), datastore.NewKey(keyPeer+p.String()), []byte(p))
+		err := cg.ds.Put(context.Background(), datastore.NewKey(keyPeer+p.String()), p.MustMarshalBinary())
 		if err != nil {
 			log.Errorf("error writing blocked peer to datastore: %s", err)
 			return err

--- a/p2p/net/conngater/conngater_test.go
+++ b/p2p/net/conngater/conngater_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
 
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -14,8 +14,8 @@ import (
 func TestConnectionGater(t *testing.T) {
 	ds := datastore.NewMapDatastore()
 
-	peerA := peer.ID("A")
-	peerB := peer.ID("B")
+	peerA := test.MustPeerIDFromSeed("A")
+	peerB := test.MustPeerIDFromSeed("B")
 
 	ip1 := net.ParseIP("1.2.3.4")
 

--- a/p2p/net/connmgr/connmgr.go
+++ b/p2p/net/connmgr/connmgr.go
@@ -71,7 +71,8 @@ type segments struct {
 	buckets   [256]*segment
 }
 
-func (ss *segments) get(p peer.ID) *segment {
+func (ss *segments) get(peer peer.ID) *segment {
+	p := peer.MustMarshalBinary()
 	return ss.buckets[byte(p[len(p)-1])]
 }
 

--- a/p2p/net/connmgr/connmgr_test.go
+++ b/p2p/net/connmgr/connmgr_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
 	tu "github.com/libp2p/go-libp2p/core/test"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -831,28 +832,28 @@ func makeSegmentsWithPeerInfos(peerInfos peerInfos) *segments {
 
 func TestPeerInfoSorting(t *testing.T) {
 	t.Run("starts with temporary connections", func(t *testing.T) {
-		p1 := &peerInfo{id: peer.ID("peer1")}
-		p2 := &peerInfo{id: peer.ID("peer2"), temp: true}
+		p1 := &peerInfo{id: test.MustPeerIDFromSeed("peer1")}
+		p2 := &peerInfo{id: test.MustPeerIDFromSeed("peer2"), temp: true}
 		pis := peerInfos{p1, p2}
 		pis.SortByValueAndStreams(makeSegmentsWithPeerInfos(pis), false)
 		require.Equal(t, pis, peerInfos{p2, p1})
 	})
 
 	t.Run("starts with low-value connections", func(t *testing.T) {
-		p1 := &peerInfo{id: peer.ID("peer1"), value: 40}
-		p2 := &peerInfo{id: peer.ID("peer2"), value: 20}
+		p1 := &peerInfo{id: test.MustPeerIDFromSeed("peer1"), value: 40}
+		p2 := &peerInfo{id: test.MustPeerIDFromSeed("peer2"), value: 20}
 		pis := peerInfos{p1, p2}
 		pis.SortByValueAndStreams(makeSegmentsWithPeerInfos(pis), false)
 		require.Equal(t, pis, peerInfos{p2, p1})
 	})
 
 	t.Run("prefer peers with no streams", func(t *testing.T) {
-		p1 := &peerInfo{id: peer.ID("peer1"),
+		p1 := &peerInfo{id: test.MustPeerIDFromSeed("peer1"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: network.ConnStats{NumStreams: 0}}: time.Now(),
 			},
 		}
-		p2 := &peerInfo{id: peer.ID("peer2"),
+		p2 := &peerInfo{id: test.MustPeerIDFromSeed("peer2"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: network.ConnStats{NumStreams: 1}}: time.Now(),
 			},
@@ -871,27 +872,27 @@ func TestPeerInfoSorting(t *testing.T) {
 		outgoingSomeStreams := network.ConnStats{Stats: network.Stats{Direction: network.DirOutbound}, NumStreams: 1}
 		outgoingMoreStreams := network.ConnStats{Stats: network.Stats{Direction: network.DirOutbound}, NumStreams: 2}
 		p1 := &peerInfo{
-			id: peer.ID("peer1"),
+			id: test.MustPeerIDFromSeed("peer1"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: outgoingSomeStreams}: time.Now(),
 			},
 		}
 		p2 := &peerInfo{
-			id: peer.ID("peer2"),
+			id: test.MustPeerIDFromSeed("peer2"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: outgoingSomeStreams}: time.Now(),
 				&mockConn{stats: incoming}:            time.Now(),
 			},
 		}
 		p3 := &peerInfo{
-			id: peer.ID("peer3"),
+			id: test.MustPeerIDFromSeed("peer3"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: outgoing}: time.Now(),
 				&mockConn{stats: incoming}: time.Now(),
 			},
 		}
 		p4 := &peerInfo{
-			id: peer.ID("peer4"),
+			id: test.MustPeerIDFromSeed("peer4"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: outgoingMoreStreams}: time.Now(),
 				&mockConn{stats: incoming}:            time.Now(),
@@ -907,13 +908,13 @@ func TestPeerInfoSorting(t *testing.T) {
 
 	t.Run("in a memory emergency, starts with connections that have many streams", func(t *testing.T) {
 		p1 := &peerInfo{
-			id: peer.ID("peer1"),
+			id: test.MustPeerIDFromSeed("peer1"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: network.ConnStats{NumStreams: 100}}: time.Now(),
 			},
 		}
 		p2 := &peerInfo{
-			id: peer.ID("peer2"),
+			id: test.MustPeerIDFromSeed("peer2"),
 			conns: map[network.Conn]time.Time{
 				&mockConn{stats: network.ConnStats{NumStreams: 80}}: time.Now(),
 				&mockConn{stats: network.ConnStats{NumStreams: 40}}: time.Now(),
@@ -929,8 +930,8 @@ func TestSafeConcurrency(t *testing.T) {
 	t.Run("Safe Concurrency", func(t *testing.T) {
 		cl := clock.NewMock()
 
-		p1 := &peerInfo{id: peer.ID("peer1"), conns: map[network.Conn]time.Time{}}
-		p2 := &peerInfo{id: peer.ID("peer2"), conns: map[network.Conn]time.Time{}}
+		p1 := &peerInfo{id: test.MustPeerIDFromSeed("peer1"), conns: map[network.Conn]time.Time{}}
+		p2 := &peerInfo{id: test.MustPeerIDFromSeed("peer2"), conns: map[network.Conn]time.Time{}}
 		pis := peerInfos{p1, p2}
 
 		ss := makeSegmentsWithPeerInfos(pis)

--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -71,9 +71,9 @@ func (mn *mocknet) GenPeer() (host.Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	suffix := id
-	if len(id) > 8 {
-		suffix = id[len(id)-8:]
+	suffix := id.MustMarshalBinary()
+	if len(suffix) > 8 {
+		suffix = suffix[len(suffix)-8:]
 	}
 	ip := append(net.IP{}, blackholeIP6...)
 	copy(ip[net.IPv6len-len(suffix):], suffix)
@@ -190,10 +190,10 @@ func (mn *mocknet) Links() LinkMap {
 
 	links := map[string]map[string]map[Link]struct{}{}
 	for p1, lm := range mn.links {
-		sp1 := string(p1)
+		sp1 := p1.String()
 		links[sp1] = map[string]map[Link]struct{}{}
 		for p2, ls := range lm {
-			sp2 := string(p2)
+			sp2 := p2.String()
 			links[sp1][sp2] = map[Link]struct{}{}
 			for l := range ls {
 				links[sp1][sp2][l] = struct{}{}
@@ -396,13 +396,17 @@ func (mn *mocknet) LinkDefaults() LinkOptions {
 // netSlice for sorting by peer
 type netSlice []network.Network
 
-func (es netSlice) Len() int           { return len(es) }
-func (es netSlice) Swap(i, j int)      { es[i], es[j] = es[j], es[i] }
-func (es netSlice) Less(i, j int) bool { return string(es[i].LocalPeer()) < string(es[j].LocalPeer()) }
+func (es netSlice) Len() int      { return len(es) }
+func (es netSlice) Swap(i, j int) { es[i], es[j] = es[j], es[i] }
+func (es netSlice) Less(i, j int) bool {
+	return string(es[i].LocalPeer().MustMarshalBinary()) < string(es[j].LocalPeer().MustMarshalBinary())
+}
 
 // hostSlice for sorting by peer
 type hostSlice []host.Host
 
-func (es hostSlice) Len() int           { return len(es) }
-func (es hostSlice) Swap(i, j int)      { es[i], es[j] = es[j], es[i] }
-func (es hostSlice) Less(i, j int) bool { return string(es[i].ID()) < string(es[j].ID()) }
+func (es hostSlice) Len() int      { return len(es) }
+func (es hostSlice) Swap(i, j int) { es[i], es[j] = es[j], es[i] }
+func (es hostSlice) Less(i, j int) bool {
+	return string(es[i].ID().MustMarshalBinary()) < string(es[j].ID().MustMarshalBinary())
+}

--- a/p2p/net/mock/mock_peernet.go
+++ b/p2p/net/mock/mock_peernet.go
@@ -150,7 +150,7 @@ func (pn *peernet) openConn(r peer.ID, l *link) *conn {
 func addConnPair(pn1, pn2 *peernet, c1, c2 *conn) {
 	var l1, l2 = pn1, pn2 // peernets in lock order
 	// bytes compare as string compare is lexicographical
-	if bytes.Compare([]byte(l1.LocalPeer()), []byte(l2.LocalPeer())) > 0 {
+	if bytes.Compare(l1.LocalPeer().MustMarshalBinary(), l2.LocalPeer().MustMarshalBinary()) > 0 {
 		l1, l2 = l2, l1
 	}
 

--- a/p2p/net/mock/mock_printer.go
+++ b/p2p/net/mock/mock_printer.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // separate object so our interfaces are separate :)
@@ -18,9 +17,9 @@ func (p *printer) MocknetLinks(mn Mocknet) {
 
 	fmt.Fprintf(p.w, "Mocknet link map:\n")
 	for p1, lm := range links {
-		fmt.Fprintf(p.w, "\t%s linked to:\n", peer.ID(p1))
+		fmt.Fprintf(p.w, "\t%s linked to:\n", p1)
 		for p2, l := range lm {
-			fmt.Fprintf(p.w, "\t\t%s (%d links)\n", peer.ID(p2), len(l))
+			fmt.Fprintf(p.w, "\t\t%s (%d links)\n", p2, len(l))
 		}
 	}
 	fmt.Fprintf(p.w, "\n")

--- a/p2p/net/swarm/dial_sync_test.go
+++ b/p2p/net/swarm/dial_sync_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
 
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func getMockDialFunc() (dialWorkerFunc, func(), context.Context, <-chan struct{}
 func TestBasicDialSync(t *testing.T) {
 	df, done, _, callsch := getMockDialFunc()
 	dsync := newDialSync(df)
-	p := peer.ID("testpeer")
+	p := test.MustPeerIDFromSeed("testpeer")
 
 	finished := make(chan struct{}, 2)
 	go func() {
@@ -69,7 +70,7 @@ func TestDialSyncCancel(t *testing.T) {
 
 	dsync := newDialSync(df)
 
-	p := peer.ID("testpeer")
+	p := test.MustPeerIDFromSeed("testpeer")
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 
@@ -119,7 +120,7 @@ func TestDialSyncAllCancel(t *testing.T) {
 	df, done, dctx, _ := getMockDialFunc()
 
 	dsync := newDialSync(df)
-	p := peer.ID("testpeer")
+	p := test.MustPeerIDFromSeed("testpeer")
 	ctx, cancel := context.WithCancel(context.Background())
 
 	finished := make(chan struct{})
@@ -182,7 +183,7 @@ func TestFailFirst(t *testing.T) {
 	}
 
 	ds := newDialSync(f)
-	p := peer.ID("testing")
+	p := test.MustPeerIDFromSeed("testing")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -210,7 +211,7 @@ func TestStressActiveDial(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 
-	pid := peer.ID("foo")
+	pid := test.MustPeerIDFromSeed("foo")
 
 	makeDials := func() {
 		for i := 0; i < 10000; i++ {

--- a/p2p/net/swarm/limiter_test.go
+++ b/p2p/net/swarm/limiter_test.go
@@ -80,7 +80,7 @@ func TestLimiterBasicDials(t *testing.T) {
 	good := addrWithPort(20)
 
 	resch := make(chan dialResult)
-	pid := peer.ID("testpeer")
+	pid := test.MustPeerIDFromSeed("testpeer")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -126,7 +126,12 @@ func TestFDLimiting(t *testing.T) {
 	l := newDialLimiterWithParams(hangDialFunc(hang), 16, 5)
 
 	bads := []ma.Multiaddr{addrWithPort(1), addrWithPort(2), addrWithPort(3), addrWithPort(4)}
-	pids := []peer.ID{"testpeer1", "testpeer2", "testpeer3", "testpeer4"}
+	pids := []peer.ID{
+		test.MustPeerIDFromSeed("testpeer1"),
+		test.MustPeerIDFromSeed("testpeer2"),
+		test.MustPeerIDFromSeed("testpeer3"),
+		test.MustPeerIDFromSeed("testpeer4"),
+	}
 	goodTCP := addrWithPort(20)
 
 	ctx := context.Background()
@@ -154,7 +159,7 @@ func TestFDLimiting(t *testing.T) {
 	case <-time.After(time.Millisecond * 100):
 	}
 
-	pid5 := peer.ID("testpeer5")
+	pid5 := test.MustPeerIDFromSeed("testpeer5")
 	utpaddr := ma.StringCast("/ip4/127.0.0.1/udp/7777/utp")
 
 	// This should complete immediately since utp addresses arent blocked by fd rate limiting
@@ -202,7 +207,10 @@ func TestTokenRedistribution(t *testing.T) {
 	l := newDialLimiterWithParams(df, 8, 4)
 
 	bads := []ma.Multiaddr{addrWithPort(1), addrWithPort(2), addrWithPort(3), addrWithPort(4)}
-	pids := []peer.ID{"testpeer1", "testpeer2"}
+	pids := []peer.ID{
+		test.MustPeerIDFromSeed("testpeer1"),
+		test.MustPeerIDFromSeed("testpeer2"),
+	}
 
 	ctx := context.Background()
 	resch := make(chan dialResult)
@@ -322,7 +330,7 @@ func TestStressLimiter(t *testing.T) {
 					return
 				}
 			}
-		}(peer.ID(fmt.Sprintf("testpeer%d", i)))
+		}(test.MustPeerIDFromSeed(fmt.Sprintf("testpeer%d", i)))
 	}
 
 	for i := 0; i < 20; i++ {
@@ -375,7 +383,7 @@ func TestFDLimitUnderflow(t *testing.T) {
 				}
 				errs <- errors.New("got dial res, but shouldn't")
 			}
-		}(peer.ID(fmt.Sprintf("testpeer%d", i%20)), i)
+		}(test.MustPeerIDFromSeed(fmt.Sprintf("testpeer%d", i%20)), i)
 	}
 
 	go func() {

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -75,7 +75,7 @@ func TestDialAddressSelection(t *testing.T) {
 	require.NoError(t, err)
 	id, err := peer.IDFromPrivateKey(priv)
 	require.NoError(t, err)
-	s, err := swarm.NewSwarm("local", nil, eventbus.NewBus())
+	s, err := swarm.NewSwarm(test.MustPeerIDFromSeed("local"), nil, eventbus.NewBus())
 	require.NoError(t, err)
 
 	tcpTr, err := tcp.NewTCPTransport(nil, nil)

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/transport"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -118,7 +119,7 @@ func (l *listener) handleIncoming() {
 			ctx, cancel := context.WithTimeout(l.ctx, l.upgrader.acceptTimeout)
 			defer cancel()
 
-			conn, err := l.upgrader.Upgrade(ctx, l.transport, maconn, network.DirInbound, "", connScope)
+			conn, err := l.upgrader.Upgrade(ctx, l.transport, maconn, network.DirInbound, peer.EmptyID, connScope)
 			if err != nil {
 				// Don't bother bubbling this up. We just failed
 				// to completely negotiate the connection.

--- a/p2p/net/upgrader/listener_test.go
+++ b/p2p/net/upgrader/listener_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/network"
 	mocknetwork "github.com/libp2p/go-libp2p/core/network/mocks"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/sec"
 	"github.com/libp2p/go-libp2p/core/sec/insecure"
+	"github.com/libp2p/go-libp2p/core/test"
 	"github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/net/upgrader"
 
@@ -161,7 +161,7 @@ func TestListenerClose(t *testing.T) {
 	require.Contains(err.Error(), "use of closed network connection")
 
 	// doesn't accept new connections when it is closed
-	_, err = dial(t, u, ln.Multiaddr(), peer.ID("1"), &network.NullScope{})
+	_, err = dial(t, u, ln.Multiaddr(), test.MustPeerIDFromSeed("1"), &network.NullScope{})
 	require.Error(err)
 }
 
@@ -307,21 +307,21 @@ func TestListenerConnectionGater(t *testing.T) {
 	// rejecting after handshake.
 	testGater.BlockSecured(true)
 	testGater.BlockAccept(false)
-	conn, err = dial(t, u, ln.Multiaddr(), "invalid", &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddr(), test.MustPeerIDFromSeed("invalid"), &network.NullScope{})
 	require.Error(err)
 	require.Nil(conn)
 
 	// rejecting on accept will trigger firupgrader.
 	testGater.BlockSecured(true)
 	testGater.BlockAccept(true)
-	conn, err = dial(t, u, ln.Multiaddr(), "invalid", &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddr(), test.MustPeerIDFromSeed("invalid"), &network.NullScope{})
 	require.Error(err)
 	require.Nil(conn)
 
 	// rejecting only on acceptance.
 	testGater.BlockSecured(false)
 	testGater.BlockAccept(true)
-	conn, err = dial(t, u, ln.Multiaddr(), "invalid", &network.NullScope{})
+	conn, err = dial(t, u, ln.Multiaddr(), test.MustPeerIDFromSeed("invalid"), &network.NullScope{})
 	require.Error(err)
 	require.Nil(conn)
 

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -131,7 +131,7 @@ func (u *upgrader) Upgrade(ctx context.Context, t transport.Transport, maconn ma
 }
 
 func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn manet.Conn, dir network.Direction, p peer.ID, connScope network.ConnManagementScope) (transport.CapableConn, error) {
-	if dir == network.DirOutbound && p == "" {
+	if dir == network.DirOutbound && p == peer.EmptyID {
 		return nil, ErrNilPeer
 	}
 	var stat network.ConnStats

--- a/p2p/protocol/circuitv2/proto/voucher.go
+++ b/p2p/protocol/circuitv2/proto/voucher.go
@@ -41,8 +41,8 @@ func (rv *ReservationVoucher) Codec() []byte {
 func (rv *ReservationVoucher) MarshalRecord() ([]byte, error) {
 	expiration := uint64(rv.Expiration.Unix())
 	return proto.Marshal(&pbv2.ReservationVoucher{
-		Relay:      []byte(rv.Relay),
-		Peer:       []byte(rv.Peer),
+		Relay:      []byte(rv.Relay.MustMarshalBinary()),
+		Peer:       []byte(rv.Peer.MustMarshalBinary()),
 		Expiration: &expiration,
 	})
 }

--- a/p2p/protocol/circuitv2/util/pbconv.go
+++ b/p2p/protocol/circuitv2/util/pbconv.go
@@ -38,7 +38,7 @@ func PeerInfoToPeerV2(pi peer.AddrInfo) *pbv2.Peer {
 	}
 
 	return &pbv2.Peer{
-		Id:    []byte(pi.ID),
+		Id:    pi.ID.MustMarshalBinary(),
 		Addrs: addrs,
 	}
 }

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -771,7 +771,7 @@ func (ids *idService) consumeReceivedPubKey(c network.Conn, kb []byte) {
 	if np != rp {
 		// if the newKey's peer.ID does not match known peer.ID...
 
-		if rp == "" && np != "" {
+		if rp == peer.EmptyID && np != peer.EmptyID {
 			// if local peerid is empty, then use the new, sent key.
 			err := ids.Host.Peerstore().AddPubKey(rp, newKey)
 			if err != nil {

--- a/p2p/security/noise/benchmark_test.go
+++ b/p2p/security/noise/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/sec"
 )
 
@@ -84,7 +85,7 @@ func (b benchenv) connect(stopTimer bool) (*secureSession, *secureSession) {
 		initSession, initErr = b.initTpt.SecureOutbound(context.TODO(), initConn, b.respTpt.localID)
 	}()
 
-	respSession, respErr := b.respTpt.SecureInbound(context.TODO(), respConn, "")
+	respSession, respErr := b.respTpt.SecureInbound(context.TODO(), respConn, peer.EmptyID)
 	<-done
 
 	if initErr != nil {

--- a/p2p/security/noise/crypto_test.go
+++ b/p2p/security/noise/crypto_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/test"
 )
 
 func TestEncryptAndDecrypt_InitToResp(t *testing.T) {
@@ -93,7 +94,7 @@ func TestCryptoFailsIfHandshakeIncomplete(t *testing.T) {
 	init, resp := net.Pipe()
 	_ = resp.Close()
 
-	session, _ := newSecureSession(initTransport, context.TODO(), init, "remote-peer", nil, nil, nil, true, true)
+	session, _ := newSecureSession(initTransport, context.TODO(), init, test.MustPeerIDFromSeed("remote-peer"), nil, nil, nil, true, true)
 	_, err := session.encrypt(nil, []byte("hi"))
 	if err == nil {
 		t.Error("expected encryption error when handshake incomplete")

--- a/p2p/security/noise/session_transport.go
+++ b/p2p/security/noise/session_transport.go
@@ -80,7 +80,7 @@ type SessionTransport struct {
 // SecureInbound runs the Noise handshake as the responder.
 // If p is empty, connections from any peer are accepted.
 func (i *SessionTransport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
-	checkPeerID := !i.disablePeerIDCheck && p != ""
+	checkPeerID := !i.disablePeerIDCheck && p != peer.EmptyID
 	c, err := newSecureSession(i.t, ctx, insecure, p, i.prologue, i.initiatorEarlyDataHandler, i.responderEarlyDataHandler, false, checkPeerID)
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())

--- a/p2p/security/noise/transport.go
+++ b/p2p/security/noise/transport.go
@@ -53,7 +53,7 @@ func New(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*Tr
 // If p is empty, connections from any peer are accepted.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn, p peer.ID) (sec.SecureConn, error) {
 	responderEDH := newTransportEDH(t)
-	c, err := newSecureSession(t, ctx, insecure, p, nil, nil, responderEDH, false, p != "")
+	c, err := newSecureSession(t, ctx, insecure, p, nil, nil, responderEDH, false, p != peer.EmptyID)
 	if err != nil {
 		addr, maErr := manet.FromNetAddr(insecure.RemoteAddr())
 		if maErr == nil {

--- a/p2p/security/tls/cmd/tlsdiag/server.go
+++ b/p2p/security/tls/cmd/tlsdiag/server.go
@@ -57,7 +57,7 @@ func StartServer() error {
 func handleConn(tp *libp2ptls.Transport, conn net.Conn) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	sconn, err := tp.SecureInbound(ctx, conn, "")
+	sconn, err := tp.SecureInbound(ctx, conn, peer.EmptyID)
 	if err != nil {
 		return err
 	}

--- a/p2p/security/tls/crypto.go
+++ b/p2p/security/tls/crypto.go
@@ -124,12 +124,12 @@ func (i *Identity) ConfigForPeer(remote peer.ID) (*tls.Config, <-chan ic.PubKey)
 		if err != nil {
 			return err
 		}
-		if remote != "" && !remote.MatchesPublicKey(pubKey) {
+		if remote != peer.EmptyID && !remote.MatchesPublicKey(pubKey) {
 			peerID, err := peer.IDFromPublicKey(pubKey)
 			if err != nil {
-				peerID = peer.ID(fmt.Sprintf("(not determined: %s)", err.Error()))
+				return fmt.Errorf("peer IDs don't match: expected %s, failed to parse key: %w", remote, err)
 			}
-			return fmt.Errorf("peer IDs don't match: expected %s, got %s", remote, peerID)
+			return fmt.Errorf("peer IDs don't match: expected %s, got %s. %w", remote, peerID, err)
 		}
 		keyCh <- pubKey
 		return nil

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -92,7 +92,7 @@ func TestHandshakeSucceeds(t *testing.T) {
 
 		serverConnChan := make(chan sec.SecureConn)
 		go func() {
-			serverConn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, "")
+			serverConn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, peer.EmptyID)
 			require.NoError(t, err)
 			serverConnChan <- serverConn
 		}()
@@ -230,7 +230,7 @@ func TestHandshakeWithNextProtoSucceeds(t *testing.T) {
 
 		serverConnChan := make(chan sec.SecureConn)
 		go func() {
-			serverConn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, "")
+			serverConn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, peer.EmptyID)
 			require.NoError(t, err)
 			serverConnChan <- serverConn
 		}()
@@ -314,7 +314,7 @@ func TestHandshakeConnectionCancellations(t *testing.T) {
 
 		errChan := make(chan error)
 		go func() {
-			conn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, "")
+			conn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, peer.EmptyID)
 			// crypto/tls' context handling works by spinning up a separate Go routine that watches the context,
 			// and closes the underlying connection when that context is canceled.
 			// It is therefore not guaranteed (but very likely) that this happens _during_ the TLS handshake.
@@ -337,7 +337,7 @@ func TestHandshakeConnectionCancellations(t *testing.T) {
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			conn, err := serverTransport.SecureInbound(ctx, &delayedConn{Conn: serverInsecureConn, delay: 5 * time.Millisecond}, "")
+			conn, err := serverTransport.SecureInbound(ctx, &delayedConn{Conn: serverInsecureConn, delay: 5 * time.Millisecond}, peer.EmptyID)
 			// crypto/tls' context handling works by spinning up a separate Go routine that watches the context,
 			// and closes the underlying connection when that context is canceled.
 			// It is therefore not guaranteed (but very likely) that this happens _during_ the TLS handshake.
@@ -366,7 +366,7 @@ func TestPeerIDMismatch(t *testing.T) {
 
 		errChan := make(chan error)
 		go func() {
-			conn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, "")
+			conn, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, peer.EmptyID)
 			// crypto/tls' context handling works by spinning up a separate Go routine that watches the context,
 			// and closes the underlying connection when that context is canceled.
 			// It is therefore not guaranteed (but very likely) that this happens _during_ the TLS handshake.
@@ -643,7 +643,7 @@ func TestInvalidCerts(t *testing.T) {
 
 			serverErrChan := make(chan error)
 			go func() {
-				_, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, "")
+				_, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, peer.EmptyID)
 				serverErrChan <- err
 			}()
 
@@ -686,7 +686,7 @@ func TestInvalidCerts(t *testing.T) {
 
 			errChan := make(chan error)
 			go func() {
-				_, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, "")
+				_, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, peer.EmptyID)
 				errChan <- err
 			}()
 

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	mocknetwork "github.com/libp2p/go-libp2p/core/network/mocks"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
 	tpt "github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
 
@@ -200,7 +201,7 @@ func testResourceManagerDialDenied(t *testing.T, tc *connTestCase) {
 
 	rcmgr.EXPECT().OpenConnection(network.DirOutbound, false, target).Return(connScope, nil)
 	rerr := errors.New("nope")
-	p := peer.ID("server")
+	p := test.MustPeerIDFromSeed("server")
 	connScope.EXPECT().SetPeer(p).Return(rerr)
 	connScope.EXPECT().Done()
 

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -280,7 +280,7 @@ func (t *transport) Listen(addr ma.Multiaddr) (tpt.Listener, error) {
 		// Note that since we have no way of associating an incoming QUIC connection with
 		// the peer ID calculated here, we don't actually receive the peer's public key
 		// from the key chan.
-		conf, _ := t.identity.ConfigForPeer("")
+		conf, _ := t.identity.ConfigForPeer(peer.EmptyID)
 		return conf, nil
 	}
 	tlsConf.NextProtos = []string{"libp2p"}

--- a/p2p/transport/quicreuse/connmgr_test.go
+++ b/p2p/transport/quicreuse/connmgr_test.go
@@ -193,7 +193,7 @@ func getTLSConfForProto(t *testing.T, alpn string) (peer.ID, *tls.Config) {
 	var tlsConf tls.Config
 	tlsConf.NextProtos = []string{alpn}
 	tlsConf.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-		c, _ := identity.ConfigForPeer("")
+		c, _ := identity.ConfigForPeer(peer.EmptyID)
 		c.NextProtos = tlsConf.NextProtos
 		return c, nil
 	}
@@ -206,13 +206,13 @@ func connectWithProtocol(t *testing.T, addr net.Addr, alpn string) (peer.ID, err
 	require.NoError(t, err)
 	clientIdentity, err := libp2ptls.NewIdentity(clientKey)
 	require.NoError(t, err)
-	tlsConf, peerChan := clientIdentity.ConfigForPeer("")
+	tlsConf, peerChan := clientIdentity.ConfigForPeer(peer.EmptyID)
 	cconn, err := net.ListenUDP("udp4", nil)
 	tlsConf.NextProtos = []string{alpn}
 	require.NoError(t, err)
 	c, err := quic.Dial(cconn, addr, "localhost", tlsConf, nil)
 	if err != nil {
-		return "", err
+		return peer.EmptyID, err
 	}
 	defer c.CloseWithError(0, "")
 	require.Equal(t, alpn, c.ConnectionState().TLS.NegotiatedProtocol)

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -305,7 +305,7 @@ func TestWebsocketTransport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ttransport.SubtestTransport(t, ta, tb, "/ip4/127.0.0.1/tcp/0/ws", "peerA")
+	ttransport.SubtestTransport(t, ta, tb, "/ip4/127.0.0.1/tcp/0/ws", test.MustPeerIDFromSeed("peerA"))
 }
 
 func connectAndExchangeData(t *testing.T, laddr ma.Multiaddr, secure bool) {

--- a/p2p/transport/webtransport/listener.go
+++ b/p2p/transport/webtransport/listener.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	tpt "github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	"github.com/libp2p/go-libp2p/p2p/security/noise/pb"
@@ -187,7 +188,7 @@ func (l *listener) handshake(ctx context.Context, sess *webtransport.Session) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Noise session: %w", err)
 	}
-	c, err := n.SecureInbound(ctx, &webtransportStream{Stream: str, wsess: sess}, "")
+	c, err := n.SecureInbound(ctx, &webtransportStream{Stream: str, wsess: sess}, peer.EmptyID)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/transport/webtransport/transport_test.go
+++ b/p2p/transport/webtransport/transport_test.go
@@ -268,7 +268,7 @@ func TestResourceManagerDialing(t *testing.T) {
 	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
 
 	addr := ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport")
-	p := peer.ID("foobar")
+	p := test.MustPeerIDFromSeed("foobar")
 
 	_, key := newIdentity(t)
 	tr, err := libp2pwebtransport.New(key, nil, newConnManager(t), nil, rcmgr)


### PR DESCRIPTION
Protects against fiddling with the peer bytes directly, which is probably wrong. Also fixes the root issues like https://github.com/libp2p/go-libp2p-resource-manager/pull/67#issuecomment-1176820561 and #2155.

This change should only be a translation of existing uses and doesn't try to change the semantics. If things needed bytes we update the code to return the bytes.