### PR TITLE
connmgr: reduce log level for closing connections

### DIFF
--- a/p2p/net/connmgr/connmgr.go
+++ b/p2p/net/connmgr/connmgr.go
@@ -375,7 +375,7 @@ func (cm *BasicConnMgr) doTrim() {
 func (cm *BasicConnMgr) trim() {
 	// do the actual trim.
 	for _, c := range cm.getConnsToClose() {
-		log.Infow("closing conn", "peer", c.RemotePeer())
+		log.Debugw("closing conn", "peer", c.RemotePeer())
 		c.Close()
 	}
 }


### PR DESCRIPTION
This PR changes the log level for closing connections in connmgr.go from INFO to DEBUG, since as reported in https://github.com/status-im/status-go/issues/3249 these logs add too much noise.