### PR TITLE
fix(host/routed): return connection error instead of routing

### DIFF
--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -114,7 +114,8 @@ func (rh *RoutedHost) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		// try to connect again.
 		newAddrs, err := rh.findPeerAddrs(ctx, pi.ID)
 		if err != nil {
-			return fmt.Errorf("failed to find peers: %w", err)
+			log.Debugf("failed to find more peer addresses %s: %s", pi.ID, err)
+			return cerr
 		}
 
 		// Build lookup map


### PR DESCRIPTION
A peer might not have any connections, and failure to establish the first one will not give a meaningful error, but the `failed to find peers: no peers in the table`