### PR TITLE
identify: Fix IdentifyWait when Connected events happen out of order

### DIFF
--- a/core/network/conn.go
+++ b/core/network/conn.go
@@ -33,6 +33,10 @@ type Conn interface {
 
 	// GetStreams returns all open streams over this conn.
 	GetStreams() []Stream
+
+	// IsClosed returns whether a connection is fully closed, so it can
+	// be garbage collected.
+	IsClosed() bool
 }
 
 // ConnectionState holds information about the connection.

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -40,9 +40,11 @@ func TestHostSimple(t *testing.T) {
 	h1, err := NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
 	defer h1.Close()
+	h1.Start()
 	h2, err := NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
 	defer h2.Close()
+	h2.Start()
 
 	h2pi := h2.Peerstore().PeerInfo(h2.ID())
 	require.NoError(t, h1.Connect(ctx, h2pi))
@@ -447,8 +449,10 @@ func TestNewDialOld(t *testing.T) {
 func TestNewStreamResolve(t *testing.T) {
 	h1, err := NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
+	h1.Start()
 	h2, err := NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
+	h2.Start()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/p2p/host/routed/routed_test.go
+++ b/p2p/host/routed/routed_test.go
@@ -28,6 +28,7 @@ func TestRoutedHostConnectToObsoleteAddresses(t *testing.T) {
 	h1, err := basic.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
 	defer h1.Close()
+	h1.Start()
 
 	h2, err := basic.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)

--- a/p2p/net/connmgr/connmgr_test.go
+++ b/p2p/net/connmgr/connmgr_test.go
@@ -802,6 +802,7 @@ func (m mockConn) LocalMultiaddr() ma.Multiaddr                          { panic
 func (m mockConn) RemoteMultiaddr() ma.Multiaddr                         { panic("implement me") }
 func (m mockConn) Stat() network.ConnStats                               { return m.stats }
 func (m mockConn) ID() string                                            { panic("implement me") }
+func (m mockConn) IsClosed() bool                                        { panic("implement me") }
 func (m mockConn) NewStream(ctx context.Context) (network.Stream, error) { panic("implement me") }
 func (m mockConn) GetStreams() []network.Stream                          { panic("implement me") }
 func (m mockConn) Scope() network.ConnScope                              { panic("implement me") }

--- a/p2p/net/mock/mock_conn.go
+++ b/p2p/net/mock/mock_conn.go
@@ -41,6 +41,8 @@ type conn struct {
 
 	closeOnce sync.Once
 
+	isClosed atomic.Bool
+
 	sync.RWMutex
 }
 
@@ -67,12 +69,17 @@ func newConn(ln, rn *peernet, l *link, dir network.Direction) *conn {
 	return c
 }
 
+func (c *conn) IsClosed() bool {
+	return c.isClosed.Load()
+}
+
 func (c *conn) ID() string {
 	return strconv.FormatInt(c.id, 10)
 }
 
 func (c *conn) Close() error {
 	c.closeOnce.Do(func() {
+		c.isClosed.Store(true)
 		go c.rconn.Close()
 		c.teardown()
 	})

--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -43,6 +43,10 @@ type Conn struct {
 
 var _ network.Conn = &Conn{}
 
+func (c *Conn) IsClosed() bool {
+	return c.conn.IsClosed()
+}
+
 func (c *Conn) ID() string {
 	// format: <first 10 chars of peer id>-<global conn ordinal>
 	return fmt.Sprintf("%s-%d", c.RemotePeer().Pretty()[0:10], c.id)

--- a/p2p/protocol/ping/ping_test.go
+++ b/p2p/protocol/ping/ping_test.go
@@ -20,9 +20,11 @@ func TestPing(t *testing.T) {
 	h1, err := bhost.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
 	defer h1.Close()
+	h1.Start()
 	h2, err := bhost.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
 	defer h2.Close()
+	h2.Start()
 
 	err = h1.Connect(ctx, peer.AddrInfo{
 		ID:    h2.ID(),

--- a/p2p/test/backpressure/backpressure_test.go
+++ b/p2p/test/backpressure/backpressure_test.go
@@ -25,8 +25,10 @@ func TestStBackpressureStreamWrite(t *testing.T) {
 
 	h1, err := bhost.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
+	h1.Start()
 	h2, err := bhost.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
+	h2.Start()
 
 	// setup sender handler on 2
 	h2.SetStreamHandler(protocol.TestingID, func(s network.Stream) {

--- a/p2p/test/reconnects/reconnect_test.go
+++ b/p2p/test/reconnects/reconnect_test.go
@@ -37,6 +37,7 @@ func TestReconnect5(t *testing.T) {
 			h, err := bhost.NewHost(swarmt.GenSwarm(t, swarmOpt), nil)
 			require.NoError(t, err)
 			defer h.Close()
+			h.Start()
 			hosts = append(hosts, h)
 			h.SetStreamHandler(protocol.TestingID, EchoStreamHandler)
 		}


### PR DESCRIPTION
fixes #2163 

Adds an `IsClosed` method to `network.Conn`