### PR TITLE
test-plans: Add wss transport to interop tester impl

### DIFF
--- a/test-plans/cmd/ping/main.go
+++ b/test-plans/cmd/ping/main.go
@@ -2,9 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/big"
 	"os"
 	"strconv"
 	"time"
@@ -85,6 +91,9 @@ func main() {
 	case "ws":
 		options = append(options, libp2p.Transport(websocket.New))
 		listenAddr = fmt.Sprintf("/ip4/%s/tcp/0/ws", ip)
+	case "wss":
+		options = append(options, libp2p.Transport(websocket.New, websocket.WithTLSConfig(generateTLSConfig()), websocket.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true})))
+		listenAddr = fmt.Sprintf("/ip4/%s/tcp/0/wss", ip)
 	case "tcp":
 		options = append(options, libp2p.Transport(tcp.NewTCPTransport))
 		listenAddr = fmt.Sprintf("/ip4/%s/tcp/0", ip)
@@ -198,5 +207,30 @@ func main() {
 		}
 		time.Sleep(testTimeout)
 		os.Exit(1)
+	}
+}
+
+func generateTLSConfig() *tls.Config {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour), // valid for an hour
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{{
+			PrivateKey:  priv,
+			Certificate: [][]byte{certDER},
+		}},
 	}
 }

--- a/test-plans/ping-version.json
+++ b/test-plans/ping-version.json
@@ -4,6 +4,7 @@
     "transports": [
         "tcp",
         "ws",
+        "wss",
         "quic",
         "quic-v1",
         "webtransport"


### PR DESCRIPTION
Adds support for listening on a WSS addr. After this is merged, I'll backport this patch to a branch off v0.25 to update the interop tester.