### PR TITLE
autorelay: set leastFrequentInterval correctly

### DIFF
--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -140,7 +140,7 @@ func (rf *relayFinder) background(ctx context.Context) {
 		leastFrequentInterval = rf.conf.maxCandidateAge
 	}
 	if rsvpRefreshInterval > leastFrequentInterval {
-		leastFrequentInterval = rf.conf.maxCandidateAge
+		leastFrequentInterval = rsvpRefreshInterval
 	}
 
 	now := rf.conf.clock.Now()


### PR DESCRIPTION
In practice this bug has very low impact. rsvpRefreshInterval is only 1 minute