### PR TITLE
basichost: prevent duplicate dials

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -635,8 +635,13 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 		}
 	}
 
-	s, err := h.Network().NewStream(ctx, p)
+	s, err := h.Network().NewStream(network.WithNoDial(ctx, "already dialed"), p)
 	if err != nil {
+		// TODO: It would be nicer to get the actual error from the swarm,
+		// but this will require some more work.
+		if errors.Is(err, network.ErrNoConn) {
+			return nil, errors.New("connection failed")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #2195.

This fix is not perfect. The error returned will be a `network.ErrNoConn`. Ideally, the swarm would not count a connection as "fully connected" before opening the first stream (and receiving _something_ from the peer) succeeds. This will also be necessary when we implement 0-RTT.