### PR TITLE
autorelay: fix busy loop bug and flaky tests in relay finder

### DIFF
--- a/core/test/mockclock.go
+++ b/core/test/mockclock.go
@@ -89,6 +89,10 @@ func (c *mockClock) AdvanceBy(dur time.Duration) {
 	// sort timers by when
 	if len(c.timers) > 1 {
 		sort.Slice(c.timers, func(i, j int) bool {
+			c.timers[i].mu.Lock()
+			c.timers[j].mu.Lock()
+			defer c.timers[i].mu.Unlock()
+			defer c.timers[j].mu.Unlock()
 			return c.timers[i].when.Before(c.timers[j].when)
 		})
 	}

--- a/core/test/mockclock.go
+++ b/core/test/mockclock.go
@@ -1,0 +1,119 @@
+package test
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
+)
+
+type mockClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*mockInstantTimer
+}
+
+type mockInstantTimer struct {
+	c      *mockClock
+	mu     sync.Mutex
+	when   time.Time
+	active bool
+	ch     chan time.Time
+}
+
+func (t *mockInstantTimer) Ch() <-chan time.Time {
+	return t.ch
+}
+
+func (t *mockInstantTimer) Reset(d time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	wasActive := t.active
+	t.active = true
+	t.when = d
+
+	// Schedule any timers that need to run. This will run this timer if t.when is before c.now
+	go t.c.AdvanceBy(0)
+
+	return wasActive
+}
+
+func (t *mockInstantTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	wasActive := t.active
+	t.active = false
+	return wasActive
+}
+
+var _ autorelay.InstantTimer = &mockInstantTimer{}
+var _ autorelay.ClockWithInstantTimer = &mockClock{}
+
+func NewMockClock() *mockClock {
+	return &mockClock{now: time.Unix(0, 0)}
+}
+
+// InstantTimer implements autorelay.ClockWithInstantTimer
+func (c *mockClock) InstantTimer(when time.Time) autorelay.InstantTimer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := &mockInstantTimer{
+		c:      c,
+		when:   when,
+		ch:     make(chan time.Time, 1),
+		active: true,
+	}
+	c.timers = append(c.timers, t)
+	return t
+}
+
+// Since implements autorelay.ClockWithInstantTimer
+func (c *mockClock) Since(t time.Time) time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now.Sub(t)
+}
+
+func (c *mockClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *mockClock) AdvanceBy(dur time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	endTime := c.now.Add(dur)
+
+	// sort timers by when
+	if len(c.timers) > 1 {
+		sort.Slice(c.timers, func(i, j int) bool {
+			return c.timers[i].when.Before(c.timers[j].when)
+		})
+	}
+
+	for _, t := range c.timers {
+		t.mu.Lock()
+		if !t.active {
+			t.mu.Unlock()
+			continue
+		}
+		if !t.when.After(c.now) {
+			t.active = false
+			t.mu.Unlock()
+			// This may block if the channel is full, but that's intended. This way our mock clock never gets too far ahead of consumer.
+			// This also prevents us from dropping times because we're advancing too fast.
+			t.ch <- c.now
+		} else if !t.when.After(endTime) {
+			c.now = t.when
+			t.active = false
+			t.mu.Unlock()
+			// This may block if the channel is full, but that's intended. See comment above
+			t.ch <- c.now
+		} else {
+			t.mu.Unlock()
+		}
+	}
+	c.now = endTime
+}

--- a/core/test/mockclock.go
+++ b/core/test/mockclock.go
@@ -4,8 +4,6 @@ import (
 	"sort"
 	"sync"
 	"time"
-
-	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 )
 
 type mockClock struct {
@@ -48,15 +46,11 @@ func (t *mockInstantTimer) Stop() bool {
 	return wasActive
 }
 
-var _ autorelay.InstantTimer = &mockInstantTimer{}
-var _ autorelay.ClockWithInstantTimer = &mockClock{}
-
 func NewMockClock() *mockClock {
 	return &mockClock{now: time.Unix(0, 0), advanceBySem: make(chan struct{}, 1)}
 }
 
-// InstantTimer implements autorelay.ClockWithInstantTimer
-func (c *mockClock) InstantTimer(when time.Time) autorelay.InstantTimer {
+func (c *mockClock) InstantTimer(when time.Time) *mockInstantTimer {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	t := &mockInstantTimer{

--- a/core/test/mockclock.go
+++ b/core/test/mockclock.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-type mockClock struct {
+type MockClock struct {
 	mu           sync.Mutex
 	now          time.Time
 	timers       []*mockInstantTimer
@@ -14,7 +14,7 @@ type mockClock struct {
 }
 
 type mockInstantTimer struct {
-	c      *mockClock
+	c      *MockClock
 	mu     sync.Mutex
 	when   time.Time
 	active bool
@@ -46,11 +46,11 @@ func (t *mockInstantTimer) Stop() bool {
 	return wasActive
 }
 
-func NewMockClock() *mockClock {
-	return &mockClock{now: time.Unix(0, 0), advanceBySem: make(chan struct{}, 1)}
+func NewMockClock() *MockClock {
+	return &MockClock{now: time.Unix(0, 0), advanceBySem: make(chan struct{}, 1)}
 }
 
-func (c *mockClock) InstantTimer(when time.Time) *mockInstantTimer {
+func (c *MockClock) InstantTimer(when time.Time) *mockInstantTimer {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	t := &mockInstantTimer{
@@ -64,19 +64,19 @@ func (c *mockClock) InstantTimer(when time.Time) *mockInstantTimer {
 }
 
 // Since implements autorelay.ClockWithInstantTimer
-func (c *mockClock) Since(t time.Time) time.Duration {
+func (c *MockClock) Since(t time.Time) time.Duration {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.now.Sub(t)
 }
 
-func (c *mockClock) Now() time.Time {
+func (c *MockClock) Now() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.now
 }
 
-func (c *mockClock) AdvanceBy(dur time.Duration) {
+func (c *MockClock) AdvanceBy(dur time.Duration) {
 	c.advanceBySem <- struct{}{}
 	defer func() { <-c.advanceBySem }()
 

--- a/core/test/mockclock_test.go
+++ b/core/test/mockclock_test.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMockClock(t *testing.T) {
+	cl := NewMockClock()
+	t1 := cl.InstantTimer(cl.Now().Add(2 * time.Second))
+	t2 := cl.InstantTimer(cl.Now().Add(time.Second))
+
+	// Advance the clock by 500ms
+	cl.AdvanceBy(time.Millisecond * 500)
+
+	// No event
+	select {
+	case <-t1.Ch():
+		t.Fatal("t1 fired early")
+	case <-t2.Ch():
+		t.Fatal("t2 fired early")
+	default:
+	}
+
+	// Advance the clock by 500ms
+	cl.AdvanceBy(time.Millisecond * 500)
+
+	// t2 fires
+	select {
+	case <-t1.Ch():
+		t.Fatal("t1 fired early")
+	case <-t2.Ch():
+	}
+
+	// Advance the clock by 2s
+	cl.AdvanceBy(time.Second * 2)
+
+	// t1 fires
+	select {
+	case <-t1.Ch():
+	case <-t2.Ch():
+		t.Fatal("t2 fired again")
+	}
+}

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -22,6 +22,20 @@ import (
 
 const protoIDv2 = circuitv2_proto.ProtoIDv2Hop
 
+type mockClock struct {
+	*test.MockClock
+}
+
+func (c mockClock) InstantTimer(when time.Time) autorelay.InstantTimer {
+	return c.MockClock.InstantTimer(when)
+}
+
+func newMockClock() mockClock {
+	return mockClock{MockClock: test.NewMockClock()}
+}
+
+var _ autorelay.ClockWithInstantTimer = mockClock{}
+
 func numRelays(h host.Host) int {
 	return len(usedRelays(h))
 }
@@ -183,7 +197,7 @@ func TestWaitForCandidates(t *testing.T) {
 
 func TestBackoff(t *testing.T) {
 	const backoff = 20 * time.Second
-	cl := test.NewMockClock()
+	cl := newMockClock()
 	r, err := libp2p.New(
 		libp2p.DisableRelay(),
 		libp2p.ForceReachabilityPublic(),
@@ -308,7 +322,7 @@ func TestConnectOnDisconnect(t *testing.T) {
 }
 
 func TestMaxAge(t *testing.T) {
-	cl := test.NewMockClock()
+	cl := newMockClock()
 
 	const num = 4
 	peerChan1 := make(chan peer.AddrInfo, num)
@@ -407,7 +421,7 @@ func TestMaxAge(t *testing.T) {
 }
 
 func TestReconnectToStaticRelays(t *testing.T) {
-	cl := test.NewMockClock()
+	cl := newMockClock()
 	var staticRelays []peer.AddrInfo
 	const numStaticRelays = 1
 	relays := make([]host.Host, 0, numStaticRelays)
@@ -448,7 +462,7 @@ func TestReconnectToStaticRelays(t *testing.T) {
 }
 
 func TestMinInterval(t *testing.T) {
-	cl := test.NewMockClock()
+	cl := newMockClock()
 	h := newPrivateNode(t,
 		func(context.Context, int) <-chan peer.AddrInfo {
 			peerChan := make(chan peer.AddrInfo, 1)
@@ -475,7 +489,7 @@ func TestMinInterval(t *testing.T) {
 
 func TestNoBusyLoop0MinInterval(t *testing.T) {
 	var calledTimes uint64
-	cl := test.NewMockClock()
+	cl := newMockClock()
 	h := newPrivateNode(t,
 		func(context.Context, int) <-chan peer.AddrInfo {
 			atomic.AddUint64(&calledTimes, 1)

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -248,7 +248,7 @@ func TestBackoff(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return reservations.Load() == 2
 	}, 3*time.Second, 100*time.Millisecond, "reservations load should be 2")
-	require.Less(t, int(counter.Load()), 5) // just make sure we're not busy-looping
+	require.Less(t, int(counter.Load()), 10) // just make sure we're not busy-looping
 	require.Equal(t, 2, int(reservations.Load()))
 }
 

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -443,9 +443,9 @@ func TestMinInterval(t *testing.T) {
 	)
 	defer h.Close()
 
-	cl.Add(500 * time.Millisecond)
+	cl.Add(400 * time.Millisecond)
 	// The second call to peerSource should happen after 1 second
 	require.Never(t, func() bool { return numRelays(h) > 0 }, 500*time.Millisecond, 100*time.Millisecond)
 	cl.Add(500 * time.Millisecond)
-	require.Eventually(t, func() bool { return numRelays(h) > 0 }, 10*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return numRelays(h) > 0 }, 3*time.Second, 100*time.Millisecond)
 }

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -330,7 +330,7 @@ func TestMaxAge(t *testing.T) {
 		autorelay.WithBootDelay(0),
 		autorelay.WithMaxCandidateAge(20*time.Minute),
 		autorelay.WithClock(cl),
-		autorelay.WithMinInterval(time.Second),
+		autorelay.WithMinInterval(30*time.Second),
 	)
 	defer h.Close()
 
@@ -340,9 +340,8 @@ func TestMaxAge(t *testing.T) {
 	relays := usedRelays(h)
 	require.Len(t, relays, 1)
 
+	cl.Add(time.Minute)
 	require.Eventually(t, func() bool {
-		// we don't know exactly when the timer is reset, just advance our timer multiple times if necessary
-		cl.Add(30 * time.Second)
 		return len(peerChans) == 0
 	}, 10*time.Second, 100*time.Millisecond)
 

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
-
-	"github.com/benbjohnson/clock"
 )
 
 // AutoRelay will call this function when it needs new candidates because it is
@@ -24,7 +22,7 @@ import (
 type PeerSource func(ctx context.Context, num int) <-chan peer.AddrInfo
 
 type config struct {
-	clock      clock.Clock
+	clock      ClockWithInstantTimer
 	peerSource PeerSource
 	// minimum interval used to call the peerSource callback
 	minInterval time.Duration
@@ -45,7 +43,7 @@ type config struct {
 }
 
 var defaultConfig = config{
-	clock:           clock.New(),
+	clock:           RealClock{},
 	minCandidates:   4,
 	maxCandidates:   20,
 	bootDelay:       3 * time.Minute,
@@ -162,7 +160,50 @@ func WithMaxCandidateAge(d time.Duration) Option {
 	}
 }
 
-func WithClock(cl clock.Clock) Option {
+type InstantTimer interface {
+	Reset(d time.Time) bool
+	Stop() bool
+	Ch() <-chan time.Time
+}
+
+type ClockWithInstantTimer interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	InstantTimer(when time.Time) InstantTimer
+}
+
+type RealTimer struct{ t *time.Timer }
+
+var _ InstantTimer = (*RealTimer)(nil)
+
+func (t RealTimer) Ch() <-chan time.Time {
+	return t.t.C
+}
+
+func (t RealTimer) Reset(d time.Time) bool {
+	return t.t.Reset(time.Until(d))
+}
+
+func (t RealTimer) Stop() bool {
+	return t.t.Stop()
+}
+
+type RealClock struct{}
+
+var _ ClockWithInstantTimer = RealClock{}
+
+func (RealClock) Now() time.Time {
+	return time.Now()
+}
+func (RealClock) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+func (RealClock) InstantTimer(when time.Time) InstantTimer {
+	t := time.NewTimer(time.Until(when))
+	return &RealTimer{t}
+}
+
+func WithClock(cl ClockWithInstantTimer) Option {
 	return func(c *config) error {
 		c.clock = cl
 		return nil

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -160,12 +160,15 @@ func WithMaxCandidateAge(d time.Duration) Option {
 	}
 }
 
+// InstantTimer is a timer that triggers at some instant rather than some duration
 type InstantTimer interface {
 	Reset(d time.Time) bool
 	Stop() bool
 	Ch() <-chan time.Time
 }
 
+// ClockWithInstantTimer is a clock that can create timers that trigger at some
+// instant rather than some duration
 type ClockWithInstantTimer interface {
 	Now() time.Time
 	Since(t time.Time) time.Duration

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -198,13 +198,7 @@ func (rf *relayFinder) background(ctx context.Context) {
 		case now := <-workTimer.Ch():
 			// Note: `now` is not guaranteed to be the current time. It's the time
 			// that the timer was fired. This is okay because we'll schedule
-			// future work relative the true current time. Which we need to do
-			// to make up for possibly being late here.
-			// We use the time from the timer to avoid a race condition with
-			// mock clock. We want the time we were scheduled to run. If we were
-			// to call clock.Now(), we may end up with some other future time
-			// depending if we got the lock before or after the mock clock
-			// worker goroutine.
+			// future work at a specific time.
 			nextTime := rf.runScheduledWork(ctx, now, scheduledWork, peerSourceRateLimiter)
 			workTimer.Reset(nextTime)
 		case <-rf.triggerRunScheduledWork:

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -148,10 +148,6 @@ func (rf *relayFinder) background(ctx context.Context) {
 	if rsvpRefreshInterval > leastFrequentInterval || leastFrequentInterval == 0 {
 		leastFrequentInterval = rsvpRefreshInterval
 	}
-	if leastFrequentInterval == 0 {
-		// fallback to avoid busy looping in case the config is set to all 0s
-		leastFrequentInterval = time.Hour
-	}
 
 	scheduledWork := &scheduledWorkTimes{
 		leastFrequentInterval:       leastFrequentInterval,

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -274,6 +274,11 @@ func (rf *relayFinder) runScheduledWork(ctx context.Context, now time.Time, sche
 			}
 		default:
 		}
+	} else {
+		// We still need to schedule this work if it's sooner than nextTime
+		if scheduledWork.nextAllowedCallToPeerSource.Before(nextTime) {
+			nextTime = scheduledWork.nextAllowedCallToPeerSource
+		}
 	}
 
 	// Find the next time we need to run scheduled work.

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/benbjohnson/clock"
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -77,6 +78,20 @@ type relayFinder struct {
 
 	cachedAddrs       []ma.Multiaddr
 	cachedAddrsExpiry time.Time
+
+	// A channel that may trigger a run of scheduled background tasks. Needed to
+	// avoid flaky test failures due to a race condition with the background
+	// task loop and the mock clock.
+	// For example:
+	// We may `.Add` some time to the mock clock which triggers the workTimer. The results in work in two goroutines:
+	// Goroutine A (inside the mock clock):
+	//   - Go through each each registered timer and `Tick` anything that happened before out next end time. `Tick` simply puts a value on the timer's channel.
+	//   - If there are no more registered timers, set the final end time and return.
+	// Goroutine B (our background task loop):
+	//   - Wait for a value from the workTimer channel.
+	//   - Run scheduled tasks, then reset the workTimer to the next scheduled run by reseting with duration = nextScheduledRun - "now".
+	//   - If the above happens after the last step in Goroutine A, then we reset the timer to end time + duration rather than "now" + duration.
+	maybeRunBackgroundTasks chan struct{}
 }
 
 func newRelayFinder(host *basic.BasicHost, peerSource PeerSource, conf *config) *relayFinder {
@@ -94,6 +109,7 @@ func newRelayFinder(host *basic.BasicHost, peerSource PeerSource, conf *config) 
 		candidateFound:             make(chan struct{}, 1),
 		maybeConnectToRelayTrigger: make(chan struct{}, 1),
 		maybeRequestNewCandidates:  make(chan struct{}, 1),
+		maybeRunBackgroundTasks:    make(chan struct{}, 1),
 		relays:                     make(map[peer.ID]*circuitv2.Reservation),
 		relayUpdated:               make(chan struct{}, 1),
 	}
@@ -120,6 +136,25 @@ func (rf *relayFinder) background(ctx context.Context) {
 		defer rf.refCount.Done()
 		rf.handleNewCandidates(ctx)
 	}()
+
+	// Workaround for mock clock so we don't miss scheduled background work. See
+	// the comment around maybeRunBackgroundTasks.
+	if _, ok := rf.conf.clock.(*clock.Mock); ok {
+		go func() {
+			ticker := time.NewTicker(time.Second)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					select {
+					case rf.maybeRunBackgroundTasks <- struct{}{}:
+					default:
+					}
+				}
+			}
+		}()
+	}
 
 	subConnectedness, err := rf.host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged), eventbus.Name("autorelay (relay finder)"))
 	if err != nil {
@@ -191,6 +226,9 @@ func (rf *relayFinder) background(ctx context.Context) {
 			now := rf.conf.clock.Now()
 			nextTime := rf.runScheduledWork(ctx, now, scheduledWork, peerSourceRateLimiter)
 			workTimer.Reset(nextTime.Sub(now))
+		case <-rf.maybeRunBackgroundTasks:
+			// Ignore the next time because we aren't scheduling any future work here
+			_ = rf.runScheduledWork(ctx, rf.conf.clock.Now(), scheduledWork, peerSourceRateLimiter)
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
Also adds our own custom mock clock that fits a better interface for this module.

The new mock clock implements the following interface:
```go
// InstantTimer is a timer that triggers at some instant rather than some duration
type InstantTimer interface {
	Reset(d time.Time) bool
	Stop() bool
	Ch() <-chan time.Time
}

// ClockWithInstantTimer is a clock that can create timers that trigger at some
// instant rather than some duration
type ClockWithInstantTimer interface {
	Now() time.Time
	Since(t time.Time) time.Duration
	InstantTimer(when time.Time) InstantTimer
}
```

This lets us avoid the issue of https://github.com/libp2p/go-libp2p/pull/2187 altogether.

The new mock clock is about 100 LOC and should behave logically close to a real clock (time shouldn't jump from 0 to 1000 without work being done in between).

Closes #2187. Closes #2192. Fixes #2189. Closes #2183 

I chose to incorporate those PRs into this one to avoid the merge conflicts that would ensue.