### PR TITLE
discovery (backoff): fix typo in comment 

### DIFF
--- a/p2p/discovery/backoff/backoff.go
+++ b/p2p/discovery/backoff/backoff.go
@@ -26,7 +26,7 @@ type BackoffStrategy interface {
 // Jitter must return a duration between min and max. Min must be lower than, or equal to, max.
 type Jitter func(duration, min, max time.Duration, rng *rand.Rand) time.Duration
 
-// FullJitter returns a random number uniformly chose from the range [min, boundedDur].
+// FullJitter returns a random number, uniformly chosen from the range [min, boundedDur].
 // boundedDur is the duration bounded between min and max.
 func FullJitter(duration, min, max time.Duration, rng *rand.Rand) time.Duration {
 	if duration <= min {


### PR DESCRIPTION
### Changes

- Fix comment typo & add a comma:
    `a random number uniformly chose from` -> `a random number, uniformly chosen from`