### PR TITLE
webtransport: Add helpers to transform webtransport multiaddrs in AddrsFactory

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -17,6 +17,7 @@ import (
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
@@ -288,4 +289,49 @@ func TestSecurityConstructor(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to negotiate security protocol")
 	require.NoError(t, h2.Connect(context.Background(), ai))
+}
+
+func TestTransportConstructorWebTransport(t *testing.T) {
+	h, err := New(
+		Transport(webtransport.New),
+		DisableRelay(),
+	)
+	require.NoError(t, err)
+	defer h.Close()
+	require.NoError(t, h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport")))
+	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), swarm.ErrNoTransport.Error())
+}
+
+func TestTransportCustomAddressWebTransport(t *testing.T) {
+	customAddr, err := ma.NewMultiaddr("/ip4/1.2.3.4/udp/1234/quic-v1/webtransport")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := New(
+		Transport(webtransport.New),
+		DisableRelay(),
+		AddrsFactory(func(multiaddrs []ma.Multiaddr) []ma.Multiaddr {
+			customAddrWithCertHash := customAddr
+			for _, addr := range multiaddrs {
+				if webtransport.IsWebtransportMultiaddrWithCerthash(addr) {
+					customAddrWithCertHash = webtransport.CopyCerthashes(addr, customAddrWithCertHash)
+					break
+				}
+			}
+			return []ma.Multiaddr{customAddrWithCertHash}
+		}),
+	)
+	require.NoError(t, err)
+	defer h.Close()
+	require.NoError(t, h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1/webtransport")))
+	addrs := h.Addrs()
+	require.Len(t, addrs, 1)
+	require.NotEqual(t, addrs[0], customAddr)
+	restOfAddr, lastComp := ma.SplitLast(addrs[0])
+	restOfAddr, secondToLastComp := ma.SplitLast(restOfAddr)
+	require.Equal(t, lastComp.Protocol().Code, ma.P_CERTHASH)
+	require.Equal(t, secondToLastComp.Protocol().Code, ma.P_CERTHASH)
+	require.True(t, restOfAddr.Equal(customAddr))
 }

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -313,14 +313,7 @@ func TestTransportCustomAddressWebTransport(t *testing.T) {
 		Transport(webtransport.New),
 		DisableRelay(),
 		AddrsFactory(func(multiaddrs []ma.Multiaddr) []ma.Multiaddr {
-			customAddrWithCertHash := customAddr
-			for _, addr := range multiaddrs {
-				if webtransport.IsWebtransportMultiaddrWithCerthash(addr) {
-					customAddrWithCertHash = webtransport.CopyCerthashes(addr, customAddrWithCertHash)
-					break
-				}
-			}
-			return []ma.Multiaddr{customAddrWithCertHash}
+			return []ma.Multiaddr{customAddr}
 		}),
 	)
 	require.NoError(t, err)

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -760,6 +760,7 @@ func (h *BasicHost) ConnManager() connmgr.ConnManager {
 // Addrs returns listening addresses that are safe to announce to the network.
 // The output is the same as AllAddrs, but processed by AddrsFactory.
 func (h *BasicHost) Addrs() []ma.Multiaddr {
+	h.Network()
 	return h.AddrsFactory(h.AllAddrs())
 }
 

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -760,7 +760,6 @@ func (h *BasicHost) ConnManager() connmgr.ConnManager {
 // Addrs returns listening addresses that are safe to announce to the network.
 // The output is the same as AllAddrs, but processed by AddrsFactory.
 func (h *BasicHost) Addrs() []ma.Multiaddr {
-	h.Network()
 	return h.AddrsFactory(h.AllAddrs())
 }
 

--- a/p2p/transport/webtransport/multiaddr.go
+++ b/p2p/transport/webtransport/multiaddr.go
@@ -80,10 +80,10 @@ func addrComponentForCert(hash []byte) (ma.Multiaddr, error) {
 // well formed webtransport multiaddr. Returns the number of certhashes found.
 func IsWebtransportMultiaddr(multiaddr ma.Multiaddr) (bool, int) {
 	const (
-		init              = iota
-		foundUDP          = iota
-		foundQuicV1       = iota
-		foundWebTransport = iota
+		init = iota
+		foundUDP
+		foundQuicV1
+		foundWebTransport
 	)
 	state := init
 	certhashCount := 0
@@ -118,7 +118,7 @@ func IsWebtransportMultiaddrWithCerthash(multiaddr ma.Multiaddr) bool {
 // unchanged.  Otherwise a new multiaddr is returned with certhashes appeneded
 // to it
 func CopyCerthashes(existingMultiaddrWithCerthashes, multiaddrWithoutCerthashes ma.Multiaddr) ma.Multiaddr {
-	var certhashComponents []ma.Component
+	certhashComponents := make([]ma.Component, 0, 2) // 2 is the common case
 	ma.ForEach(existingMultiaddrWithCerthashes, func(c ma.Component) bool {
 		if c.Protocol().Code == ma.P_CERTHASH {
 			certhashComponents = append(certhashComponents, c)

--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -286,23 +286,13 @@ func decodeCertHashesFromProtobuf(b [][]byte) ([]multihash.DecodedMultihash, err
 }
 
 func (t *transport) CanDial(addr ma.Multiaddr) bool {
-	var numHashes int
-	ma.ForEach(addr, func(c ma.Component) bool {
-		if c.Protocol().Code == ma.P_CERTHASH {
-			numHashes++
-		}
-		return true
-	})
-	// Remove the /certhash components from the multiaddr.
-	// If the multiaddr doesn't contain any certhashes, the node might have a CA-signed certificate.
-	for i := 0; i < numHashes; i++ {
-		addr, _ = ma.SplitLast(addr)
-	}
-	return webtransportMatcher.Matches(addr)
+	ok, _ := IsWebtransportMultiaddr(addr)
+	return ok
 }
 
 func (t *transport) Listen(laddr ma.Multiaddr) (tpt.Listener, error) {
-	if !webtransportMatcher.Matches(laddr) {
+	isWebTransport, _ := IsWebtransportMultiaddr(laddr)
+	if !isWebTransport {
 		return nil, fmt.Errorf("cannot listen on non-WebTransport addr: %s", laddr)
 	}
 	if t.staticTLSConf == nil {


### PR DESCRIPTION
I think the AddrsFactory is a bit hard to use. This PR doesn't address that.

This PR adds some helper functions to allow users to do the correct thing inside AddrsFactory. Fixes #2223 

Users can add their own webtransport mappings by copying certhashes from an existing multiaddr. For example,

```go
AddrsFactory(func(multiaddrs []ma.Multiaddr) []ma.Multiaddr {
	outAddrs := make([]ma.Multiaddr, 0, len(multiaddrs)+1)
	for _, addr := range multiaddrs {
		// Keep the original addrs.
		outAddrs = append(outAddrs, addr)
		if webtransport.IsWebtransportMultiaddrWithCerthash(addr) {
			// Add our custom addr with certhashes from an existing addr.
			outAddrs = append(outAddrs, webtransport.CopyCerthashes(addr, customAddr))
		}
	}
	return outAddrs
})
```

This also allows users to do this only for specifics addresses in case they are listening on multiple addresses.