### PR TITLE
swarm: fix multiaddr comparison in ListenClose

### DIFF
--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -156,7 +156,7 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 
 func containsMultiaddr(addrs []ma.Multiaddr, addr ma.Multiaddr) bool {
 	for _, a := range addrs {
-		if addr == a {
+		if addr.Equal(a) {
 			return true
 		}
 	}


### PR DESCRIPTION
Multiaddresses need to be compared with `Equal`, not with `==`, since `ma.StringCast(addr) != ma.StringCast(addr)`, but `ma.StringCast(addr).Equal(ma.StringCast(addr))`.