### PR TITLE
identify: fix normalization of interface listen addresses

### DIFF
--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -360,26 +360,39 @@ type normalizeMultiaddrer interface {
 	NormalizeMultiaddr(addr ma.Multiaddr) ma.Multiaddr
 }
 
-func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observed ma.Multiaddr) {
+type addrsProvider interface {
+	Addrs() []ma.Multiaddr
+}
+type listenAddrsProvider interface {
+	ListenAddresses() []ma.Multiaddr
+	InterfaceListenAddresses() ([]ma.Multiaddr, error)
+}
+
+type connMultiaddrProvider interface {
+	RemoteMultiaddr() ma.Multiaddr
+	LocalMultiaddr() ma.Multiaddr
+}
+
+func shouldRecordObservation(host addrsProvider, network listenAddrsProvider, conn connMultiaddrProvider, observed ma.Multiaddr) bool {
 	// First, determine if this observation is even worth keeping...
 
 	// Ignore observations from loopback nodes. We already know our loopback
 	// addresses.
 	if manet.IsIPLoopback(observed) {
-		return
+		return false
 	}
 
 	// we should only use ObservedAddr when our connection's LocalAddr is one
 	// of our ListenAddrs. If we Dial out using an ephemeral addr, knowing that
 	// address's external mapping is not very useful because the port will not be
 	// the same as the listen addr.
-	ifaceaddrs, err := oas.host.Network().InterfaceListenAddresses()
+	ifaceaddrs, err := network.InterfaceListenAddresses()
 	if err != nil {
 		log.Infof("failed to get interface listen addrs", err)
-		return
+		return false
 	}
 
-	normalizer, canNormalize := oas.host.(normalizeMultiaddrer)
+	normalizer, canNormalize := host.(normalizeMultiaddrer)
 
 	if canNormalize {
 		for i, a := range ifaceaddrs {
@@ -392,7 +405,7 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 		local = normalizer.NormalizeMultiaddr(local)
 	}
 
-	listenAddrs := oas.host.Network().ListenAddresses()
+	listenAddrs := network.ListenAddresses()
 	if canNormalize {
 		for i, a := range listenAddrs {
 			listenAddrs[i] = normalizer.NormalizeMultiaddr(a)
@@ -401,10 +414,10 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 
 	if !ma.Contains(ifaceaddrs, local) && !ma.Contains(listenAddrs, local) {
 		// not in our list
-		return
+		return false
 	}
 
-	hostAddrs := oas.host.Addrs()
+	hostAddrs := host.Addrs()
 	if canNormalize {
 		for i, a := range hostAddrs {
 			hostAddrs[i] = normalizer.NormalizeMultiaddr(a)
@@ -420,20 +433,26 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 			"from", conn.RemoteMultiaddr(),
 			"observed", observed,
 		)
-		return
+		return false
 	}
 
-	// Ok, the observation is good, record it.
-	log.Debugw("added own observed listen addr", "observed", observed)
+	return true
+}
 
-	defer oas.addConn(conn, observed)
+func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observed ma.Multiaddr) {
+	shouldRecord := shouldRecordObservation(oas.host, oas.host.Network(), conn, observed)
+	if shouldRecord {
+		// Ok, the observation is good, record it.
+		log.Debugw("added own observed listen addr", "observed", observed)
+		defer oas.addConn(conn, observed)
 
-	oas.mu.Lock()
-	defer oas.mu.Unlock()
-	oas.recordObservationUnlocked(conn, observed)
+		oas.mu.Lock()
+		defer oas.mu.Unlock()
+		oas.recordObservationUnlocked(conn, observed)
 
-	if oas.reachability == network.ReachabilityPrivate {
-		oas.emitAllNATTypes()
+		if oas.reachability == network.ReachabilityPrivate {
+			oas.emitAllNATTypes()
+		}
 	}
 }
 

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -391,7 +391,15 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 	if canNormalize {
 		local = normalizer.NormalizeMultiaddr(local)
 	}
-	if !ma.Contains(ifaceaddrs, local) && !ma.Contains(oas.host.Network().ListenAddresses(), local) {
+
+	listenAddrs := oas.host.Network().ListenAddresses()
+	if canNormalize {
+		for i, a := range listenAddrs {
+			listenAddrs[i] = normalizer.NormalizeMultiaddr(a)
+		}
+	}
+
+	if !ma.Contains(ifaceaddrs, local) && !ma.Contains(listenAddrs, local) {
 		// not in our list
 		return
 	}
@@ -400,12 +408,6 @@ func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observ
 	if canNormalize {
 		for i, a := range hostAddrs {
 			hostAddrs[i] = normalizer.NormalizeMultiaddr(a)
-		}
-	}
-	listenAddrs := oas.host.Network().ListenAddresses()
-	if canNormalize {
-		for i, a := range listenAddrs {
-			listenAddrs[i] = normalizer.NormalizeMultiaddr(a)
 		}
 	}
 

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -363,17 +363,13 @@ type normalizeMultiaddrer interface {
 type addrsProvider interface {
 	Addrs() []ma.Multiaddr
 }
+
 type listenAddrsProvider interface {
 	ListenAddresses() []ma.Multiaddr
 	InterfaceListenAddresses() ([]ma.Multiaddr, error)
 }
 
-type connMultiaddrProvider interface {
-	RemoteMultiaddr() ma.Multiaddr
-	LocalMultiaddr() ma.Multiaddr
-}
-
-func shouldRecordObservation(host addrsProvider, network listenAddrsProvider, conn connMultiaddrProvider, observed ma.Multiaddr) bool {
+func shouldRecordObservation(host addrsProvider, network listenAddrsProvider, conn network.ConnMultiaddrs, observed ma.Multiaddr) bool {
 	// First, determine if this observation is even worth keeping...
 
 	// Ignore observations from loopback nodes. We already know our loopback


### PR DESCRIPTION
The previous fix in #2235 was so close, but didn't catch this bug since ListenAddrs == InterfaceListeneAddrs in the [mocknet](https://github.com/libp2p/go-libp2p/blob/master/p2p/net/mock/mock_peernet.go#L307).