### PR TITLE
quic: prioritise listen connections for reuse

### DIFF
--- a/p2p/transport/quicreuse/connmgr_test.go
+++ b/p2p/transport/quicreuse/connmgr_test.go
@@ -25,7 +25,7 @@ func checkClosed(t *testing.T, cm *ConnManager) {
 			continue
 		}
 		r.mutex.Lock()
-		for _, conn := range r.global {
+		for _, conn := range r.globalListeners {
 			require.Zero(t, conn.GetCount())
 		}
 		for _, conns := range r.unicast {

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -230,15 +230,15 @@ func (r *reuse) Listen(network string, laddr *net.UDPAddr) (*reuseConn, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	var rconn *reuseConn
-	var localAddr *net.UDPAddr
-
 	// Check if we can reuse a connection we have already dialed out from.
 	// We reuse a connection from globalDialers when the requested port is 0 or the requested
 	// port is already in the globalDialers.
 	// If we are reusing a connection from globalDialers, we move the globalDialers entry to
 	// globalListeners
 	if laddr.IP.IsUnspecified() {
+		var rconn *reuseConn
+		var localAddr *net.UDPAddr
+
 		if laddr.Port == 0 {
 			// the requested port is 0, we can reuse any connection
 			for _, conn := range r.globalDialers {
@@ -264,8 +264,8 @@ func (r *reuse) Listen(network string, laddr *net.UDPAddr) (*reuseConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	localAddr = conn.LocalAddr().(*net.UDPAddr)
-	rconn = newReuseConn(conn)
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	rconn := newReuseConn(conn)
 
 	rconn.IncreaseCount()
 

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -78,7 +78,7 @@ type reuse struct {
 	globalListeners map[int]*reuseConn
 	// globalDialers contains connections that we've dialed out from. These connections are listening on 0.0.0.0 / ::
 	// On Dial, connections are reused from this map if no connection is available in the globalListeners
-	// On Listen, connections are reused from this map if the requested port is 0
+	// On Listen, connections are reused from this map if the requested port is 0, and then moved to globalListeners
 	globalDialers map[int]*reuseConn
 }
 

--- a/p2p/transport/quicreuse/reuse_test.go
+++ b/p2p/transport/quicreuse/reuse_test.go
@@ -137,11 +137,11 @@ func TestReuseConnectionWhenDialBeforeListen(t *testing.T) {
 	// dial any address
 	raddr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
 	require.NoError(t, err)
-	_, err = reuse.Dial("udp4", raddr)
+	rconn, err := reuse.Dial("udp4", raddr)
 	require.NoError(t, err)
 
 	// open a listener
-	laddr := &net.UDPAddr{IP: net.IPv4zero, Port: 10000}
+	laddr := &net.UDPAddr{IP: net.IPv4zero, Port: 1234}
 	lconn, err := reuse.Listen("udp4", laddr)
 	require.NoError(t, err)
 
@@ -152,6 +152,13 @@ func TestReuseConnectionWhenDialBeforeListen(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, conn, lconn)
 	require.Equal(t, conn.GetCount(), 2)
+
+	// a listener on an unspecified port should reuse the dialer
+	laddr2 := &net.UDPAddr{IP: net.IPv4zero, Port: 0}
+	lconn2, err := reuse.Listen("udp4", laddr2)
+	require.NoError(t, err)
+	require.Equal(t, lconn2, rconn)
+	require.Equal(t, lconn2.GetCount(), 2)
 }
 
 func TestReuseListenOnSpecificInterface(t *testing.T) {
@@ -210,7 +217,7 @@ func TestReuseGarbageCollect(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dconn.GetCount(), 1)
 
-	addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
+	addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:1234")
 	require.NoError(t, err)
 	lconn, err := reuse.Listen("udp4", addr)
 	require.NoError(t, err)

--- a/p2p/transport/quicreuse/reuse_test.go
+++ b/p2p/transport/quicreuse/reuse_test.go
@@ -26,7 +26,7 @@ func closeAllConns(reuse *reuse) {
 			conn.DecreaseCount()
 		}
 	}
-	for _, conn := range reuse.globalDial {
+	for _, conn := range reuse.globalFallback {
 		for conn.GetCount() > 0 {
 			conn.DecreaseCount()
 		}


### PR DESCRIPTION
Currently there is a race in kubo between the first dial made by a node on startup and starting to listen on a quic address. 

If the dial happens first, this places an entry in the ```reuse.global``` map. This entry will stay in the map till we get a period of 30 seconds where we make no new dials. In my experiments this entry is removed after 15 minutes of starting the node. This dial happens before listening 5-10% of the times on my machine. 

The impact of this is on holepunching. While this entry is in the map, the function ```reuse.Dial``` in ```p2p/transport/quicreuse/reuse.go``` can return either this connection that we dialed out of but are not listening on, or it can return the correct connection the one on which we are listening.  