### PR TITLE
Add debug message show log to show if security protocol wasn't negotiated

### DIFF
--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -154,6 +154,7 @@ func (u *upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 
 	sconn, security, server, err := u.setupSecurity(ctx, conn, p, dir)
 	if err != nil {
+		log.Debugf("failed to negotiate security protocol %s\n", err.Error())
 		conn.Close()
 		return nil, fmt.Errorf("failed to negotiate security protocol: %w", err)
 	}


### PR DESCRIPTION
Reference issue #2265 
Whilst the error message appears meaningful - not appending it to the debug log means the engineer in search of a problem won't locate it as easily.