### PR TITLE
chore: add interop testing to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -30,4 +30,5 @@ about: 'Start a new libp2p release.'
     - [ ] [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht/)
     - [ ] [go-libp2p-pubsub](https://github.com/libp2p/go-libp2p-pubsub) (In case of breaking changes.)
     - [ ] [ipfs/kubo](https://github.com/ipfs/kubo)
+  - [ ] Add new release to interop tester in [test-plans](https://github.com/libp2p/test-plans/)
 - [ ] Make required changes to the release process.


### PR DESCRIPTION
Don't consider a release "complete" until it's added to the interop test suite