### PR TITLE
ci: run interop tests on self-hosted runners

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run-multidim-interop:
     name: Run multidimensional interoperability tests
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(vars['INTEROP_TEST_RUNNER_UBUNTU'] || '"ubuntu-22.04"') }}
     steps:
       - uses: actions/checkout@v3
       - name: Build image


### PR DESCRIPTION
Speedup:
* Build step: 20s instead of 1m
* Test step: 10m instead of 15m

Switching to self-hosted runners therefore definitely pays off, even though spinning up the runner (currently) takes 1-2m. It also reduces contention for our quota of 20 GitHub provided runners.