### PR TITLE
swarm: change maps with multiaddress keys to use strings

### DIFF
--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -119,16 +119,16 @@ func (rh *RoutedHost) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		}
 
 		// Build lookup map
-		lookup := make(map[ma.Multiaddr]struct{}, len(addrs))
+		lookup := make(map[string]struct{}, len(addrs))
 		for _, addr := range addrs {
-			lookup[addr] = struct{}{}
+			lookup[string(addr.Bytes())] = struct{}{}
 		}
 
 		// if there's any address that's not in the previous set
 		// of addresses, try to connect again. If all addresses
 		// where known previously we return the original error.
 		for _, newAddr := range newAddrs {
-			if _, found := lookup[newAddr]; found {
+			if _, found := lookup[string(newAddr.Bytes())]; found {
 				continue
 			}
 

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -360,6 +360,7 @@ func TestDialWorkerLoopAddrDedup(t *testing.T) {
 			return
 		}
 		go func() {
+			ch <- struct{}{}
 			for {
 				conn, err := list.Accept()
 				if err != nil {
@@ -372,10 +373,11 @@ func TestDialWorkerLoopAddrDedup(t *testing.T) {
 		<-closech
 		list.Close()
 	}
-	ch := make(chan struct{})
+	ch := make(chan struct{}, 1)
 	closeCh := make(chan struct{})
 	go acceptAndClose(t1, ch, closeCh)
 	defer close(closeCh)
+	<-ch // the routine has started listening on addr
 
 	s1.Peerstore().AddAddrs(s2.LocalPeer(), []ma.Multiaddr{t1}, peerstore.PermanentAddrTTL)
 


### PR DESCRIPTION
fixes: https://github.com/libp2p/go-libp2p/issues/2283

`string(addr.Bytes())` is already used in peerstore. https://github.com/libp2p/go-libp2p/issues/2283

Fixes one more instance in `routed.go` https://github.com/libp2p/go-libp2p/blob/master/p2p/host/routed/routed.go#L122