### PR TITLE
Transport integration tests: transport suite

### DIFF
--- a/p2p/test/transport/suite_test.go
+++ b/p2p/test/transport/suite_test.go
@@ -1,0 +1,46 @@
+package transport_integration
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/transport"
+	ttransport "github.com/libp2p/go-libp2p/p2p/transport/testsuite"
+	libp2pwebtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
+	ma "github.com/multiformats/go-multiaddr"
+	multiaddr "github.com/multiformats/go-multiaddr"
+)
+
+func TestWithSuite(t *testing.T) {
+	portMatcher := regexp.MustCompile(`(tcp|udp)\/\d+`)
+
+	for _, tc := range transportsToTest {
+		t.Run(tc.Name, func(t *testing.T) {
+			// We use this host just to get a valid multiaddr for this transport.
+			hostToGetAddr := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true})
+			a := multiaddr.StringCast(portMatcher.ReplaceAllString(hostToGetAddr.Addrs()[0].String(), "$1/0"))
+			hostToGetAddr.Close()
+
+			if tc.Name == "WebTransport" {
+				// Remove certhash components
+				_, n := libp2pwebtransport.IsWebtransportMultiaddr(a)
+				for i := 0; i < n; i++ {
+					a, _ = multiaddr.SplitLast(a)
+				}
+			}
+
+			listener := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true, NoListen: true, DisableQuicReuseport: false}) // Transport suite will listen on its own
+			defer listener.Close()
+			dialer := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true, NoListen: true, DisableQuicReuseport: true})
+			defer dialer.Close()
+
+			type transportForListeninger interface {
+				TransportForListening(a ma.Multiaddr) transport.Transport
+			}
+
+			listenerTransport := listener.Network().(transportForListeninger).TransportForListening(a)
+			dialerTransport := dialer.Network().(transportForListeninger).TransportForListening(a)
+			ttransport.SubtestTransport(t, listenerTransport, dialerTransport, a.String(), listener.ID())
+		})
+	}
+}

--- a/p2p/test/transport/suite_test.go
+++ b/p2p/test/transport/suite_test.go
@@ -8,7 +8,6 @@ import (
 	ttransport "github.com/libp2p/go-libp2p/p2p/transport/testsuite"
 	libp2pwebtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	ma "github.com/multiformats/go-multiaddr"
-	multiaddr "github.com/multiformats/go-multiaddr"
 )
 
 func TestWithSuite(t *testing.T) {
@@ -18,14 +17,14 @@ func TestWithSuite(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			// We use this host just to get a valid multiaddr for this transport.
 			hostToGetAddr := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true})
-			a := multiaddr.StringCast(portMatcher.ReplaceAllString(hostToGetAddr.Addrs()[0].String(), "$1/0"))
+			a := ma.StringCast(portMatcher.ReplaceAllString(hostToGetAddr.Addrs()[0].String(), "$1/0"))
 			hostToGetAddr.Close()
 
 			if tc.Name == "WebTransport" {
 				// Remove certhash components
 				_, n := libp2pwebtransport.IsWebtransportMultiaddr(a)
 				for i := 0; i < n; i++ {
-					a, _ = multiaddr.SplitLast(a)
+					a, _ = ma.SplitLast(a)
 				}
 			}
 

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
+	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,9 +32,10 @@ type TransportTestCase struct {
 }
 
 type TransportTestCaseOpts struct {
-	NoListen  bool
-	NoRcmgr   bool
-	ConnGater connmgr.ConnectionGater
+	NoListen             bool
+	DisableQuicReuseport bool
+	NoRcmgr              bool
+	ConnGater            connmgr.ConnectionGater
 }
 
 func transformOpts(opts TransportTestCaseOpts) []config.Option {
@@ -44,6 +46,10 @@ func transformOpts(opts TransportTestCaseOpts) []config.Option {
 	}
 	if opts.ConnGater != nil {
 		libp2pOpts = append(libp2pOpts, libp2p.ConnectionGater(opts.ConnGater))
+	}
+
+	if opts.DisableQuicReuseport {
+		libp2pOpts = append(libp2pOpts, libp2p.QUICReuse(quicreuse.NewConnManager, quicreuse.DisableReuseport()))
 	}
 	return libp2pOpts
 }


### PR DESCRIPTION
Related to #2194 

This runs the `p2p/transport/testsuite` on all transports. There is one change made to avoid starting a new listener for every connection, which would fail for QUIC listeners since multiple calls to listen on port 0 will use the same port and fail.