### PR TITLE
transport tests: many streams and lots of data

### DIFF
--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -149,6 +149,8 @@ func TestPing(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer h1.Close()
+			defer h2.Close()
 
 			require.NoError(t, h2.Connect(context.Background(), peer.AddrInfo{
 				ID:    h1.ID(),
@@ -176,6 +178,8 @@ func TestBigPing(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer h1.Close()
+			defer h2.Close()
 
 			require.NoError(t, h2.Connect(context.Background(), peer.AddrInfo{
 				ID:    h1.ID(),
@@ -241,6 +245,8 @@ func TestManyBigPings(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer h1.Close()
+			defer h2.Close()
 			start := time.Now()
 			defer func() {
 				t.Log("Total time:", time.Since(start))
@@ -300,6 +306,8 @@ func TestManyStreams(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true, NoRcmgr: true})
+			defer h1.Close()
+			defer h2.Close()
 
 			require.NoError(t, h2.Connect(context.Background(), peer.AddrInfo{
 				ID:    h1.ID(),
@@ -362,6 +370,8 @@ func TestManyMoreStreams(t *testing.T) {
 			}
 			listener := tc.HostGenerator(t, TransportTestCaseOpts{})
 			dialer := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer listener.Close()
+			defer dialer.Close()
 
 			require.NoError(t, dialer.Connect(context.Background(), peer.AddrInfo{
 				ID:    listener.ID(),
@@ -453,6 +463,8 @@ func TestListenerStreamResets(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer h1.Close()
+			defer h2.Close()
 
 			require.NoError(t, h2.Connect(context.Background(), peer.AddrInfo{
 				ID:    h1.ID(),
@@ -480,6 +492,8 @@ func TestDialerStreamResets(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer h1.Close()
+			defer h2.Close()
 
 			require.NoError(t, h2.Connect(context.Background(), peer.AddrInfo{
 				ID:    h1.ID(),
@@ -509,6 +523,8 @@ func TestStreamReadDeadline(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true})
+			defer h1.Close()
+			defer h2.Close()
 
 			require.NoError(t, h2.Connect(context.Background(), peer.AddrInfo{
 				ID:    h1.ID(),

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -232,7 +232,7 @@ func TestBigPing(t *testing.T) {
 func TestLotsOfDataManyStreams(t *testing.T) {
 	// Skip on windows because of https://github.com/libp2p/go-libp2p/issues/2341
 	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on windows because ofhttps://github.com/libp2p/go-libp2p/issues/2341")
+		t.Skip("Skipping on windows because of https://github.com/libp2p/go-libp2p/issues/2341")
 	}
 
 	// 64k buffer

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -186,14 +186,14 @@ func TestBigPing(t *testing.T) {
 				Addrs: h1.Addrs(),
 			}))
 
-			h1.SetStreamHandler("/BIG-ping/1.0.0", func(s network.Stream) {
+			h1.SetStreamHandler("/big-ping", func(s network.Stream) {
 				io.Copy(s, s)
 				s.Close()
 			})
 
 			errCh := make(chan error, 1)
 			allocs := testing.AllocsPerRun(10, func() {
-				s, err := h2.NewStream(context.Background(), h1.ID(), "/BIG-ping/1.0.0")
+				s, err := h2.NewStream(context.Background(), h1.ID(), "/big-ping")
 				require.NoError(t, err)
 				defer s.Close()
 
@@ -257,7 +257,7 @@ func TestManyBigPings(t *testing.T) {
 				Addrs: h1.Addrs(),
 			}))
 
-			h1.SetStreamHandler("/BIG-ping/1.0.0", func(s network.Stream) {
+			h1.SetStreamHandler("/big-ping", func(s network.Stream) {
 				io.Copy(s, s)
 				s.Close()
 			})
@@ -272,7 +272,7 @@ func TestManyBigPings(t *testing.T) {
 					recvBuf := [bufSize]byte{}
 					defer func() { <-sem }()
 
-					s, err := h2.NewStream(context.Background(), h1.ID(), "/BIG-ping/1.0.0")
+					s, err := h2.NewStream(context.Background(), h1.ID(), "/big-ping")
 					require.NoError(t, err)
 					defer s.Close()
 


### PR DESCRIPTION
Related to #2194.

There is a failure with mplex that I haven't spent time yet debugging. If it's not obvious, I'd suggest we fix this in parallel with the webrtc work. Meaning merge this as is and have an issue to fix it soon.