### PR TITLE
webtransport: close the challenge stream after the Noise handshake

### DIFF
--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -233,6 +233,7 @@ func (t *transport) upgrade(ctx context.Context, sess *webtransport.Session, p p
 	if err != nil {
 		return nil, err
 	}
+	defer str.Close()
 
 	// Now run a Noise handshake (using early data) and get all the certificate hashes from the server.
 	// We will verify that the certhashes we used to dial is a subset of the certhashes we received from the server.
@@ -262,6 +263,9 @@ func (t *transport) upgrade(ctx context.Context, sess *webtransport.Session, p p
 	}
 	c, err := n.SecureOutbound(ctx, &webtransportStream{Stream: str, wsess: sess}, p)
 	if err != nil {
+		return nil, err
+	}
+	if err = c.Close(); err != nil {
 		return nil, err
 	}
 	// The Noise handshake _should_ guarantee that our verification callback is called.

--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -265,9 +265,7 @@ func (t *transport) upgrade(ctx context.Context, sess *webtransport.Session, p p
 	if err != nil {
 		return nil, err
 	}
-	if err = c.Close(); err != nil {
-		return nil, err
-	}
+	defer c.Close()
 	// The Noise handshake _should_ guarantee that our verification callback is called.
 	// Double-check just in case.
 	if !verified {


### PR DESCRIPTION
Once the challenge succeeded there is no reason to keep the challenge stream open, it will never be used again.