### PR TITLE
use standard library sha256 implementation for Go 1.21

### DIFF
--- a/core/crypto/ecdsa.go
+++ b/core/crypto/ecdsa.go
@@ -12,8 +12,7 @@ import (
 
 	pb "github.com/libp2p/go-libp2p/core/crypto/pb"
 	"github.com/libp2p/go-libp2p/core/internal/catch"
-
-	"github.com/minio/sha256-simd"
+	"github.com/libp2p/go-libp2p/internal/sha256"
 )
 
 // ECDSAPrivateKey is an implementation of an ECDSA private key

--- a/core/crypto/key_test.go
+++ b/core/crypto/key_test.go
@@ -16,10 +16,10 @@ import (
 	. "github.com/libp2p/go-libp2p/core/crypto"
 	pb "github.com/libp2p/go-libp2p/core/crypto/pb"
 	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/libp2p/go-libp2p/internal/sha256"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	secp256k1ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"github.com/minio/sha256-simd"
 )
 
 func TestKeys(t *testing.T) {

--- a/core/crypto/rsa_go.go
+++ b/core/crypto/rsa_go.go
@@ -10,8 +10,7 @@ import (
 
 	pb "github.com/libp2p/go-libp2p/core/crypto/pb"
 	"github.com/libp2p/go-libp2p/core/internal/catch"
-
-	"github.com/minio/sha256-simd"
+	"github.com/libp2p/go-libp2p/internal/sha256"
 )
 
 // RsaPrivateKey is a rsa private key

--- a/core/crypto/secp256k1.go
+++ b/core/crypto/secp256k1.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"github.com/minio/sha256-simd"
+	"github.com/libp2p/go-libp2p/internal/sha256"
 )
 
 // Secp256k1PrivateKey is a Secp256k1 private key

--- a/internal/sha256/post_go1_21.go
+++ b/internal/sha256/post_go1_21.go
@@ -1,0 +1,23 @@
+//go:build go1.21
+
+// This package use build tags to select between github.com/minio/sha256-simd
+// for go1.20 and bellow and crypto/sha256 for go1.21 and above.
+// This is used because a fast SHANI implementation of sha256 is only avaiable
+// in the std for go1.21 and above. See https://go.dev/issue/50543.
+// TODO: Once go1.22 releases remove this package and replace all uses
+// with crypto/sha256 because the two supported version of go will have the fast
+// implementation.
+package sha256
+
+import (
+	"crypto/sha256"
+	"hash"
+)
+
+func Sum256(b []byte) [sha256.Size]byte {
+	return sha256.Sum256(b)
+}
+
+func New() hash.Hash {
+	return sha256.New()
+}

--- a/internal/sha256/pre_go1_21.go
+++ b/internal/sha256/pre_go1_21.go
@@ -1,0 +1,24 @@
+//go:build !go1.21
+
+// This package use build tags to select between github.com/minio/sha256-simd
+// for go1.20 and bellow and crypto/sha256 for go1.21 and above.
+// This is used because a fast SHANI implementation of sha256 is only avaiable
+// in the std for go1.21 and above. See https://go.dev/issue/50543.
+// TODO: Once go1.22 releases remove this package and replace all uses
+// with crypto/sha256 because the two supported version of go will have the fast
+// implementation.
+package sha256
+
+import (
+	"hash"
+
+	"github.com/minio/sha256-simd"
+)
+
+func Sum256(b []byte) [sha256.Size]byte {
+	return sha256.Sum256(b)
+}
+
+func New() hash.Hash {
+	return sha256.New()
+}

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/libp2p/go-libp2p/internal/sha256"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
@@ -18,7 +19,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 
-	"github.com/minio/sha256-simd"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multihash"

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/internal/sha256"
 	"github.com/libp2p/go-libp2p/p2p/security/noise/pb"
 
 	"github.com/flynn/noise"
 	pool "github.com/libp2p/go-buffer-pool"
-	"github.com/minio/sha256-simd"
 	"google.golang.org/protobuf/proto"
 )
 


### PR DESCRIPTION
See rational and benchmarks in multiformats/go-multihash#173.

Fixes: #2308