### PR TITLE
test: rcmgr: Snapshot defaults and test that we keep consistent defaults

### DIFF
--- a/p2p/host/resource-manager/limit_config_test.go
+++ b/p2p/host/resource-manager/limit_config_test.go
@@ -123,6 +123,20 @@ func TestLimitConfigRoundTrip(t *testing.T) {
 	require.Equal(t, concreteCfg, concreteCfgRT)
 }
 
+func TestDefaultsDontChange(t *testing.T) {
+	concrete := DefaultLimits.AutoScale()
+	jsonBytes, err := json.MarshalIndent(concrete.ToPartialLimitConfig(), "", "  ")
+	require.NoError(t, err)
+
+	// Uncomment to update the defaults file
+	// err = os.WriteFile("limit_config_test_default.json", jsonBytes, 0644)
+	// require.NoError(t, err)
+
+	defaultsFromFile, err := os.ReadFile("limit_config_test_default.json")
+	require.NoError(t, err)
+	require.Equal(t, defaultsFromFile, jsonBytes)
+}
+
 func TestReadmeLimitConfigSerialization(t *testing.T) {
 	noisyNeighbor, _ := peer.Decode("QmVvtzcZgCkMnSFf2dnrBPXrWuNFWNM9J3MpZQCvWPuVZf")
 	cfg := PartialLimitConfig{

--- a/p2p/host/resource-manager/limit_config_test_default.json
+++ b/p2p/host/resource-manager/limit_config_test_default.json
@@ -1,0 +1,112 @@
+{
+  "System": {
+    "Streams": 18432,
+    "StreamsInbound": 9216,
+    "StreamsOutbound": 18432,
+    "Conns": 1152,
+    "ConnsInbound": 576,
+    "ConnsOutbound": 1152,
+    "FD": 122880,
+    "Memory": "8724152320"
+  },
+  "Transient": {
+    "Streams": 2304,
+    "StreamsInbound": 1152,
+    "StreamsOutbound": 2304,
+    "Conns": 320,
+    "ConnsInbound": 160,
+    "ConnsOutbound": 320,
+    "FD": 30720,
+    "Memory": "1107296256"
+  },
+  "AllowlistedSystem": {
+    "Streams": 18432,
+    "StreamsInbound": 9216,
+    "StreamsOutbound": 18432,
+    "Conns": 1152,
+    "ConnsInbound": 576,
+    "ConnsOutbound": 1152,
+    "FD": 122880,
+    "Memory": "8724152320"
+  },
+  "AllowlistedTransient": {
+    "Streams": 2304,
+    "StreamsInbound": 1152,
+    "StreamsOutbound": 2304,
+    "Conns": 320,
+    "ConnsInbound": 160,
+    "ConnsOutbound": 320,
+    "FD": 30720,
+    "Memory": "1107296256"
+  },
+  "ServiceDefault": {
+    "Streams": 20480,
+    "StreamsInbound": 5120,
+    "StreamsOutbound": 20480,
+    "Conns": "blockAll",
+    "ConnsInbound": "blockAll",
+    "ConnsOutbound": "blockAll",
+    "FD": "blockAll",
+    "Memory": "1140850688"
+  },
+  "ServicePeerDefault": {
+    "Streams": 320,
+    "StreamsInbound": 160,
+    "StreamsOutbound": 320,
+    "Conns": "blockAll",
+    "ConnsInbound": "blockAll",
+    "ConnsOutbound": "blockAll",
+    "FD": "blockAll",
+    "Memory": "50331648"
+  },
+  "ProtocolDefault": {
+    "Streams": 6144,
+    "StreamsInbound": 2560,
+    "StreamsOutbound": 6144,
+    "Conns": "blockAll",
+    "ConnsInbound": "blockAll",
+    "ConnsOutbound": "blockAll",
+    "FD": "blockAll",
+    "Memory": "1442840576"
+  },
+  "ProtocolPeerDefault": {
+    "Streams": 384,
+    "StreamsInbound": 96,
+    "StreamsOutbound": 192,
+    "Conns": "blockAll",
+    "ConnsInbound": "blockAll",
+    "ConnsOutbound": "blockAll",
+    "FD": "blockAll",
+    "Memory": "16777248"
+  },
+  "PeerDefault": {
+    "Streams": 2560,
+    "StreamsInbound": 1280,
+    "StreamsOutbound": 2560,
+    "Conns": 8,
+    "ConnsInbound": 8,
+    "ConnsOutbound": 8,
+    "FD": 1920,
+    "Memory": "1140850688"
+  },
+  "Conn": {
+    "Streams": "blockAll",
+    "StreamsInbound": "blockAll",
+    "StreamsOutbound": "blockAll",
+    "Conns": 1,
+    "ConnsInbound": 1,
+    "ConnsOutbound": 1,
+    "FD": 1,
+    "Memory": "33554432"
+  },
+  "Stream": {
+    "Streams": 1,
+    "StreamsInbound": 1,
+    "StreamsOutbound": 1,
+    "Conns": "blockAll",
+    "ConnsInbound": "blockAll",
+    "ConnsOutbound": "blockAll",
+    "FD": "blockAll",
+    "Memory": "16777216"
+  }
+}


### PR DESCRIPTION
No logical changes. Adds a test to make sure we don't silently break the defaults by snapshotting the current default state. If we change the defaults the diff will show what changed.