### PR TITLE
identify: don't save signed peer records

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -3,6 +3,7 @@ package identify
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -757,21 +758,18 @@ func (ids *idService) consumeMessage(mes *pb.Identify, c network.Conn, isPush bo
 		ids.Host.Peerstore().UpdateAddrs(context.TODO(), p, ttl, peerstore.TempAddrTTL)
 	}
 
-	// add signed addrs if we have them and the peerstore supports them
-	cab, ok := peerstore.GetCertifiedAddrBook(ids.Host.Peerstore())
-
-	if ok && signedPeerRecord != nil && signedPeerRecord.PublicKey != nil {
-		id, err := peer.IDFromPublicKey(signedPeerRecord.PublicKey)
+	var addrs []ma.Multiaddr
+	if signedPeerRecord != nil {
+		signedAddrs, err := ids.consumeSignedPeerRecord(c.RemotePeer(), signedPeerRecord)
 		if err != nil {
-			log.Debugf("failed to derive peer ID from peer record: %s", err)
-		} else if id != c.RemotePeer() {
-			log.Debugf("received signed peer record for unexpected peer ID. expected %s, got %s", c.RemotePeer(), id)
-		} else if _, err := cab.ConsumePeerRecord(context.TODO(), signedPeerRecord, ttl); err != nil {
-			log.Debugf("error adding signed addrs to peerstore: %v", err)
+			log.Debugf("failed to consume signed peer record: %s", err)
+		} else {
+			addrs = signedAddrs
 		}
 	} else {
-		ids.Host.Peerstore().AddAddrs(context.TODO(), p, filterAddrs(lmaddrs, c.RemoteMultiaddr()), ttl)
+		addrs = lmaddrs
 	}
+	ids.Host.Peerstore().AddAddrs(context.TODO(), p, filterAddrs(addrs, c.RemoteMultiaddr()), ttl)
 
 	// Finally, expire all temporary addrs.
 	ids.Host.Peerstore().UpdateAddrs(context.TODO(), p, peerstore.TempAddrTTL, 0)
@@ -788,6 +786,34 @@ func (ids *idService) consumeMessage(mes *pb.Identify, c network.Conn, isPush bo
 
 	// get the key from the other side. we may not have it (no-auth transport)
 	ids.consumeReceivedPubKey(c, mes.PublicKey)
+}
+
+func (ids *idService) consumeSignedPeerRecord(p peer.ID, signedPeerRecord *record.Envelope) ([]ma.Multiaddr, error) {
+	if signedPeerRecord.PublicKey == nil {
+		return nil, errors.New("missing pubkey")
+	}
+	id, err := peer.IDFromPublicKey(signedPeerRecord.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive peer ID: %s", err)
+	}
+	if id != p {
+		return nil, fmt.Errorf("received signed peer record envelope for unexpected peer ID. expected %s, got %s", p, id)
+	}
+	r, err := signedPeerRecord.Record()
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain record: %w", err)
+	}
+	rec, ok := r.(*peer.PeerRecord)
+	if !ok {
+		return nil, errors.New("not a peer record")
+	}
+	if rec.PeerID != p {
+		return nil, fmt.Errorf("received signed peer record for unexpected peer ID. expected %s, got %s", p, rec.PeerID)
+	}
+	// Don't put the signed peer record into the peer store.
+	// They're not used anywhere.
+	// All we care about are the addresses.
+	return rec.Addrs, nil
 }
 
 func (ids *idService) consumeReceivedPubKey(c network.Conn, kb []byte) {


### PR DESCRIPTION
For multiple reasons:
1. They were not consumed anywhere.
2. We need to filter the addresses to avoid polluting the address book with local addresses.