### PR TITLE
basichost / blankhost: wrap errors

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -641,7 +641,7 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 		if errors.Is(err, network.ErrNoConn) {
 			return nil, errors.New("connection failed")
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
 
 	// Wait for any in-progress identifies on the connection to finish. This
@@ -653,7 +653,7 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 	case <-h.ids.IdentifyWait(s.Conn()):
 	case <-ctx.Done():
 		_ = s.Reset()
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("identify failed to complete: %w", ctx.Err())
 	}
 
 	pref, err := h.preferredProtocol(p, pids)
@@ -682,13 +682,13 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 	case err = <-errCh:
 		if err != nil {
 			s.Reset()
-			return nil, err
+			return nil, fmt.Errorf("failed to negotiate protocol: %w", err)
 		}
 	case <-ctx.Done():
 		s.Reset()
 		// wait for `SelectOneOf` to error out because of resetting the stream.
 		<-errCh
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("failed to negotiate protocol: %w", ctx.Err())
 	}
 
 	s.SetProtocol(selected)
@@ -734,7 +734,7 @@ func (h *BasicHost) dialPeer(ctx context.Context, p peer.ID) error {
 	log.Debugf("host %s dialing %s", h.ID(), p)
 	c, err := h.Network().DialPeer(ctx, p)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to dial: %w", err)
 	}
 
 	// TODO: Consider removing this? On one hand, it's nice because we can
@@ -745,7 +745,7 @@ func (h *BasicHost) dialPeer(ctx context.Context, p peer.ID) error {
 	select {
 	case <-h.ids.IdentifyWait(c):
 	case <-ctx.Done():
-		return ctx.Err()
+		return fmt.Errorf("identify failed to complete: %w", ctx.Err())
 	}
 
 	log.Debugf("host %s finished dialing %s", h.ID(), p)

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -739,7 +739,7 @@ func TestNegotiationCancel(t *testing.T) {
 
 	select {
 	case err := <-errCh:
-		require.Equal(t, err, context.Canceled)
+		require.ErrorIs(t, err, context.Canceled)
 	case <-time.After(500 * time.Millisecond):
 		// failed to cancel
 		t.Fatal("expected negotiation to be canceled")

--- a/p2p/host/blank/blank.go
+++ b/p2p/host/blank/blank.go
@@ -136,6 +136,9 @@ func (bh *BlankHost) Connect(ctx context.Context, ai peer.AddrInfo) error {
 	}
 
 	_, err := bh.Network().DialPeer(ctx, ai.ID)
+	if err != nil {
+		return fmt.Errorf("failed to dial: %w", err)
+	}
 	return err
 }
 
@@ -150,13 +153,13 @@ func (bh *BlankHost) ID() peer.ID {
 func (bh *BlankHost) NewStream(ctx context.Context, p peer.ID, protos ...protocol.ID) (network.Stream, error) {
 	s, err := bh.n.NewStream(ctx, p)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
 
 	selected, err := mstream.SelectOneOf(protos, s)
 	if err != nil {
 		s.Reset()
-		return nil, err
+		return nil, fmt.Errorf("failed to negotiate protocol: %w", err)
 	}
 
 	s.SetProtocol(selected)


### PR DESCRIPTION
The goal here is to improve the experience of working with errors returned by the Host. With the current state, it's PITA to debug exactly what went wrong during a stream open and this feat attempts to solve it.

* Inspired by errors in std `net`.
* I wanted to improve the RoutedHost as well, but I will wait until you migrate to v1.20, as I need `errors.Join`
* I am open to any other suggestions on how to make this even better
* Can we include this in 0.28? 🙏🏻 🙏🏻 🙏🏻 

Closes https://github.com/libp2p/go-libp2p/issues/2334