### PR TITLE
Clear stream scope if we error

### DIFF
--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -130,6 +130,7 @@ func (c *Conn) start() {
 
 				// We only get an error here when the swarm is closed or closing.
 				if err != nil {
+					scope.Done()
 					return
 				}
 


### PR DESCRIPTION
We should still clean up the resources tracked by the resource manager even if we error here.