### PR TITLE
nat: add HasNAT method for checking NAT environments

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -843,11 +843,10 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 
 	finalAddrs = network.DedupAddrs(finalAddrs)
 
-	// natmgr is nil if we do not use nat option;
-	if h.natmgr != nil {
+	// use nat mappings if we have them
+	if h.natmgr != nil && h.natmgr.HasNAT() {
 		// We have successfully mapped ports on our NAT. Use those
 		// instead of observed addresses (mostly).
-
 		// Next, apply this mapping to our addresses.
 		for _, listen := range listenAddrs {
 			extMaddr := h.natmgr.GetMapping(listen)

--- a/p2p/host/basic/natmgr.go
+++ b/p2p/host/basic/natmgr.go
@@ -21,6 +21,7 @@ import (
 // and tries to obtain port mappings for those.
 type NATManager interface {
 	GetMapping(ma.Multiaddr) ma.Multiaddr
+	HasNAT() bool
 	io.Closer
 }
 
@@ -84,6 +85,12 @@ func (nmgr *natManager) Close() error {
 	nmgr.ctxCancel()
 	nmgr.refCount.Wait()
 	return nil
+}
+
+func (nmgr *natManager) HasNAT() bool {
+	nmgr.natMx.RLock()
+	defer nmgr.natMx.RUnlock()
+	return nmgr.nat != nil
 }
 
 func (nmgr *natManager) background(ctx context.Context) {


### PR DESCRIPTION
This PR fixes 1 major and 2 minor issues with address inference in NATed environments. 

1. Introduces a check to determine if we have a nat device. This is reasonable. We can never be sure that we will support all NAT devices. In case the user has selected the `NATPortMap` option and we are unable to do a NAT mapping, we should do address inference using addresses obtained from observed address manager. This is the same behaviour as 0.27
2. In case we have a NAT device but we failed to do the mapping, we should use the addresses obtained from the observed address manager. 
3. Fixes an edge case for inferring observed addresses for QUIC addresses correctly in case the NAT doesn't give use a publicly routable address. QUIC addresses have local address as 0.0.0.0 and so only checking resolved listen addresses isn't enough, we need to check the unresolved listen address as well. 