### PR TITLE
core: fix incorrect comment about no allocation in network.DedupAddrs

### DIFF
--- a/core/network/network.go
+++ b/core/network/network.go
@@ -197,8 +197,7 @@ type AddrDelay struct {
 // DialRanker provides a schedule of dialing the provided addresses
 type DialRanker func([]ma.Multiaddr) []AddrDelay
 
-// DedupAddrs deduplicates addresses in place, leave only unique addresses.
-// It doesn't allocate.
+// DedupAddrs deduplicates addresses in place, leaving only unique addresses.
 func DedupAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	if len(addrs) == 0 {
 		return addrs


### PR DESCRIPTION
fixes: https://github.com/libp2p/go-libp2p/issues/2323
sort.Slice will allocate. 

repro: 
```
func BenchmarkDedupAddrs(b *testing.B) {
	b.ReportAllocs()
	tcpAddr := ma.StringCast("/ip4/127.0.0.1/tcp/1234")
	quicAddr := ma.StringCast("/ip4/127.0.0.1/udp/1234/quic-v1")
	wsAddr := ma.StringCast("/ip4/127.0.0.1/tcp/1234/ws")
	addrs := []ma.Multiaddr{tcpAddr, quicAddr, tcpAddr, quicAddr, wsAddr}
	for i := 0; i < b.N; i++ {
		addrs = DedupAddrs(addrs)
	}
}
```