### PR TITLE
rcmgr: register prometheus metrics with the libp2p registerer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ import (
 	blankhost "github.com/libp2p/go-libp2p/p2p/host/blank"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
@@ -297,6 +298,10 @@ func (cfg *Config) NewNode() (host.Host, error) {
 	swrm, err := cfg.makeSwarm(eventBus, !cfg.DisableMetrics)
 	if err != nil {
 		return nil, err
+	}
+
+	if !cfg.DisableMetrics {
+		rcmgrObs.MustRegisterWith(cfg.PrometheusRegisterer)
 	}
 
 	h, err := bhost.NewHost(swrm, &bhost.HostOpts{

--- a/dashboards/resource-manager/README.md
+++ b/dashboards/resource-manager/README.md
@@ -5,8 +5,10 @@ import follow the Grafana docs [here](https://grafana.com/docs/grafana/latest/da
 
 ## Setup
 
-To make sure you're emitting the correct metrics you'll have to register the
-metrics with a Prometheus Registerer. For example:
+To make sure you're emitting the metrics you'll have to create the Resource
+Manager with a StatsTraceReporter. By default metrics will be sent to
+prometheus.DefaultRegisterer. To use a different Registerer use the libp2p
+option libp2p.PrometheusRegisterer. For example:
 
 ``` go
 import (
@@ -18,8 +20,6 @@ import (
 )
 
     func SetupResourceManager() (network.ResourceManager, error) {
-        rcmgrObs.MustRegisterWith(prometheus.DefaultRegisterer)
-
         str, err := rcmgrObs.NewStatsTraceReporter()
         if err != nil {
             return nil, err

--- a/p2p/host/resource-manager/obs/stats.go
+++ b/p2p/host/resource-manager/obs/stats.go
@@ -142,7 +142,7 @@ var (
 )
 
 func MustRegisterWith(reg prometheus.Registerer) {
-	reg.MustRegister(
+	metricshelper.RegisterCollectors(reg,
 		conns,
 		peerConns,
 		previousPeerConns,


### PR DESCRIPTION
If the caller forgot to call rcmgrObs.MustRegisterWith, we will still get the metrics. If they have a StatsTraceReporter, they're anyway updating the counters. If they didn't provide a StatsTraceReporter, we will have registered a few extra metrics with prometheus. 

fixes: https://github.com/libp2p/go-libp2p/issues/2371