### PR TITLE
fix: in the swarm move Connectedness emit after releasing conns

### DIFF
--- a/p2p/net/swarm/swarm_event_test.go
+++ b/p2p/net/swarm/swarm_event_test.go
@@ -72,7 +72,7 @@ func TestNoDeadlockWhenConsumingConnectednessEvents(t *testing.T) {
 
 	listener := swarmt.GenSwarm(t, swarmt.OptDialOnly)
 	addrsToListen := []ma.Multiaddr{
-		ma.StringCast("/ip4/0.0.0.0/udp/0/quic-v1"),
+		ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"),
 	}
 
 	if err := listener.Listen(addrsToListen...); err != nil {

--- a/p2p/net/swarm/swarm_event_test.go
+++ b/p2p/net/swarm/swarm_event_test.go
@@ -96,10 +96,10 @@ func TestNoDeadlockWhenConsumingConnectednessEvents(t *testing.T) {
 			case <-ctx.Done():
 				return
 			case <-sub.Out():
-				time.Sleep(time.Second)
+				time.Sleep(100 * time.Millisecond)
 				// Do something with the swarm that needs the conns lock
 				_ = dialer.ConnsToPeer(listener.LocalPeer())
-				time.Sleep(time.Second)
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 	}()

--- a/p2p/net/swarm/swarm_event_test.go
+++ b/p2p/net/swarm/swarm_event_test.go
@@ -64,3 +64,52 @@ func TestConnectednessEventsSingleConn(t *testing.T) {
 	checkEvent(t, sub1, event.EvtPeerConnectednessChanged{Peer: s2.LocalPeer(), Connectedness: network.NotConnected})
 	checkEvent(t, sub2, event.EvtPeerConnectednessChanged{Peer: s1.LocalPeer(), Connectedness: network.NotConnected})
 }
+
+func TestNoDeadlockWhenConsumingConnectednessEvents(t *testing.T) {
+	dialerEventBus := eventbus.NewBus()
+	dialer := swarmt.GenSwarm(t, swarmt.OptDialOnly, swarmt.EventBus(dialerEventBus))
+	defer dialer.Close()
+
+	listener := swarmt.GenSwarm(t, swarmt.OptDialOnly)
+	addrsToListen := []ma.Multiaddr{
+		ma.StringCast("/ip4/0.0.0.0/udp/0/quic-v1"),
+	}
+
+	if err := listener.Listen(addrsToListen...); err != nil {
+		t.Fatal(err)
+	}
+	listenedAddrs := listener.ListenAddresses()
+
+	dialer.Peerstore().AddAddrs(listener.LocalPeer(), listenedAddrs, time.Hour)
+
+	sub, err := dialerEventBus.Subscribe(new(event.EvtPeerConnectednessChanged))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// A slow consumer
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sub.Out():
+				time.Sleep(time.Second)
+				// Do something with the swarm that needs the conns lock
+				_ = dialer.ConnsToPeer(listener.LocalPeer())
+				time.Sleep(time.Second)
+			}
+		}
+	}()
+
+	for i := 0; i < 10; i++ {
+		// Connect and disconnect to trigger a bunch of events
+		_, err := dialer.DialPeer(context.Background(), listener.LocalPeer())
+		require.NoError(t, err)
+		dialer.ClosePeer(listener.LocalPeer())
+	}
+
+	// The test should finish without deadlocking
+}


### PR DESCRIPTION
go-libp2p-kad-dht now listen to both EvtPeerIdentificationCompleted and EvtPeerConnectednessChanged and EvtPeerIdentificationCompleted calls .ConnsToPeer inorder to do some filtering.

However it happens that it deadlocks because if the swarm is trying to emit a EvtPeerConnectednessChanged while the subscriber is trying to process an EvtPeerIdentificationCompleted, the subscriber is stuck on s.conns.RLock() while the swarm wont release it before having sent EvtPeerConnectednessChanged. Deadlock !

I havn't confirmed this fixes my bug given this takes time to reproduce, I'll startup a new experiment later.