### PR TITLE
metrics: make it possible to spin up Grafana using docker-compose

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -25,7 +25,7 @@ Dashboards can be inspected locally by running
 docker-compose up
 ```
 
-and opening Grafana at http://localhost:3000 (user: admin, password: admin).
+and opening Grafana at http://localhost:3000.
 
 
 ### Making Dashboards usable with Provisioning

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -33,4 +33,3 @@ and opening Grafana at http://localhost:3000 (user: admin, password: admin).
 The following section is only relevant for creators of dashboards.
 
 Due to a bug in Grafana, it's not possible to provision dashboards shared for external use directly. We need to apply the workaround described in https://github.com/grafana/grafana/issues/10786#issuecomment-568788499 (adding the a few lines in the dashboard JSON file).
->>>>>>> Stashed changes

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -2,3 +2,35 @@
 
 This directory contains prebuilt dashboards (provided as JSON files) for various components.
 For steps on how to import and use them [please read the official Grafana documentation.](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard)
+
+## Using locally
+
+For local development and debugging, it can be useful to spin up a local Prometheus and Grafana instance.
+
+To expose metrics, we first need to expose a metrics collection endpoint. Add this to your code:
+
+```go
+import "github.com/prometheus/client_golang/prometheus/promhttp"
+
+go func() {
+    http.Handle("/debug/metrics/prometheus", promhttp.Handler())
+    log.Fatal(http.ListenAndServe(":5001", nil))
+}()
+```
+
+This exposes a metrics collection endpoint at http://localhost:5001/debug/metrics/prometheus. Note that this is the same endpoint that [Kubo](https://github.com/ipfs/kubo) uses, so if you want to gather metrics from Kubo, you can skip this step.
+
+Dashboards can be inspected locally by running
+```bash
+docker-compose up
+```
+
+and opening Grafana at http://localhost:3000 (user: admin, password: admin).
+
+
+### Making Dashboards usable with Provisioning
+
+The following section is only relevant for creators of dashboards.
+
+Due to a bug in Grafana, it's not possible to provision dashboards shared for external use directly. We need to apply the workaround described in https://github.com/grafana/grafana/issues/10786#issuecomment-568788499 (adding the a few lines in the dashboard JSON file).
+>>>>>>> Stashed changes

--- a/dashboards/autonat/autonat.json
+++ b/dashboards/autonat/autonat.json
@@ -691,6 +691,16 @@
   "tags": [],
   "templating": {
     "list": [
+       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "current": {},
         "datasource": {

--- a/dashboards/autorelay/autorelay.json
+++ b/dashboards/autorelay/autorelay.json
@@ -1034,6 +1034,16 @@
   "tags": [],
   "templating": {
     "list": [
+       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "current": {},
         "datasource": {

--- a/dashboards/dashboard.yml
+++ b/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "libp2p dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/dashboards/datasources.yml
+++ b/dashboards/datasources.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+datasources:
+  - name: Prometheus
+    orgId: 1
+    type: prometheus
+    access: proxy
+    url: http://host.docker.internal:9090
+    editable: false

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - prometheus
     ports:
       - "3000:3000"
+    environment:
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     volumes:
       - ./dashboard.yml:/etc/grafana/provisioning/dashboards/main.yml
       - ./datasources.yml:/etc/grafana/provisioning/datasources/prom.yml

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./dashboard.yml:/etc/grafana/provisioning/dashboards/main.yml
+      - ./datasources.yml:/etc/grafana/provisioning/datasources/prom.yml
+      - ./autonat/autonat.json:/var/lib/grafana/dashboards/autonat.json
+      - ./autorelay/autorelay.json:/var/lib/grafana/dashboards/autorelay.json
+      - ./eventbus/eventbus.json:/var/lib/grafana/dashboards/eventbus.json
+      - ./identify/identify.json:/var/lib/grafana/dashboards/identify.json
+      - ./relaysvc/relaysvc.json:/var/lib/grafana/dashboards/relaysvc.json
+      - ./swarm/swarm.json:/var/lib/grafana/dashboards/swarm.json

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ./autonat/autonat.json:/var/lib/grafana/dashboards/autonat.json
       - ./autorelay/autorelay.json:/var/lib/grafana/dashboards/autorelay.json
       - ./eventbus/eventbus.json:/var/lib/grafana/dashboards/eventbus.json
+      - ./holepunch/holepunch.json:/var/lib/grafana/dashboards/holepunch.json
       - ./identify/identify.json:/var/lib/grafana/dashboards/identify.json
       - ./relaysvc/relaysvc.json:/var/lib/grafana/dashboards/relaysvc.json
       - ./swarm/swarm.json:/var/lib/grafana/dashboards/swarm.json

--- a/dashboards/eventbus/eventbus.json
+++ b/dashboards/eventbus/eventbus.json
@@ -515,6 +515,16 @@
   "tags": [],
   "templating": {
     "list": [
+       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "current": {},
         "datasource": {

--- a/dashboards/holepunch/holepunch.json
+++ b/dashboards/holepunch/holepunch.json
@@ -1093,6 +1093,16 @@
   "tags": [],
   "templating": {
     "list": [
+       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "current": {},
         "definition": "label_values(instance)",

--- a/dashboards/identify/identify.json
+++ b/dashboards/identify/identify.json
@@ -838,6 +838,16 @@
   "tags": [],
   "templating": {
     "list": [
+       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "current": {},
         "datasource": {

--- a/dashboards/prometheus.yml
+++ b/dashboards/prometheus.yml
@@ -1,0 +1,30 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+alerting:
+  alertmanagers:
+  - scheme: http
+    timeout: 10s
+    api_version: v1
+    static_configs:
+    - targets: []
+scrape_configs:
+- job_name: prometheus
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - localhost:9090
+- job_name: libp2p
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /debug/metrics/prometheus
+  scheme: http
+  static_configs:
+  - targets:
+    - host.docker.internal:5001

--- a/dashboards/relaysvc/relaysvc.json
+++ b/dashboards/relaysvc/relaysvc.json
@@ -1191,6 +1191,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "prometheus",

--- a/dashboards/resource-manager/resource-manager.json
+++ b/dashboards/resource-manager/resource-manager.json
@@ -1783,6 +1783,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "prometheus",

--- a/dashboards/swarm/swarm.json
+++ b/dashboards/swarm/swarm.json
@@ -3034,6 +3034,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
As a last step to finish our metrics story, here's an easy way to make them more useful for local development.Just run
```bash
docker-compose up
```

and your local Grafana instance is up and running, collecting metrics from your libp2p node! See README for more instructions.