### PR TITLE
rcmgr: move StatsTraceReporter to rcmgr package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 	blankhost "github.com/libp2p/go-libp2p/p2p/host/blank"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
-	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
@@ -301,7 +301,7 @@ func (cfg *Config) NewNode() (host.Host, error) {
 	}
 
 	if !cfg.DisableMetrics {
-		rcmgrObs.MustRegisterWith(cfg.PrometheusRegisterer)
+		rcmgr.MustRegisterWith(cfg.PrometheusRegisterer)
 	}
 
 	h, err := bhost.NewHost(swrm, &bhost.HostOpts{

--- a/dashboards/resource-manager/README.md
+++ b/dashboards/resource-manager/README.md
@@ -14,13 +14,12 @@ option libp2p.PrometheusRegisterer. For example:
 import (
     // ...
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
     func SetupResourceManager() (network.ResourceManager, error) {
-        str, err := rcmgrObs.NewStatsTraceReporter()
+        str, err := rcmgr.NewStatsTraceReporter()
         if err != nil {
             return nil, err
         }

--- a/p2p/host/resource-manager/README.md
+++ b/p2p/host/resource-manager/README.md
@@ -48,8 +48,8 @@ limits := cfg.Build(scaledDefaultLimits)
 limiter := rcmgr.NewFixedLimiter(limits)
 
 // (Optional if you want metrics)
-rcmgrObs.MustRegisterWith(prometheus.DefaultRegisterer)
-str, err := rcmgrObs.NewStatsTraceReporter()
+rcmgr.MustRegisterWith(prometheus.DefaultRegisterer)
+str, err := rcmgr.NewStatsTraceReporter()
 if err != nil {
   panic(err)
 }

--- a/p2p/host/resource-manager/noalloc_test.go
+++ b/p2p/host/resource-manager/noalloc_test.go
@@ -1,6 +1,6 @@
 //go:build nocover
 
-package obs
+package rcmgr
 
 import (
 	"math/rand"
@@ -8,26 +8,25 @@ import (
 	"testing"
 	"time"
 
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
-func randomTraceEvt(rng *rand.Rand) rcmgr.TraceEvt {
+func randomTraceEvt(rng *rand.Rand) TraceEvt {
 	// Possibly non-sensical
-	typs := []rcmgr.TraceEvtTyp{
-		rcmgr.TraceStartEvt,
-		rcmgr.TraceCreateScopeEvt,
-		rcmgr.TraceDestroyScopeEvt,
-		rcmgr.TraceReserveMemoryEvt,
-		rcmgr.TraceBlockReserveMemoryEvt,
-		rcmgr.TraceReleaseMemoryEvt,
-		rcmgr.TraceAddStreamEvt,
-		rcmgr.TraceBlockAddStreamEvt,
-		rcmgr.TraceRemoveStreamEvt,
-		rcmgr.TraceAddConnEvt,
-		rcmgr.TraceBlockAddConnEvt,
-		rcmgr.TraceRemoveConnEvt,
+	typs := []TraceEvtTyp{
+		TraceStartEvt,
+		TraceCreateScopeEvt,
+		TraceDestroyScopeEvt,
+		TraceReserveMemoryEvt,
+		TraceBlockReserveMemoryEvt,
+		TraceReleaseMemoryEvt,
+		TraceAddStreamEvt,
+		TraceBlockAddStreamEvt,
+		TraceRemoveStreamEvt,
+		TraceAddConnEvt,
+		TraceBlockAddConnEvt,
+		TraceRemoveConnEvt,
 	}
 
 	names := []string{
@@ -43,7 +42,7 @@ func randomTraceEvt(rng *rand.Rand) rcmgr.TraceEvt {
 		"service:libp2p.autonat.peer:12D3Koo",
 	}
 
-	return rcmgr.TraceEvt{
+	return TraceEvt{
 		Type:       typs[rng.Intn(len(typs))],
 		Name:       names[rng.Intn(len(names))],
 		DeltaOut:   rng.Intn(5),
@@ -60,7 +59,7 @@ func randomTraceEvt(rng *rand.Rand) rcmgr.TraceEvt {
 
 }
 
-var registerOnce sync.Once
+var regOnce sync.Once
 
 func BenchmarkMetricsRecording(b *testing.B) {
 	b.ReportAllocs()
@@ -70,7 +69,7 @@ func BenchmarkMetricsRecording(b *testing.B) {
 	})
 
 	evtCount := 10000
-	evts := make([]rcmgr.TraceEvt, evtCount)
+	evts := make([]TraceEvt, evtCount)
 	rng := rand.New(rand.NewSource(int64(b.N)))
 	for i := 0; i < evtCount; i++ {
 		evts[i] = randomTraceEvt(rng)
@@ -92,7 +91,7 @@ func TestNoAllocsNoCover(t *testing.T) {
 	require.NoError(t, err)
 
 	evtCount := 10_000
-	evts := make([]rcmgr.TraceEvt, 0, evtCount)
+	evts := make([]TraceEvt, 0, evtCount)
 	rng := rand.New(rand.NewSource(1))
 
 	for i := 0; i < evtCount; i++ {

--- a/p2p/host/resource-manager/obs/obs.go
+++ b/p2p/host/resource-manager/obs/obs.go
@@ -1,0 +1,18 @@
+// Package obs implements metrics tracing for resource manager
+//
+// Deprecated: obs is deprecated and the exported types and methods
+// are moved to rcmgr package. Use the corresponding identifier in
+// the rcmgr package, for example
+// obs.NewStatsTraceReporter => rcmgr.NewStatsTraceReporter
+package obs
+
+import (
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+)
+
+var MustRegisterWith = rcmgr.MustRegisterWith
+
+// StatsTraceReporter reports stats on the resource manager using its traces.
+type StatsTraceReporter = rcmgr.StatsTraceReporter
+
+var NewStatsTraceReporter = rcmgr.NewStatsTraceReporter

--- a/p2p/host/resource-manager/stats_test.go
+++ b/p2p/host/resource-manager/stats_test.go
@@ -1,19 +1,17 @@
-package obs_test
+package rcmgr
 
 import (
 	"sync"
 	"testing"
 	"time"
 
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-	"github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var registerOnce sync.Once
 
 func TestTraceReporterStartAndClose(t *testing.T) {
-	rcmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale()), rcmgr.WithTraceReporter(obs.StatsTraceReporter{}))
+	rcmgr, err := NewResourceManager(NewFixedLimiter(DefaultLimits.AutoScale()), WithTraceReporter(StatsTraceReporter{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,18 +19,18 @@ func TestTraceReporterStartAndClose(t *testing.T) {
 }
 
 func TestConsumeEvent(t *testing.T) {
-	evt := rcmgr.TraceEvt{
-		Type:     rcmgr.TraceBlockAddStreamEvt,
+	evt := TraceEvt{
+		Type:     TraceBlockAddStreamEvt,
 		Name:     "conn-1",
 		DeltaOut: 1,
 		Time:     time.Now().Format(time.RFC3339Nano),
 	}
 
 	registerOnce.Do(func() {
-		obs.MustRegisterWith(prometheus.DefaultRegisterer)
+		MustRegisterWith(prometheus.DefaultRegisterer)
 	})
 
-	str, err := obs.NewStatsTraceReporter()
+	str, err := NewStatsTraceReporter()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 
 	"github.com/stretchr/testify/require"
 )
@@ -319,7 +318,7 @@ func TestReadmeExample(t *testing.T) {
 	limiter := rcmgr.NewFixedLimiter(limits)
 
 	// (Optional if you want metrics) Construct the OpenCensus metrics reporter.
-	str, err := rcmgrObs.NewStatsTraceReporter()
+	str, err := rcmgr.NewStatsTraceReporter()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Required for https://github.com/libp2p/go-libp2p/issues/2372

Moves the exported types and functions of package `obs` to  `rcmgr`
Deprecates package `obs`
