### PR TITLE
docs: fix some comments errors

### DIFF
--- a/core/crypto/rsa_go.go
+++ b/core/crypto/rsa_go.go
@@ -68,7 +68,7 @@ func (pk *RsaPublicKey) Raw() (res []byte, err error) {
 
 // Equals checks whether this key is equal to another
 func (pk *RsaPublicKey) Equals(k Key) bool {
-	// make sure this is an rsa public key
+	// make sure this is a rsa public key
 	other, ok := (k).(*RsaPublicKey)
 	if !ok {
 		return basicEquals(pk, k)

--- a/core/event/network.go
+++ b/core/event/network.go
@@ -46,7 +46,7 @@ import (
 //
 // Explanation: There were two connections and one was cut. This connection
 // might have been in active use but neither peer will observe a change in
-// "connectedness". Peers should always make sure to re-try network requests.
+// "connectedness". Peers should always make sure to retry network requests.
 type EvtPeerConnectednessChanged struct {
 	// Peer is the remote peer whose connectedness has changed.
 	Peer peer.ID

--- a/core/host/host.go
+++ b/core/host/host.go
@@ -47,7 +47,7 @@ type Host interface {
 	// SetStreamHandler sets the protocol handler on the Host's Mux.
 	// This is equivalent to:
 	//   host.Mux().SetHandler(proto, handler)
-	// (Threadsafe)
+	// (Thread-safe)
 	SetStreamHandler(pid protocol.ID, handler network.StreamHandler)
 
 	// SetStreamHandlerMatch sets the protocol handler on the Host's Mux

--- a/core/network/errors.go
+++ b/core/network/errors.go
@@ -28,6 +28,6 @@ var ErrTransientConn = errors.New("transient connection to peer")
 // exceed system resource limits.
 var ErrResourceLimitExceeded = temporaryError("resource limit exceeded")
 
-// ErrResourceScopeClosed is returned when attemptig to reserve resources in a closed resource
+// ErrResourceScopeClosed is returned when attempting to reserve resources in a closed resource
 // scope.
 var ErrResourceScopeClosed = errors.New("resource scope closed")

--- a/core/network/network.go
+++ b/core/network/network.go
@@ -36,10 +36,12 @@ const (
 	DirOutbound
 )
 
+const unrecognized = "(unrecognized)"
+
 func (d Direction) String() string {
 	str := [...]string{"Unknown", "Inbound", "Outbound"}
 	if d < 0 || int(d) >= len(str) {
-		return "(unrecognized)"
+		return unrecognized
 	}
 	return str[d]
 }
@@ -66,7 +68,7 @@ const (
 func (c Connectedness) String() string {
 	str := [...]string{"NotConnected", "Connected", "CanConnect", "CannotConnect"}
 	if c < 0 || int(c) >= len(str) {
-		return "(unrecognized)"
+		return unrecognized
 	}
 	return str[c]
 }
@@ -93,7 +95,7 @@ const (
 func (r Reachability) String() string {
 	str := [...]string{"Unknown", "Public", "Private"}
 	if r < 0 || int(r) >= len(str) {
-		return "(unrecognized)"
+		return unrecognized
 	}
 	return str[r]
 }

--- a/core/network/rcmgr.go
+++ b/core/network/rcmgr.go
@@ -28,7 +28,7 @@ import (
 //	                   +--------------------------->  Stream
 //
 // The basic resources accounted by the ResourceManager include memory, streams, connections,
-// and file  descriptors. These account for both space and time used by
+// and file descriptors. These account for both space and time used by
 // the stack, as each resource has a direct effect on the system
 // availability and performance.
 //
@@ -69,7 +69,7 @@ import (
 //     service scope using the ResourceManager interface.
 //   - Applications that want to account for their network resource usage can reserve memory,
 //     typically using a span, directly in the System or a Service scope; they can also
-//     opt to use appropriate steam scopes for streams that they create or own.
+//     opt to use appropriate stream scopes for streams that they create or own.
 //
 // User Serviceable Parts: the user has the option to specify their own implementation of the
 // interface. We provide a canonical implementation in the go-libp2p-resource-manager package.
@@ -77,8 +77,7 @@ import (
 // or dynamic.
 //
 // WARNING The ResourceManager interface is considered experimental and subject to change
-//
-//	in subsequent releases.
+// in subsequent releases.
 type ResourceManager interface {
 	ResourceScopeViewer
 
@@ -110,7 +109,7 @@ type ResourceScopeViewer interface {
 
 	// ViewTransient views the transient (DMZ) resource scope.
 	// The transient scope accounts for resources that are in the process of
-	// full establishment.  For instance, a new connection prior to the
+	// full establishment. For instance, a new connection prior to the
 	// handshake does not belong to any peer, but it still needs to be
 	// constrained as this opens an avenue for attacks in transient resource
 	// usage. Similarly, a stream that has not negotiated a protocol yet is
@@ -155,7 +154,7 @@ type ResourceScope interface {
 	// For instance, a muxer growing a window buffer will use a low priority and only grow the buffer
 	// if there is no memory pressure in the system.
 	//
-	// The are 4 predefined priority levels, Low, Medium, High and Always,
+	// There are 4 predefined priority levels, Low, Medium, High and Always,
 	// capturing common patterns, but the user is free to use any granularity applicable to his case.
 	ReserveMemory(size int, prio uint8) error
 

--- a/core/peer/addrinfo.go
+++ b/core/peer/addrinfo.go
@@ -47,7 +47,7 @@ func AddrInfosFromP2pAddrs(maddrs ...ma.Multiaddr) ([]AddrInfo, error) {
 // SplitAddr splits a p2p Multiaddr into a transport multiaddr and a peer ID.
 //
 // * Returns a nil transport if the address only contains a /p2p part.
-// * Returns a empty peer ID if the address doesn't contain a /p2p part.
+// * Returns an empty peer ID if the address doesn't contain a /p2p part.
 func SplitAddr(m ma.Multiaddr) (transport ma.Multiaddr, id ID) {
 	if m == nil {
 		return nil, ""

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -88,7 +88,7 @@ func (id ID) MatchesPublicKey(pk ic.PubKey) bool {
 
 // ExtractPublicKey attempts to extract the public key from an ID.
 //
-// This method returns ErrNoPublicKey if the peer ID looks valid but it can't extract
+// This method returns ErrNoPublicKey if the peer ID looks valid, but it can't extract
 // the public key.
 func (id ID) ExtractPublicKey() (ic.PubKey, error) {
 	decoded, err := mh.Decode([]byte(id))

--- a/core/peer/record.go
+++ b/core/peer/record.go
@@ -22,10 +22,10 @@ func init() {
 	record.RegisterType(&PeerRecord{})
 }
 
-// PeerRecordEnvelopeDomain is the domain string used for peer records contained in a Envelope.
+// PeerRecordEnvelopeDomain is the domain string used for peer records contained in an Envelope.
 const PeerRecordEnvelopeDomain = "libp2p-peer-record"
 
-// PeerRecordEnvelopePayloadType is the type hint used to identify peer records in a Envelope.
+// PeerRecordEnvelopePayloadType is the type hint used to identify peer records in an Envelope.
 // Defined in https://github.com/multiformats/multicodec/blob/master/table.csv
 // with name "libp2p-peer-record".
 var PeerRecordEnvelopePayloadType = []byte{0x03, 0x01}
@@ -58,7 +58,7 @@ var PeerRecordEnvelopePayloadType = []byte{0x03, 0x01}
 // routing.Envelope, and PeerRecord implements the routing.Record interface
 // to facilitate this.
 //
-// To share a PeerRecord, first call Sign to wrap the record in a Envelope
+// To share a PeerRecord, first call Sign to wrap the record in an Envelope
 // and sign it with the local peer's private key:
 //
 //	rec := &PeerRecord{PeerID: myPeerId, Addrs: myAddrs}

--- a/core/peerstore/peerstore.go
+++ b/core/peerstore/peerstore.go
@@ -46,7 +46,7 @@ const (
 	ConnectedAddrTTL
 )
 
-// Peerstore provides a threadsafe store of Peer related
+// Peerstore provides a thread-safe store of Peer related
 // information.
 type Peerstore interface {
 	io.Closer
@@ -174,7 +174,7 @@ type CertifiedAddrBook interface {
 	// added via ConsumePeerRecord.
 	ConsumePeerRecord(s *record.Envelope, ttl time.Duration) (accepted bool, err error)
 
-	// GetPeerRecord returns a Envelope containing a PeerRecord for the
+	// GetPeerRecord returns an Envelope containing a PeerRecord for the
 	// given peer id, if one exists.
 	// Returns nil if no signed PeerRecord exists for the peer.
 	GetPeerRecord(p peer.ID) *record.Envelope

--- a/core/pnet/codec.go
+++ b/core/pnet/codec.go
@@ -31,7 +31,7 @@ func expectHeader(r *bufio.Reader, expected []byte) error {
 		return err
 	}
 	if !bytes.Equal(header, expected) {
-		return fmt.Errorf("expected file header %s, got: %s", pathPSKv1, header)
+		return fmt.Errorf("expected file header %s, got: %s", expected, header)
 	}
 	return nil
 }

--- a/core/record/envelope.go
+++ b/core/record/envelope.go
@@ -189,7 +189,7 @@ func UnmarshalEnvelope(data []byte) (*Envelope, error) {
 }
 
 // Marshal returns a byte slice containing a serialized protobuf representation
-// of a Envelope.
+// of an Envelope.
 func (e *Envelope) Marshal() (res []byte, err error) {
 	defer func() { catch.HandlePanic(recover(), &err, "libp2p envelope marshal") }()
 	key, err := crypto.PublicKeyToProto(e.PublicKey)

--- a/core/routing/query.go
+++ b/core/routing/query.go
@@ -104,7 +104,7 @@ func PublishQueryEvent(ctx context.Context, ev *QueryEvent) {
 }
 
 // SubscribesToQueryEvents returns true if the context subscribes to query
-// events. If this function returns falls, calling `PublishQueryEvent` on the
+// events. If this function returns false, calling `PublishQueryEvent` on the
 // context will be a no-op.
 func SubscribesToQueryEvents(ctx context.Context) bool {
 	return ctx.Value(routingQueryKey{}) != nil

--- a/core/routing/routing.go
+++ b/core/routing/routing.go
@@ -55,7 +55,7 @@ type ValueStore interface {
 	GetValue(context.Context, string, ...Option) ([]byte, error)
 
 	// SearchValue searches for better and better values from this value
-	// store corresponding to the given Key. By default implementations must
+	// store corresponding to the given Key. By default, implementations must
 	// stop the search after a good value is found. A 'good' value is a value
 	// that would be returned from GetValue.
 	//

--- a/core/sec/insecure/insecure.go
+++ b/core/sec/insecure/insecure.go
@@ -1,4 +1,4 @@
-// Package insecure provides an insecure, unencrypted implementation of the the SecureConn and SecureTransport interfaces.
+// Package insecure provides an insecure, unencrypted implementation of the SecureConn and SecureTransport interfaces.
 //
 // Recommended only for testing and other non-production usage.
 package insecure

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -52,7 +52,7 @@ type CapableConn interface {
 // For a conceptual overview, see https://docs.libp2p.io/concepts/transport/
 type Transport interface {
 	// Dial dials a remote peer. It should try to reuse local listener
-	// addresses if possible but it may choose not to.
+	// addresses if possible, but it may choose not to.
 	Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (CapableConn, error)
 
 	// CanDial returns true if this transport knows how to dial the given

--- a/examples/chat-with-mdns/README.md
+++ b/examples/chat-with-mdns/README.md
@@ -75,7 +75,7 @@ register [Notifee interface](https://godoc.org/github.com/libp2p/go-libp2p/p2p/d
 Finally we open stream to the peers we found, as we find them
 
 ```go
-	peer := <-peerChan // will block untill we discover a peer
+	peer := <-peerChan // will block until we discover a peer
 	fmt.Println("Found peer:", peer, ", connecting")
 
 	if err := host.Connect(ctx, peer); err != nil {

--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -19,7 +19,7 @@ import (
 func handleStream(stream network.Stream) {
 	fmt.Println("Got a new stream!")
 
-	// Create a buffer stream for non blocking read and write.
+	// Create a buffer stream for non-blocking read and write.
 	rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
 
 	go readData(rw)
@@ -115,7 +115,7 @@ func main() {
 
 	peerChan := initMDNS(host, cfg.RendezvousString)
 	for { // allows multiple peers to join
-		peer := <-peerChan // will block untill we discover a peer
+		peer := <-peerChan // will block until we discover a peer
 		fmt.Println("Found peer:", peer, ", connecting")
 
 		if err := host.Connect(ctx, peer); err != nil {

--- a/examples/chat-with-rendezvous/chat.go
+++ b/examples/chat-with-rendezvous/chat.go
@@ -26,7 +26,7 @@ var logger = log.Logger("rendezvous")
 func handleStream(stream network.Stream) {
 	logger.Info("Got a new stream!")
 
-	// Create a buffer stream for non blocking read and write.
+	// Create a buffer stream for non-blocking read and write.
 	rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
 
 	go readData(rw)

--- a/examples/chat/chat.go
+++ b/examples/chat/chat.go
@@ -51,7 +51,7 @@ import (
 func handleStream(s network.Stream) {
 	log.Println("Got a new stream!")
 
-	// Create a buffer stream for non blocking read and write.
+	// Create a buffer stream for non-blocking read and write.
 	rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
 
 	go readData(rw)
@@ -227,7 +227,7 @@ func startPeerAndConnect(ctx context.Context, h host.Host, destination string) (
 	}
 	log.Println("Established connection to destination")
 
-	// Create a buffered stream so that read and writes are non blocking.
+	// Create a buffered stream so that read and writes are non-blocking.
 	rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
 
 	return rw, nil

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -151,7 +151,7 @@ func runSender(ctx context.Context, ha host.Host, targetPeer string) {
 		return
 	}
 
-	// We have a peer ID and a targetAddr so we add it to the peerstore
+	// We have a peer ID and a targetAddr, so we add it to the peerstore
 	// so LibP2P knows how to contact it
 	ha.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.PermanentAddrTTL)
 

--- a/examples/http-proxy/proxy.go
+++ b/examples/http-proxy/proxy.go
@@ -135,7 +135,7 @@ func (p *ProxyService) Serve() {
 }
 
 // ServeHTTP implements the http.Handler interface. WARNING: This is the
-// simplest approach to a proxy. Therefore we do not do any of the things
+// simplest approach to a proxy. Therefore, we do not do any of the things
 // that should be done when implementing a reverse proxy (like handling
 // headers correctly). For how to do it properly, see:
 // https://golang.org/src/net/http/httputil/reverseproxy.go?s=3845:3920#L121
@@ -216,7 +216,7 @@ func addAddrToPeerstore(h host.Host, addr string) peer.ID {
 	targetPeerAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", peerid))
 	targetAddr := ipfsaddr.Decapsulate(targetPeerAddr)
 
-	// We have a peer ID and a targetAddr so we add
+	// We have a peer ID and a targetAddr, so we add
 	// it to the peerstore so LibP2P knows how to contact it
 	h.Peerstore().AddAddr(peerid, targetAddr, peerstore.PermanentAddrTTL)
 	return peerid

--- a/examples/libp2p-host/host.go
+++ b/examples/libp2p-host/host.go
@@ -22,7 +22,7 @@ func main() {
 
 func run() {
 	// The context governs the lifetime of the libp2p node.
-	// Cancelling it will stop the the host.
+	// Cancelling it will stop the host.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/examples/multipro/node.go
+++ b/examples/multipro/node.go
@@ -35,7 +35,7 @@ func NewNode(host host.Host, done chan bool) *Node {
 }
 
 // Authenticate incoming p2p message
-// message: a protobufs go data object
+// message: a protobuf go data object
 // data: common p2p message data
 func (n *Node) authenticateMessage(message proto.Message, data *p2p.MessageData) bool {
 	// store a temp ref to signature and remove it from message data
@@ -119,7 +119,7 @@ func (n *Node) verifyData(data []byte, signature []byte, peerId peer.ID, pubKeyD
 // helper method - generate message data shared between all node's p2p protocols
 // messageId: unique for requests, copied from request for responses
 func (n *Node) NewMessageData(messageId string, gossip bool) *p2p.MessageData {
-	// Add protobufs bin data for message author public key
+	// Add protobuf bin data for message author public key
 	// this is useful for authenticating  messages forwarded by a node authored by another node
 	nodePubKey, err := crypto.MarshalPublicKey(n.Peerstore().PubKey(n.ID()))
 

--- a/examples/pubsub/chat/ui.go
+++ b/examples/pubsub/chat/ui.go
@@ -138,7 +138,7 @@ func (ui *ChatUI) displayChatMessage(cm *ChatMessage) {
 	fmt.Fprintf(ui.msgW, "%s %s\n", prompt, cm.Message)
 }
 
-// displaySelfMessage writes a message from ourself to the message window,
+// displaySelfMessage writes a message from ourselves to the message window,
 // with our nick highlighted in yellow.
 func (ui *ChatUI) displaySelfMessage(msg string) {
 	prompt := withColor("yellow", fmt.Sprintf("<%s>:", ui.cr.nick))

--- a/examples/relay/main.go
+++ b/examples/relay/main.go
@@ -67,7 +67,7 @@ func run() {
 		return
 	}
 
-	// Configure the host to offer the ciruit relay service.
+	// Configure the host to offer the circuit relay service.
 	// Any host that is directly dialable in the network (or on the internet)
 	// can offer a circuit relay service, this isn't just the job of
 	// "dedicated" relay services.

--- a/p2p/discovery/backoff/backoff.go
+++ b/p2p/discovery/backoff/backoff.go
@@ -13,7 +13,7 @@ var log = logging.Logger("discovery-backoff")
 
 type BackoffFactory func() BackoffStrategy
 
-// BackoffStrategy describes how backoff will be implemented. BackoffStratgies are stateful.
+// BackoffStrategy describes how backoff will be implemented. BackoffStrategies are stateful.
 type BackoffStrategy interface {
 	// Delay calculates how long the next backoff duration should be, given the prior calls to Delay
 	Delay() time.Duration

--- a/p2p/discovery/routing/routing.go
+++ b/p2p/discovery/routing/routing.go
@@ -31,7 +31,7 @@ func (d *RoutingDiscovery) Advertise(ctx context.Context, ns string, opts ...dis
 
 	ttl := options.Ttl
 	if ttl == 0 || ttl > 3*time.Hour {
-		// the DHT provider record validity is 24hrs, but it is recommnded to republish at least every 6hrs
+		// the DHT provider record validity is 24hrs, but it is recommended to republish at least every 6hrs
 		// we go one step further and republish every 3hrs
 		ttl = 3 * time.Hour
 	}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -591,7 +591,7 @@ func (h *BasicHost) EventBus() event.Bus {
 //
 //	host.Mux().SetHandler(proto, handler)
 //
-// (Threadsafe)
+// (Thread-safe)
 func (h *BasicHost) SetStreamHandler(pid protocol.ID, handler network.StreamHandler) {
 	h.Mux().AddHandler(pid, func(p protocol.ID, rwc io.ReadWriteCloser) error {
 		is := rwc.(network.Stream)
@@ -627,7 +627,7 @@ func (h *BasicHost) RemoveStreamHandler(pid protocol.ID) {
 // NewStream opens a new stream to given peer p, and writes a p2p/protocol
 // header with given protocol.ID. If there is no connection to p, attempts
 // to create one. If ProtocolID is "", writes no header.
-// (Threadsafe)
+// (Thread-safe)
 func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (network.Stream, error) {
 	// Ensure we have a connection, with peer addresses resolved by the routing system (#207)
 	// It is not sufficient to let the underlying host connect, it will most likely not have

--- a/p2p/host/peerstore/pstoremem/peerstore.go
+++ b/p2p/host/peerstore/pstoremem/peerstore.go
@@ -22,7 +22,7 @@ var _ peerstore.Peerstore = &pstoremem{}
 
 type Option interface{}
 
-// NewPeerstore creates an in-memory threadsafe collection of peers.
+// NewPeerstore creates an in-memory thread-safe collection of peers.
 // It's the caller's responsibility to call RemovePeer to ensure
 // that memory consumption of the peerstore doesn't grow unboundedly.
 func NewPeerstore(opts ...Option) (ps *pstoremem, err error) {

--- a/p2p/net/mock/mock_peernet.go
+++ b/p2p/net/mock/mock_peernet.go
@@ -358,7 +358,7 @@ func (pn *peernet) NewStream(ctx context.Context, p peer.ID) (network.Stream, er
 }
 
 // SetStreamHandler sets the new stream handler on the Network.
-// This operation is threadsafe.
+// This operation is thread-safe.
 func (pn *peernet) SetStreamHandler(h network.StreamHandler) {
 	pn.Lock()
 	pn.streamHandler = h


### PR DESCRIPTION
1. fix some comments errors such as: misspelling, syntax error and so on.
2. extract a string const.