### PR TITLE
identify: filter nat64 well-known prefix ipv6 addresses

### DIFF
--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -3,7 +3,6 @@ package identify
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -377,7 +376,7 @@ func shouldRecordObservation(host addrsProvider, network listenAddrsProvider, co
 	}
 
 	// Provided by NAT64 peers, these addresses are specific to the peer and not publicly routable
-	if isNAT64IPv4ConvertedIPv6Addr(observed) {
+	if manet.IsNAT64IPv4ConvertedIPv6Addr(observed) {
 		return false
 	}
 
@@ -436,20 +435,6 @@ func shouldRecordObservation(host addrsProvider, network listenAddrsProvider, co
 	}
 
 	return true
-}
-
-// isNAT64IPv4ConvertedIPv6Addr returns whether addr is an IPv6 address that begins with
-// the well known prefix "64:ff9b" used for NAT64 Translation
-// see RFC 6052
-func isNAT64IPv4ConvertedIPv6Addr(addr ma.Multiaddr) bool {
-	ip, err := addr.ValueForProtocol(ma.P_IP6)
-	if err != nil {
-		return false
-	}
-	if strings.HasPrefix(ip, "64:ff9b::") {
-		return true
-	}
-	return false
 }
 
 func (oas *ObservedAddrManager) maybeRecordObservation(conn network.Conn, observed ma.Multiaddr) {

--- a/p2p/protocol/identify/obsaddr_glass_test.go
+++ b/p2p/protocol/identify/obsaddr_glass_test.go
@@ -4,6 +4,7 @@ package identify
 // can access internal types.
 
 import (
+	"fmt"
 	"testing"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -102,4 +103,40 @@ func TestShouldRecordObservationWithWebTransport(t *testing.T) {
 	observedAddr := ma.StringCast("/ip4/1.2.3.4/udp/1231/quic-v1/webtransport")
 
 	require.True(t, shouldRecordObservation(h, h, c, observedAddr))
+}
+
+func TestIsWellKnownPrefixIPv4ConvertedIPv6Address(t *testing.T) {
+	cases := []struct {
+		addr          ma.Multiaddr
+		want          bool
+		failureReason string
+	}{
+		{
+			addr:          ma.StringCast("/ip4/1.2.3.4/tcp/1234"),
+			want:          false,
+			failureReason: "ip4 addresses should return false",
+		},
+		{
+			addr:          ma.StringCast("/ip6/1::4/tcp/1234"),
+			want:          false,
+			failureReason: "ip6 addresses doesn't have wellknown prefix",
+		},
+		{
+			addr:          ma.StringCast("/ip6/::1/tcp/1234"),
+			want:          false,
+			failureReason: "localhost addresses should return false",
+		},
+		{
+			addr:          ma.StringCast("/ip6/64:ff9b::192.0.1.2/tcp/1234"),
+			want:          true,
+			failureReason: "ip6 address begins with well-known prefix",
+		},
+	}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			if isNAT64IPv4ConvertedIPv6Addr(tc.addr) != tc.want {
+				t.Fatalf("%s %s", tc.addr, tc.failureReason)
+			}
+		})
+	}
 }

--- a/p2p/protocol/identify/obsaddr_glass_test.go
+++ b/p2p/protocol/identify/obsaddr_glass_test.go
@@ -105,7 +105,22 @@ func TestShouldRecordObservationWithWebTransport(t *testing.T) {
 	require.True(t, shouldRecordObservation(h, h, c, observedAddr))
 }
 
-func TestIsWellKnownPrefixIPv4ConvertedIPv6Address(t *testing.T) {
+func TestShouldRecordObservationWithNAT64Addr(t *testing.T) {
+	listenAddr1 := ma.StringCast("/ip4/0.0.0.0/tcp/1234")
+	ifaceAddr1 := ma.StringCast("/ip4/10.0.0.2/tcp/4321")
+	listenAddr2 := ma.StringCast("/ip6/::/tcp/1234")
+	ifaceAddr2 := ma.StringCast("/ip6/1::1/tcp/4321")
+
+	h := &mockHost{
+		listenAddrs:      []ma.Multiaddr{listenAddr1, listenAddr2},
+		ifaceListenAddrs: []ma.Multiaddr{ifaceAddr1, ifaceAddr2},
+		addrs:            []ma.Multiaddr{listenAddr1, listenAddr2},
+	}
+	c := &mockConn{
+		local:  listenAddr1,
+		remote: ma.StringCast("/ip4/1.2.3.6/tcp/4321"),
+	}
+
 	cases := []struct {
 		addr          ma.Multiaddr
 		want          bool
@@ -113,28 +128,24 @@ func TestIsWellKnownPrefixIPv4ConvertedIPv6Address(t *testing.T) {
 	}{
 		{
 			addr:          ma.StringCast("/ip4/1.2.3.4/tcp/1234"),
-			want:          false,
-			failureReason: "ip4 addresses should return false",
+			want:          true,
+			failureReason: "IPv4 should be observed",
 		},
 		{
 			addr:          ma.StringCast("/ip6/1::4/tcp/1234"),
-			want:          false,
-			failureReason: "ip6 addresses doesn't have wellknown prefix",
-		},
-		{
-			addr:          ma.StringCast("/ip6/::1/tcp/1234"),
-			want:          false,
-			failureReason: "localhost addresses should return false",
+			want:          true,
+			failureReason: "public IPv6 address should be observed",
 		},
 		{
 			addr:          ma.StringCast("/ip6/64:ff9b::192.0.1.2/tcp/1234"),
-			want:          true,
-			failureReason: "ip6 address begins with well-known prefix",
+			want:          false,
+			failureReason: "NAT64 IPv6 address shouldn't be observed",
 		},
 	}
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			if isNAT64IPv4ConvertedIPv6Addr(tc.addr) != tc.want {
+
+			if shouldRecordObservation(h, h, c, tc.addr) != tc.want {
 				t.Fatalf("%s %s", tc.addr, tc.failureReason)
 			}
 		})


### PR DESCRIPTION
fixes #2349 

For details see https://github.com/libp2p/go-libp2p/issues/2349#issuecomment-1608033872