### PR TITLE
holepunch: skip racy TestDirectDialWorks

### DIFF
--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -102,6 +102,10 @@ func TestNoHolePunchIfDirectConnExists(t *testing.T) {
 }
 
 func TestDirectDialWorks(t *testing.T) {
+	if race.WithRace() {
+		t.Skip("modifying manet.Private4 is racy")
+	}
+
 	// mark all addresses as public
 	cpy := manet.Private4
 	manet.Private4 = []*net.IPNet{}


### PR DESCRIPTION
Similar tests are skipped [elsewhere](https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/holepunch/holepunch_test.go#L409-L411)

Disabling blackhole detection will not work. We first [check](https://github.com/libp2p/go-libp2p/blob/master/p2p/net/swarm/black_hole_detector.go#L233) if it's a public address and only then look at UDP and IPv6 black hole filters. 

Closes: #2411 