### PR TITLE
feat: add ErrPeerIDMismatch error type to replace ad-hoc errors

### DIFF
--- a/core/sec/security.go
+++ b/core/sec/security.go
@@ -3,6 +3,7 @@ package sec
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -29,3 +30,14 @@ type SecureTransport interface {
 	// ID is the protocol ID of the security protocol.
 	ID() protocol.ID
 }
+
+type ErrPeerIDMismatch struct {
+	Expected peer.ID
+	Actual   peer.ID
+}
+
+func (e ErrPeerIDMismatch) Error() string {
+	return fmt.Sprintf("peer id mismatch: expected %s, but remote key matches %s", e.Expected, e.Actual)
+}
+
+var _ error = (*ErrPeerIDMismatch)(nil)

--- a/p2p/security/noise/handshake.go
+++ b/p2p/security/noise/handshake.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/sec"
 	"github.com/libp2p/go-libp2p/internal/sha256"
 	"github.com/libp2p/go-libp2p/p2p/security/noise/pb"
 
@@ -276,7 +277,7 @@ func (s *secureSession) handleRemoteHandshakePayload(payload []byte, remoteStati
 
 	// check the peer ID if enabled
 	if s.checkPeerID && s.remoteID != id {
-		return nil, fmt.Errorf("peer id mismatch: expected %s, but remote key matches %s", s.remoteID.Pretty(), id.Pretty())
+		return nil, sec.ErrPeerIDMismatch{Expected: s.remoteID, Actual: id}
 	}
 
 	// verify payload is signed by asserted remote libp2p key.

--- a/p2p/security/noise/transport_test.go
+++ b/p2p/security/noise/transport_test.go
@@ -212,7 +212,10 @@ func TestPeerIDMismatchOutboundFailsHandshake(t *testing.T) {
 
 	initErr := <-errChan
 	require.Error(t, initErr, "expected initiator to fail with peer ID mismatch error")
-	require.Contains(t, initErr.Error(), "but remote key matches")
+	var mismatchErr sec.ErrPeerIDMismatch
+	require.ErrorAs(t, initErr, &mismatchErr)
+	require.Equal(t, peer.ID("a-random-peer-id"), mismatchErr.Expected)
+	require.Equal(t, respTransport.localID, mismatchErr.Actual)
 }
 
 func TestPeerIDMismatchInboundFailsHandshake(t *testing.T) {
@@ -231,6 +234,10 @@ func TestPeerIDMismatchInboundFailsHandshake(t *testing.T) {
 
 	_, err := respTransport.SecureInbound(context.Background(), resp, "a-random-peer-id")
 	require.Error(t, err, "expected responder to fail with peer ID mismatch error")
+	var mismatchErr sec.ErrPeerIDMismatch
+	require.ErrorAs(t, err, &mismatchErr)
+	require.Equal(t, peer.ID("a-random-peer-id"), mismatchErr.Expected)
+	require.Equal(t, initTransport.localID, mismatchErr.Actual)
 	<-done
 }
 

--- a/p2p/security/tls/crypto.go
+++ b/p2p/security/tls/crypto.go
@@ -18,6 +18,7 @@ import (
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/sec"
 )
 
 const certValidityPeriod = 100 * 365 * 24 * time.Hour // ~100 years
@@ -129,7 +130,7 @@ func (i *Identity) ConfigForPeer(remote peer.ID) (*tls.Config, <-chan ic.PubKey)
 			if err != nil {
 				peerID = peer.ID(fmt.Sprintf("(not determined: %s)", err.Error()))
 			}
-			return fmt.Errorf("peer IDs don't match: expected %s, got %s", remote, peerID)
+			return sec.ErrPeerIDMismatch{Expected: remote, Actual: peerID}
 		}
 		keyCh <- pubKey
 		return nil

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -378,6 +378,8 @@ func TestPeerIDMismatch(t *testing.T) {
 		require.Error(t, err)
 		var mismatchErr sec.ErrPeerIDMismatch
 		require.ErrorAs(t, err, &mismatchErr)
+		require.Equal(t, thirdPartyID, mismatchErr.Expected)
+		require.Equal(t, serverID, mismatchErr.Actual)
 
 		var serverErr error
 		select {
@@ -393,8 +395,8 @@ func TestPeerIDMismatch(t *testing.T) {
 		clientInsecureConn, serverInsecureConn := connect(t)
 
 		errChan := make(chan error)
+		thirdPartyID, _ := createPeer(t)
 		go func() {
-			thirdPartyID, _ := createPeer(t)
 			// expect the wrong peer ID
 			_, err := serverTransport.SecureInbound(context.Background(), serverInsecureConn, thirdPartyID)
 			errChan <- err
@@ -415,6 +417,8 @@ func TestPeerIDMismatch(t *testing.T) {
 		require.Error(t, serverErr)
 		var mismatchErr sec.ErrPeerIDMismatch
 		require.ErrorAs(t, serverErr, &mismatchErr)
+		require.Equal(t, thirdPartyID, mismatchErr.Expected)
+		require.Equal(t, clientTransport.localPeer, mismatchErr.Actual)
 	})
 }
 

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -376,7 +376,8 @@ func TestPeerIDMismatch(t *testing.T) {
 		thirdPartyID, _ := createPeer(t)
 		_, err = clientTransport.SecureOutbound(context.Background(), clientInsecureConn, thirdPartyID)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "peer IDs don't match")
+		var mismatchErr sec.ErrPeerIDMismatch
+		require.ErrorAs(t, err, &mismatchErr)
 
 		var serverErr error
 		select {
@@ -412,7 +413,8 @@ func TestPeerIDMismatch(t *testing.T) {
 			t.Fatal("expected handshake to return on the server side")
 		}
 		require.Error(t, serverErr)
-		require.Contains(t, serverErr.Error(), "peer IDs don't match")
+		var mismatchErr sec.ErrPeerIDMismatch
+		require.ErrorAs(t, serverErr, &mismatchErr)
 	})
 }
 


### PR DESCRIPTION
partially resolves #2449.

This PR mostly works. However, it doesn't work with QUIC because QUIC encapsulates the error string instead of exposing it via unwrapping in https://github.com/quic-go/quic-go/blob/f3a0ce1599732cb56b958c2f0903074b62a7e9bf/internal/handshake/crypto_setup.go#L643.

Could add additional tests (or move over the ones from vole) if we're happy with this PR.

 @marten-seemann is making a change to quic-go to allow inspection of the inner error inside the transport error reasonable?