### PR TITLE
peerstore: deprecate the database-backed peerstore

### DIFF
--- a/p2p/host/peerstore/pstoreds/deprecate.go
+++ b/p2p/host/peerstore/pstoreds/deprecate.go
@@ -1,0 +1,5 @@
+// Deprecated: The database-backed peerstore will be removed from go-libp2p in the future.
+// Use the memory peerstore (pstoremem) instead.
+// For more details see https://github.com/libp2p/go-libp2p/issues/2329
+// and https://github.com/libp2p/go-libp2p/issues/2355.
+package pstoreds


### PR DESCRIPTION
For #2329.

Not removing the code yet, but at least we can give people a heads-up that this code is destined to die. This deprecation notice will (hopefully) be surfaced by our users' IDEs and CI.