### PR TITLE
quic: drop support for QUIC draft-29

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -79,11 +79,9 @@ var RandomIdentity = func(cfg *Config) error {
 var DefaultListenAddrs = func(cfg *Config) error {
 	addrs := []string{
 		"/ip4/0.0.0.0/tcp/0",
-		"/ip4/0.0.0.0/udp/0/quic",
 		"/ip4/0.0.0.0/udp/0/quic-v1",
 		"/ip4/0.0.0.0/udp/0/quic-v1/webtransport",
 		"/ip6/::/tcp/0",
-		"/ip6/::/udp/0/quic",
 		"/ip6/::/udp/0/quic-v1",
 		"/ip6/::/udp/0/quic-v1/webtransport",
 	}

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -99,7 +99,7 @@ func TestAutoNATService(t *testing.T) {
 
 func TestDefaultListenAddrs(t *testing.T) {
 	reTCP := regexp.MustCompile("/(ip)[4|6]/((0.0.0.0)|(::))/tcp/")
-	reQUIC := regexp.MustCompile("/(ip)[4|6]/((0.0.0.0)|(::))/udp/([0-9]*)/quic")
+	reQUIC := regexp.MustCompile("/(ip)[4|6]/((0.0.0.0)|(::))/udp/([0-9]*)/quic-v1")
 	reCircuit := regexp.MustCompile("/p2p-circuit")
 
 	// Test 1: Setting the correct listen addresses if userDefined.Transport == nil && userDefined.ListenAddrs == nil
@@ -180,7 +180,7 @@ func TestTransportConstructorTCP(t *testing.T) {
 	require.NoError(t, err)
 	defer h.Close()
 	require.NoError(t, h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0")))
-	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic"))
+	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), swarm.ErrNoTransport.Error())
 }
@@ -192,7 +192,7 @@ func TestTransportConstructorQUIC(t *testing.T) {
 	)
 	require.NoError(t, err)
 	defer h.Close()
-	require.NoError(t, h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic")))
+	require.NoError(t, h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")))
 	err = h.Network().Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), swarm.ErrNoTransport.Error())

--- a/p2p/host/autorelay/addrsplosion_test.go
+++ b/p2p/host/autorelay/addrsplosion_test.go
@@ -11,14 +11,14 @@ func TestCleanupAddrs(t *testing.T) {
 	t.Run("with no addrplosion", func(t *testing.T) {
 		addrs := makeAddrList(
 			"/ip4/127.0.0.1/tcp/4001",
-			"/ip4/127.0.0.1/udp/4002/quic",
+			"/ip4/127.0.0.1/udp/4002/quic-v1",
 			"/ip4/1.2.3.4/tcp/4001",
-			"/ip4/1.2.3.4/udp/4002/quic",
+			"/ip4/1.2.3.4/udp/4002/quic-v1",
 			"/dnsaddr/somedomain.com/tcp/4002/ws",
 		)
 		clean := makeAddrList(
 			"/ip4/1.2.3.4/tcp/4001",
-			"/ip4/1.2.3.4/udp/4002/quic",
+			"/ip4/1.2.3.4/udp/4002/quic-v1",
 			"/dnsaddr/somedomain.com/tcp/4002/ws",
 		)
 		require.ElementsMatch(t, clean, cleanupAddressSet(addrs), "cleaned up set doesn't match expected")
@@ -32,11 +32,11 @@ func TestCleanupAddrs(t *testing.T) {
 			"/ip4/1.2.3.4/tcp/33333",
 			"/ip4/1.2.3.4/tcp/33334",
 			"/ip4/1.2.3.4/tcp/33335",
-			"/ip4/1.2.3.4/udp/4002/quic",
+			"/ip4/1.2.3.4/udp/4002/quic-v1",
 		)
 		clean := makeAddrList(
 			"/ip4/1.2.3.4/tcp/4001",
-			"/ip4/1.2.3.4/udp/4002/quic",
+			"/ip4/1.2.3.4/udp/4002/quic-v1",
 		)
 		require.ElementsMatch(t, clean, cleanupAddressSet(addrs), "cleaned up set doesn't match expected")
 	})
@@ -48,11 +48,11 @@ func TestCleanupAddrs(t *testing.T) {
 			"/ip4/1.2.3.4/tcp/33333",
 			"/ip4/1.2.3.4/tcp/33334",
 			"/ip4/1.2.3.4/tcp/33335",
-			"/ip4/1.2.3.4/udp/4002/quic",
+			"/ip4/1.2.3.4/udp/4002/quic-v1",
 		)
 		clean := makeAddrList(
 			"/ip4/1.2.3.4/tcp/4001",
-			"/ip4/1.2.3.4/udp/4002/quic",
+			"/ip4/1.2.3.4/udp/4002/quic-v1",
 		)
 		require.ElementsMatch(t, clean, cleanupAddressSet(addrs), "cleaned up set doesn't match expected")
 	})
@@ -75,7 +75,7 @@ func TestCleanupAddrs(t *testing.T) {
 		// test with a squeaky clean address set
 		addrs := makeAddrList(
 			"/ip4/1.2.3.4/tcp/4001",
-			"/ip4/1.2.3.4/udp/4001/quic",
+			"/ip4/1.2.3.4/udp/4001/quic-v1",
 		)
 		require.ElementsMatch(t, addrs, cleanupAddressSet(addrs), "cleaned up set doesn't match expected")
 	})

--- a/p2p/net/swarm/dial_ranker_test.go
+++ b/p2p/net/swarm/dial_ranker_test.go
@@ -20,14 +20,14 @@ func sortAddrDelays(addrDelays []network.AddrDelay) {
 }
 
 func TestNoDelayDialRanker(t *testing.T) {
-	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
+	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
 	q1v1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
 	wt1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1/webtransport/")
-	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic")
+	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
 	q2v1 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
-	q3 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic")
+	q3 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic-v1")
 	q3v1 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic-v1")
-	q4 := ma.StringCast("/ip4/1.2.3.4/udp/4/quic")
+	q4 := ma.StringCast("/ip4/1.2.3.4/udp/4/quic-v1")
 	t1 := ma.StringCast("/ip4/1.2.3.5/tcp/1/")
 
 	testCase := []struct {
@@ -70,14 +70,10 @@ func TestNoDelayDialRanker(t *testing.T) {
 }
 
 func TestDelayRankerQUICDelay(t *testing.T) {
-	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
 	q1v1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
 	wt1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1/webtransport/")
-	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic")
 	q2v1 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
-	q3 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic")
 	q3v1 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic-v1")
-	q4 := ma.StringCast("/ip4/1.2.3.4/udp/4/quic")
 
 	q1v16 := ma.StringCast("/ip6/1::2/udp/1/quic-v1")
 	q2v16 := ma.StringCast("/ip6/1::2/udp/2/quic-v1")
@@ -90,12 +86,11 @@ func TestDelayRankerQUICDelay(t *testing.T) {
 	}{
 		{
 			name:  "quic-ipv4",
-			addrs: []ma.Multiaddr{q1, q2, q3, q4},
+			addrs: []ma.Multiaddr{q1v1, q2v1, q3v1},
 			output: []network.AddrDelay{
-				{Addr: q1, Delay: 0},
-				{Addr: q2, Delay: PublicQUICDelay},
-				{Addr: q3, Delay: PublicQUICDelay},
-				{Addr: q4, Delay: PublicQUICDelay},
+				{Addr: q1v1, Delay: 0},
+				{Addr: q2v1, Delay: PublicQUICDelay},
+				{Addr: q3v1, Delay: PublicQUICDelay},
 			},
 		},
 		{
@@ -109,37 +104,29 @@ func TestDelayRankerQUICDelay(t *testing.T) {
 		},
 		{
 			name:  "quic-ip4-ip6",
-			addrs: []ma.Multiaddr{q1, q1v16, q2v1, q3, q4},
+			addrs: []ma.Multiaddr{q1v16, q2v1},
 			output: []network.AddrDelay{
 				{Addr: q1v16, Delay: 0},
 				{Addr: q2v1, Delay: PublicQUICDelay},
-				{Addr: q1, Delay: 2 * PublicQUICDelay},
-				{Addr: q3, Delay: 2 * PublicQUICDelay},
-				{Addr: q4, Delay: 2 * PublicQUICDelay},
 			},
 		},
 		{
 			name:  "quic-quic-v1-webtransport",
-			addrs: []ma.Multiaddr{q1v16, q1, q2, q3, q4, q1v1, q2v1, q3v1, wt1},
+			addrs: []ma.Multiaddr{q1v16, q1v1, q2v1, q3v1, wt1},
 			output: []network.AddrDelay{
 				{Addr: q1v16, Delay: 0},
 				{Addr: q1v1, Delay: PublicQUICDelay},
 				{Addr: q2v1, Delay: 2 * PublicQUICDelay},
 				{Addr: q3v1, Delay: 2 * PublicQUICDelay},
-				{Addr: q1, Delay: 2 * PublicQUICDelay},
-				{Addr: q2, Delay: 2 * PublicQUICDelay},
-				{Addr: q3, Delay: 2 * PublicQUICDelay},
-				{Addr: q4, Delay: 2 * PublicQUICDelay},
 				{Addr: wt1, Delay: 2 * PublicQUICDelay},
 			},
 		},
 		{
 			name:  "wt-ranking",
-			addrs: []ma.Multiaddr{q1v16, q2v16, q3v16, q2, wt1},
+			addrs: []ma.Multiaddr{q1v16, q2v16, q3v16, wt1},
 			output: []network.AddrDelay{
 				{Addr: q1v16, Delay: 0},
-				{Addr: q2, Delay: PublicQUICDelay},
-				{Addr: wt1, Delay: 2 * PublicQUICDelay},
+				{Addr: wt1, Delay: PublicQUICDelay},
 				{Addr: q2v16, Delay: 2 * PublicQUICDelay},
 				{Addr: q3v16, Delay: 2 * PublicQUICDelay},
 			},
@@ -164,11 +151,8 @@ func TestDelayRankerQUICDelay(t *testing.T) {
 }
 
 func TestDelayRankerTCPDelay(t *testing.T) {
-	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
 	q1v1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
-	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic")
 	q2v1 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
-	q3 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic")
 
 	q1v16 := ma.StringCast("/ip6/1::2/udp/1/quic-v1")
 	q2v16 := ma.StringCast("/ip6/1::2/udp/2/quic-v1")
@@ -185,11 +169,10 @@ func TestDelayRankerTCPDelay(t *testing.T) {
 	}{
 		{
 			name:  "quic-with-tcp-ip6-ip4",
-			addrs: []ma.Multiaddr{q1, q1v1, q1v16, q2v16, q3v16, q2v1, t1, t2},
+			addrs: []ma.Multiaddr{q1v1, q1v16, q2v16, q3v16, q2v1, t1, t2},
 			output: []network.AddrDelay{
 				{Addr: q1v16, Delay: 0},
 				{Addr: q1v1, Delay: PublicQUICDelay},
-				{Addr: q1, Delay: 2 * PublicQUICDelay},
 				{Addr: q2v16, Delay: 2 * PublicQUICDelay},
 				{Addr: q3v16, Delay: 2 * PublicQUICDelay},
 				{Addr: q2v1, Delay: 2 * PublicQUICDelay},
@@ -199,14 +182,12 @@ func TestDelayRankerTCPDelay(t *testing.T) {
 		},
 		{
 			name:  "quic-ip4-with-tcp",
-			addrs: []ma.Multiaddr{q1, q2, q3, t1, t2, t1v6},
+			addrs: []ma.Multiaddr{q1v1, t1, t2, t1v6},
 			output: []network.AddrDelay{
-				{Addr: q1, Delay: 0},
-				{Addr: q2, Delay: PublicQUICDelay},
-				{Addr: q3, Delay: PublicQUICDelay},
-				{Addr: t1, Delay: PublicQUICDelay + PublicTCPDelay},
-				{Addr: t2, Delay: PublicQUICDelay + PublicTCPDelay},
-				{Addr: t1v6, Delay: PublicQUICDelay + PublicTCPDelay},
+				{Addr: q1v1, Delay: 0},
+				{Addr: t1, Delay: PublicTCPDelay},
+				{Addr: t2, Delay: PublicTCPDelay},
+				{Addr: t1v6, Delay: PublicTCPDelay},
 			},
 		},
 		{
@@ -238,8 +219,8 @@ func TestDelayRankerTCPDelay(t *testing.T) {
 }
 
 func TestDelayRankerRelay(t *testing.T) {
-	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
-	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic")
+	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
+	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
 
 	pid := test.RandPeerIDFatal(t)
 	r1 := ma.StringCast(fmt.Sprintf("/ip4/1.2.3.4/tcp/1/p2p-circuit/p2p/%s", pid))

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -61,7 +61,7 @@ func makeSwarm(t *testing.T) *Swarm {
 		t.Fatal(err)
 	}
 
-	if err := s.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic")); err != nil {
+	if err := s.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -234,7 +234,7 @@ func TestDialWorkerLoopFailure(t *testing.T) {
 
 	_, p2 := newPeer(t)
 
-	s1.Peerstore().AddAddrs(p2, []ma.Multiaddr{ma.StringCast("/ip4/11.0.0.1/tcp/1234"), ma.StringCast("/ip4/11.0.0.1/udp/1234/quic")}, peerstore.PermanentAddrTTL)
+	s1.Peerstore().AddAddrs(p2, []ma.Multiaddr{ma.StringCast("/ip4/11.0.0.1/tcp/1234"), ma.StringCast("/ip4/11.0.0.1/udp/1234/quic-v1")}, peerstore.PermanentAddrTTL)
 
 	reqch := make(chan dialRequest)
 	resch := make(chan dialResponse)
@@ -259,7 +259,7 @@ func TestDialWorkerLoopConcurrentFailure(t *testing.T) {
 
 	_, p2 := newPeer(t)
 
-	s1.Peerstore().AddAddrs(p2, []ma.Multiaddr{ma.StringCast("/ip4/11.0.0.1/tcp/1234"), ma.StringCast("/ip4/11.0.0.1/udp/1234/quic")}, peerstore.PermanentAddrTTL)
+	s1.Peerstore().AddAddrs(p2, []ma.Multiaddr{ma.StringCast("/ip4/11.0.0.1/tcp/1234"), ma.StringCast("/ip4/11.0.0.1/udp/1234/quic-v1")}, peerstore.PermanentAddrTTL)
 
 	reqch := make(chan dialRequest)
 	worker := newDialWorker(s1, p2, reqch, nil)
@@ -307,7 +307,7 @@ func TestDialWorkerLoopConcurrentMix(t *testing.T) {
 	defer s2.Close()
 
 	s1.Peerstore().AddAddrs(s2.LocalPeer(), s2.ListenAddresses(), peerstore.PermanentAddrTTL)
-	s1.Peerstore().AddAddrs(s2.LocalPeer(), []ma.Multiaddr{ma.StringCast("/ip4/11.0.0.1/tcp/1234"), ma.StringCast("/ip4/11.0.0.1/udp/1234/quic")}, peerstore.PermanentAddrTTL)
+	s1.Peerstore().AddAddrs(s2.LocalPeer(), []ma.Multiaddr{ma.StringCast("/ip4/11.0.0.1/tcp/1234"), ma.StringCast("/ip4/11.0.0.1/udp/1234/quic-v1")}, peerstore.PermanentAddrTTL)
 
 	reqch := make(chan dialRequest)
 	worker := newDialWorker(s1, s2.LocalPeer(), reqch, nil)
@@ -917,7 +917,7 @@ func TestDialWorkerLoopQuicOverTCP(t *testing.T) {
 	tc := schedulingTestCase{
 		input: []timedDial{
 			{
-				addr:    ma.StringCast("/ip4/127.0.0.1/udp/20000/quic"),
+				addr:    ma.StringCast("/ip4/127.0.0.1/udp/20000/quic-v1"),
 				delay:   0,
 				success: true,
 			},

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -100,7 +100,7 @@ func TestDialAddressSelection(t *testing.T) {
 	require.NoError(t, s.AddTransport(circuitTr))
 
 	require.Equal(t, tcpTr, s.TransportForDialing(ma.StringCast("/ip4/127.0.0.1/tcp/1234")))
-	require.Equal(t, quicTr, s.TransportForDialing(ma.StringCast("/ip4/127.0.0.1/udp/1234/quic")))
+	require.Equal(t, quicTr, s.TransportForDialing(ma.StringCast("/ip4/127.0.0.1/udp/1234/quic-v1")))
 	require.Equal(t, circuitTr, s.TransportForDialing(ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic/p2p-circuit/p2p/%s", id))))
 	require.Equal(t, webtransportTr, s.TransportForDialing(ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/%s", certHash))))
 	require.Nil(t, s.TransportForDialing(ma.StringCast("/ip4/1.2.3.4")))

--- a/p2p/net/swarm/swarm_dial_test.go
+++ b/p2p/net/swarm/swarm_dial_test.go
@@ -263,15 +263,15 @@ func TestAddrResolutionRecursive(t *testing.T) {
 }
 
 func TestAddrsForDialFiltering(t *testing.T) {
-	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
+	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
 	q1v1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
 	wt1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1/webtransport/")
 
-	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic")
+	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
 	q2v1 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
 	wt2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1/webtransport/")
 
-	q3 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic")
+	q3 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic-v1")
 
 	t1 := ma.StringCast("/ip4/1.2.3.4/tcp/1")
 	ws1 := ma.StringCast("/ip4/1.2.3.4/tcp/1/ws")

--- a/p2p/net/swarm/swarm_metrics_test.go
+++ b/p2p/net/swarm/swarm_metrics_test.go
@@ -29,7 +29,7 @@ func BenchmarkMetricsConnOpen(b *testing.B) {
 	}
 	_, pub, err := crypto.GenerateEd25519Key(rand.Reader)
 	require.NoError(b, err)
-	quicAddr := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
+	quicAddr := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
 	tcpAddr := ma.StringCast("/ip4/1.2.3.4/tcp/1/")
 	tr := NewMetricsTracer()
 	for i := 0; i < b.N; i++ {

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -390,7 +390,7 @@ func TestTypedNilConn(t *testing.T) {
 
 func TestPreventDialListenAddr(t *testing.T) {
 	s := GenSwarm(t, OptDialOnly)
-	if err := s.Listen(ma.StringCast("/ip4/0.0.0.0/udp/0/quic")); err != nil {
+	if err := s.Listen(ma.StringCast("/ip4/0.0.0.0/udp/0/quic-v1")); err != nil {
 		t.Fatal(err)
 	}
 	addrs, err := s.InterfaceListenAddresses()

--- a/p2p/net/swarm/testing/testing.go
+++ b/p2p/net/swarm/testing/testing.go
@@ -187,7 +187,7 @@ func GenSwarm(t *testing.T, opts ...Option) *swarm.Swarm {
 			t.Fatal(err)
 		}
 		if !cfg.dialOnly {
-			if err := s.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic")); err != nil {
+			if err := s.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/p2p/net/swarm/util_test.go
+++ b/p2p/net/swarm/util_test.go
@@ -20,7 +20,7 @@ func TestIsFdConsuming(t *testing.T) {
 			isFdConsuming: true,
 		},
 		"quic": {
-			addr:          "/ip4/127.0.0.1/udp/0/quic",
+			addr:          "/ip4/127.0.0.1/udp/0/quic-v1",
 			isFdConsuming: false,
 		},
 		"addr-without-registered-transport": {

--- a/p2p/protocol/holepunch/metrics_noalloc_test.go
+++ b/p2p/protocol/holepunch/metrics_noalloc_test.go
@@ -14,14 +14,14 @@ func TestNoCoverNoAllocMetrics(t *testing.T) {
 	addrs1 := [][]ma.Multiaddr{
 		{
 			ma.StringCast("/ip4/0.0.0.0/tcp/1"),
-			ma.StringCast("/ip4/1.2.3.4/udp/2/quic"),
+			ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1"),
 		},
 		nil,
 	}
 	addrs2 := [][]ma.Multiaddr{
 		{
 			ma.StringCast("/ip4/1.2.3.4/tcp/3"),
-			ma.StringCast("/ip4/1.2.3.4/udp/4/quic"),
+			ma.StringCast("/ip4/1.2.3.4/udp/4/quic-v1"),
 		},
 		nil,
 	}

--- a/p2p/protocol/holepunch/metrics_test.go
+++ b/p2p/protocol/holepunch/metrics_test.go
@@ -24,10 +24,8 @@ func TestHolePunchOutcomeCounter(t *testing.T) {
 	t1 := ma.StringCast("/ip4/1.2.3.4/tcp/1")
 	t2 := ma.StringCast("/ip4/1.2.3.4/tcp/2")
 
-	q1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic")
-	q2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic")
-
 	q1v1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
+	q2v1 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
 
 	type testcase struct {
 		name       string
@@ -39,35 +37,34 @@ func TestHolePunchOutcomeCounter(t *testing.T) {
 	testcases := []testcase{
 		{
 			name:       "connection success",
-			theirAddrs: []ma.Multiaddr{t1, q1},
-			ourAddrs:   []ma.Multiaddr{t2, q2},
+			theirAddrs: []ma.Multiaddr{t1, q1v1},
+			ourAddrs:   []ma.Multiaddr{t2, q2v1},
 			conn:       &mockConnMultiaddrs{local: t1, remote: t2},
 			result: map[[3]string]int{
-				[...]string{"ip4", "tcp", "success"}:    1,
-				[...]string{"ip4", "quic", "cancelled"}: 1,
+				[...]string{"ip4", "tcp", "success"}:       1,
+				[...]string{"ip4", "quic-v1", "cancelled"}: 1,
 			},
 		},
 		{
 			name:       "connection failed",
 			theirAddrs: []ma.Multiaddr{t1},
-			ourAddrs:   []ma.Multiaddr{t2, q2},
+			ourAddrs:   []ma.Multiaddr{t2, q2v1},
 			conn:       nil,
 			result: map[[3]string]int{
-				[...]string{"ip4", "tcp", "failed"}:               1,
-				[...]string{"ip4", "quic", "no_suitable_address"}: 1,
+				[...]string{"ip4", "tcp", "failed"}:                  1,
+				[...]string{"ip4", "quic-v1", "no_suitable_address"}: 1,
 			},
 		},
 		{
 			name:       "no_suitable_address",
-			theirAddrs: []ma.Multiaddr{t1, q1},
-			ourAddrs:   []ma.Multiaddr{t2, q2, q1v1},
-			conn:       &mockConnMultiaddrs{local: q1, remote: q2},
+			theirAddrs: []ma.Multiaddr{t1, q1v1},
+			ourAddrs:   []ma.Multiaddr{t2, q2v1},
+			conn:       &mockConnMultiaddrs{local: q1v1, remote: q2v1},
 			result: map[[3]string]int{
-				[...]string{"ip4", "tcp", "cancelled"}:               1,
-				[...]string{"ip4", "quic", "failed"}:                 0,
-				[...]string{"ip4", "quic", "success"}:                1,
-				[...]string{"ip4", "tcp", "success"}:                 0,
-				[...]string{"ip4", "quic-v1", "no_suitable_address"}: 1,
+				[...]string{"ip4", "tcp", "cancelled"}:   1,
+				[...]string{"ip4", "quic-v1", "failed"}:  0,
+				[...]string{"ip4", "quic-v1", "success"}: 1,
+				[...]string{"ip4", "tcp", "success"}:     0,
 			},
 		},
 	}

--- a/p2p/protocol/identify/obsaddr_glass_test.go
+++ b/p2p/protocol/identify/obsaddr_glass_test.go
@@ -17,9 +17,9 @@ func TestObservedAddrGroupKey(t *testing.T) {
 	oa3 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.5/tcp/1231")}
 	oa4 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1231")}
 	oa5 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1531")}
-	oa6 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1531/quic")}
-	oa7 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1111/quic")}
-	oa8 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.5/udp/1111/quic")}
+	oa6 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1531/quic-v1")}
+	oa7 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.4/udp/1111/quic-v1")}
+	oa8 := &observedAddr{addr: ma.StringCast("/ip4/1.2.3.5/udp/1111/quic-v1")}
 
 	// different ports, same IP => same key
 	require.Equal(t, oa1.groupKey(), oa2.groupKey())

--- a/p2p/test/quic/quic_test.go
+++ b/p2p/test/quic/quic_test.go
@@ -26,103 +26,12 @@ func getQUICMultiaddrCode(addr ma.Multiaddr) int {
 	return 0
 }
 
-func TestQUICVersions(t *testing.T) {
-	h1, err := libp2p.New(
-		libp2p.Transport(libp2pquic.NewTransport),
-		libp2p.Transport(webtransport.New),
-		libp2p.ListenAddrStrings(
-			"/ip4/127.0.0.1/udp/12345/quic",    // QUIC draft-29
-			"/ip4/127.0.0.1/udp/12345/quic-v1", // QUIC v1
-		),
-	)
-	require.NoError(t, err)
-	defer h1.Close()
-
-	addrs := h1.Addrs()
-	require.Len(t, addrs, 2)
-	var quicDraft29Addr, quicV1Addr ma.Multiaddr
-	for _, addr := range addrs {
-		switch getQUICMultiaddrCode(addr) {
-		case ma.P_QUIC:
-			quicDraft29Addr = addr
-		case ma.P_QUIC_V1:
-			quicV1Addr = addr
-		}
-	}
-	require.NotNil(t, quicDraft29Addr, "expected to be listening on a QUIC draft-29 address")
-	require.NotNil(t, quicV1Addr, "expected to be listening on a QUIC v1 address")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-	//  connect using QUIC draft-29
-	h2, err := libp2p.New(
-		libp2p.Transport(libp2pquic.NewTransport),
-	)
-	require.NoError(t, err)
-	require.NoError(t, h2.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: []ma.Multiaddr{quicDraft29Addr}}))
-	conns := h2.Network().ConnsToPeer(h1.ID())
-	require.Len(t, conns, 1)
-	require.Equal(t, ma.P_QUIC, getQUICMultiaddrCode(conns[0].LocalMultiaddr()))
-	require.Equal(t, ma.P_QUIC, getQUICMultiaddrCode(conns[0].RemoteMultiaddr()))
-	h2.Close()
-
-	//  connect using QUIC v1
-	h3, err := libp2p.New(
-		libp2p.Transport(libp2pquic.NewTransport),
-	)
-	require.NoError(t, err)
-	require.NoError(t, h3.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: []ma.Multiaddr{quicV1Addr}}))
-	conns = h3.Network().ConnsToPeer(h1.ID())
-	require.Len(t, conns, 1)
-	require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(conns[0].LocalMultiaddr()))
-	require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(conns[0].RemoteMultiaddr()))
-	h3.Close()
-}
-
-func TestDisableQUICDraft29(t *testing.T) {
-	h1, err := libp2p.New(
-		libp2p.QUICReuse(quicreuse.NewConnManager, quicreuse.DisableDraft29()),
-		libp2p.Transport(libp2pquic.NewTransport),
-		libp2p.Transport(webtransport.New),
-		libp2p.ListenAddrStrings(
-			"/ip4/127.0.0.1/udp/12346/quic",    // QUIC draft-29
-			"/ip4/127.0.0.1/udp/12346/quic-v1", // QUIC v1
-		),
-	)
-	require.NoError(t, err)
-	defer h1.Close()
-
-	addrs := h1.Addrs()
-	require.Len(t, addrs, 1)
-	require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(addrs[0]))
-
-	//  connect using QUIC draft-29
-	h2, err := libp2p.New(
-		libp2p.Transport(libp2pquic.NewTransport),
-	)
-	require.NoError(t, err)
-	defer h2.Close()
-	// We disabled QUIC Version Negotiation, so we will _not_ receive a Version Negotiation packet.
-	// Instead, the connection will run into the context timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Microsecond)
-	defer cancel()
-	require.ErrorIs(t,
-		h2.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: []ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/udp/12346/quic")}}),
-		context.DeadlineExceeded,
-	)
-	// make sure that dialing QUIC v1 works
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	require.NoError(t, h2.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: []ma.Multiaddr{addrs[0]}}))
-}
-
 func TestQUICAndWebTransport(t *testing.T) {
 	h1, err := libp2p.New(
 		libp2p.QUICReuse(quicreuse.NewConnManager),
 		libp2p.Transport(libp2pquic.NewTransport),
 		libp2p.Transport(webtransport.New),
 		libp2p.ListenAddrStrings(
-			"/ip4/127.0.0.1/udp/12347/quic/",
 			"/ip4/127.0.0.1/udp/12347/quic-v1",
 			"/ip4/127.0.0.1/udp/12347/quic-v1/webtransport",
 		),
@@ -131,19 +40,16 @@ func TestQUICAndWebTransport(t *testing.T) {
 	defer h1.Close()
 
 	addrs := h1.Addrs()
-	require.Len(t, addrs, 3)
-	var quicDraft29Addr, quicV1Addr, webtransportAddr ma.Multiaddr
+	require.Len(t, addrs, 2)
+	var quicV1Addr, webtransportAddr ma.Multiaddr
 	for _, addr := range addrs {
 		if _, err := addr.ValueForProtocol(ma.P_WEBTRANSPORT); err == nil {
 			webtransportAddr = addr
 		} else if _, err := addr.ValueForProtocol(ma.P_QUIC_V1); err == nil {
 			quicV1Addr = addr
-		} else {
-			quicDraft29Addr = addr
 		}
 	}
 	require.NotNil(t, webtransportAddr, "expected to have a WebTransport address")
-	require.NotNil(t, quicDraft29Addr, "expected to have a QUIC draft-29 address")
 	require.NotNil(t, quicV1Addr, "expected to have a QUIC v1 address")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -165,36 +71,14 @@ func TestQUICAndWebTransport(t *testing.T) {
 	}
 	h2.Close()
 
-	// then test that we can dial a QUIC draft-29
-	h3, err := libp2p.New(
-		libp2p.Transport(libp2pquic.NewTransport),
-		libp2p.NoListenAddrs,
-	)
-	require.NoError(t, err)
-	require.NoError(t, h3.Connect(ctx, peer.AddrInfo{
-		ID: h1.ID(),
-		// a libp2p host will prefer dialing v1 if it supports both versions,
-		// so we need to filter the addresses so it thinks that h1 only supports draft-29
-		Addrs: ma.FilterAddrs(h1.Addrs(), func(addr ma.Multiaddr) bool { _, err := addr.ValueForProtocol(ma.P_QUIC); return err == nil }),
-	}))
-	for _, conns := range [][]network.Conn{h3.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h3.ID())} {
-		require.Len(t, conns, 1)
-		if _, err := conns[0].LocalMultiaddr().ValueForProtocol(ma.P_WEBTRANSPORT); err == nil {
-			t.Fatalf("expected a QUIC connection, got a WebTransport connection (%s <-> %s)", conns[0].LocalMultiaddr(), conns[0].RemoteMultiaddr())
-		}
-		require.Equal(t, ma.P_QUIC, getQUICMultiaddrCode(conns[0].LocalMultiaddr()))
-		require.Equal(t, ma.P_QUIC, getQUICMultiaddrCode(conns[0].RemoteMultiaddr()))
-	}
-	h3.Close()
-
 	// finally, test that we can dial a WebTransport connection
-	h4, err := libp2p.New(
+	h3, err := libp2p.New(
 		libp2p.Transport(webtransport.New),
 		libp2p.NoListenAddrs,
 	)
 	require.NoError(t, err)
-	require.NoError(t, h4.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}))
-	for _, conns := range [][]network.Conn{h4.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h4.ID())} {
+	require.NoError(t, h3.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}))
+	for _, conns := range [][]network.Conn{h3.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h3.ID())} {
 		require.Len(t, conns, 1)
 		if _, err := conns[0].LocalMultiaddr().ValueForProtocol(ma.P_WEBTRANSPORT); err != nil {
 			t.Fatalf("expected a WebTransport connection, got a QUIC connection (%s <-> %s)", conns[0].LocalMultiaddr(), conns[0].RemoteMultiaddr())
@@ -202,5 +86,5 @@ func TestQUICAndWebTransport(t *testing.T) {
 		require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(conns[0].LocalMultiaddr()))
 		require.Equal(t, ma.P_QUIC_V1, getQUICMultiaddrCode(conns[0].RemoteMultiaddr()))
 	}
-	h4.Close()
+	h3.Close()
 }

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -35,8 +35,8 @@ type connTestCase struct {
 }
 
 var connTestCases = []*connTestCase{
-	{"reuseport_on", []quicreuse.Option{quicreuse.DisableDraft29()}},
-	{"reuseport_off", []quicreuse.Option{quicreuse.DisableReuseport(), quicreuse.DisableDraft29()}},
+	{"reuseport_on", []quicreuse.Option{}},
+	{"reuseport_off", []quicreuse.Option{quicreuse.DisableReuseport()}},
 }
 
 func createPeer(t *testing.T) (peer.ID, ic.PrivKey) {
@@ -673,111 +673,4 @@ func TestHolePunching(t *testing.T) {
 	ln2.Close()
 	<-done1
 	<-done2
-}
-
-func TestGetErrorWhenListeningWithDraft29WhenDisabled(t *testing.T) {
-	_, serverKey := createPeer(t)
-
-	t1, err := NewTransport(serverKey, newConnManager(t, quicreuse.DisableDraft29()), nil, nil, nil)
-	require.NoError(t, err)
-	defer t1.(io.Closer).Close()
-	laddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/quic")
-	require.NoError(t, err)
-	_, err = t1.Listen(laddr)
-	require.Error(t, err)
-}
-
-func TestClientCanDialDifferentQUICVersions(t *testing.T) {
-	type testCase struct {
-		name                  string
-		serverDisablesDraft29 bool
-	}
-
-	testCases := []testCase{
-		{
-			name:                  "Client dials quic-v1 on a quic-v1 only server",
-			serverDisablesDraft29: true,
-		},
-		{
-			name:                  "Client dials both draft 29 and v1 on server that supports both",
-			serverDisablesDraft29: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			serverID, serverKey := createPeer(t)
-			_, clientKey := createPeer(t)
-
-			var serverOpts []quicreuse.Option
-			if tc.serverDisablesDraft29 {
-				serverOpts = append(serverOpts, quicreuse.DisableDraft29())
-			}
-
-			t1, err := NewTransport(serverKey, newConnManager(t, serverOpts...), nil, nil, nil)
-			require.NoError(t, err)
-			defer t1.(io.Closer).Close()
-			laddr := ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")
-			ln1, err := t1.Listen(laddr)
-			require.NoError(t, err)
-			t.Cleanup(func() { ln1.Close() })
-
-			mas := []ma.Multiaddr{ln1.Multiaddr()}
-			var ln2 tpt.Listener
-			if !tc.serverDisablesDraft29 {
-				laddrDraft29 := ma.StringCast("/ip4/127.0.0.1/udp/0/quic")
-				ln2, err = t1.Listen(laddrDraft29)
-				require.NoError(t, err)
-				t.Cleanup(func() { ln2.Close() })
-				mas = append(mas, ln2.Multiaddr())
-			}
-
-			t2, err := NewTransport(clientKey, newConnManager(t), nil, nil, nil)
-			require.NoError(t, err)
-			defer t2.(io.Closer).Close()
-
-			ctx := context.Background()
-
-			for _, a := range mas {
-				_, v, err := quicreuse.FromQuicMultiaddr(a)
-				require.NoError(t, err)
-
-				done := make(chan struct{})
-				go func() {
-					defer close(done)
-					var conn tpt.CapableConn
-					var err error
-					if v == quic.Version1 {
-						conn, err = ln1.Accept()
-					} else if v == quic.VersionDraft29 {
-						conn, err = ln2.Accept()
-					} else {
-						panic("unexpected version")
-					}
-					require.NoError(t, err)
-
-					_, versionConnLocal, err := quicreuse.FromQuicMultiaddr(conn.LocalMultiaddr())
-					require.NoError(t, err)
-					_, versionConnRemote, err := quicreuse.FromQuicMultiaddr(conn.RemoteMultiaddr())
-					require.NoError(t, err)
-
-					require.Equal(t, v, versionConnLocal)
-					require.Equal(t, v, versionConnRemote)
-				}()
-
-				conn, err := t2.Dial(ctx, a, serverID)
-				require.NoError(t, err)
-				_, versionConnLocal, err := quicreuse.FromQuicMultiaddr(conn.LocalMultiaddr())
-				require.NoError(t, err)
-				_, versionConnRemote, err := quicreuse.FromQuicMultiaddr(conn.RemoteMultiaddr())
-				require.NoError(t, err)
-
-				require.Equal(t, v, versionConnLocal)
-				require.Equal(t, v, versionConnRemote)
-
-				<-done
-				conn.Close()
-			}
-		})
-	}
 }

--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -29,9 +29,6 @@ type listener struct {
 func newListener(ln quicreuse.Listener, t *transport, localPeer peer.ID, key ic.PrivKey, rcmgr network.ResourceManager) (listener, error) {
 	localMultiaddrs := make(map[quic.VersionNumber]ma.Multiaddr)
 	for _, addr := range ln.Multiaddrs() {
-		if _, err := addr.ValueForProtocol(ma.P_QUIC); err == nil {
-			localMultiaddrs[quic.VersionDraft29] = addr
-		}
 		if _, err := addr.ValueForProtocol(ma.P_QUIC_V1); err == nil {
 			localMultiaddrs[quic.Version1] = addr
 		}

--- a/p2p/transport/quic/listener_test.go
+++ b/p2p/transport/quic/listener_test.go
@@ -34,41 +34,31 @@ func TestListenAddr(t *testing.T) {
 	defer tr.(io.Closer).Close()
 
 	t.Run("for IPv4", func(t *testing.T) {
-		localAddr := ma.StringCast("/ip4/127.0.0.1/udp/0/quic")
-		ln, err := tr.Listen(localAddr)
-		require.NoError(t, err)
 		localAddrV1 := ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")
-		ln2, err := tr.Listen(localAddrV1)
+		ln, err := tr.Listen(localAddrV1)
 		require.NoError(t, err)
 		defer ln.Close()
-		defer ln2.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
 
 		var multiaddrsStrings []string
-		for _, a := range []ma.Multiaddr{ln.Multiaddr(), ln2.Multiaddr()} {
+		for _, a := range []ma.Multiaddr{ln.Multiaddr()} {
 			multiaddrsStrings = append(multiaddrsStrings, a.String())
 		}
-		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic", port))
 		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic-v1", port))
 	})
 
 	t.Run("for IPv6", func(t *testing.T) {
-		localAddr := ma.StringCast("/ip6/::/udp/0/quic")
-		ln, err := tr.Listen(localAddr)
-		require.NoError(t, err)
 		localAddrV1 := ma.StringCast("/ip6/::/udp/0/quic-v1")
-		ln2, err := tr.Listen(localAddrV1)
+		ln, err := tr.Listen(localAddrV1)
 		require.NoError(t, err)
 		defer ln.Close()
-		defer ln2.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
 		var multiaddrsStrings []string
-		for _, a := range []ma.Multiaddr{ln.Multiaddr(), ln2.Multiaddr()} {
+		for _, a := range []ma.Multiaddr{ln.Multiaddr()} {
 			multiaddrsStrings = append(multiaddrsStrings, a.String())
 		}
-		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip6/::/udp/%d/quic", port))
 		require.Contains(t, multiaddrsStrings, fmt.Sprintf("/ip6/::/udp/%d/quic-v1", port))
 	})
 }
@@ -76,7 +66,7 @@ func TestListenAddr(t *testing.T) {
 func TestAccepting(t *testing.T) {
 	tr := newTransport(t, nil)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"))
 	require.NoError(t, err)
 	done := make(chan struct{})
 	go func() {
@@ -100,7 +90,7 @@ func TestAccepting(t *testing.T) {
 func TestAcceptAfterClose(t *testing.T) {
 	tr := newTransport(t, nil)
 	defer tr.(io.Closer).Close()
-	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic"))
+	ln, err := tr.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"))
 	require.NoError(t, err)
 	require.NoError(t, ln.Close())
 	_, err = ln.Accept()
@@ -112,23 +102,15 @@ func TestCorrectNumberOfVirtualListeners(t *testing.T) {
 	tpt := tr.(*transport)
 	defer tr.(io.Closer).Close()
 
-	localAddr := ma.StringCast("/ip4/127.0.0.1/udp/0/quic")
-	udpAddr, _, err := quicreuse.FromQuicMultiaddr(localAddr)
-	require.NoError(t, err)
-
-	ln, err := tr.Listen(localAddr)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(tpt.listeners[udpAddr.String()]))
 	localAddrV1 := ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")
-	ln2, err := tr.Listen(localAddrV1)
+	ln, err := tr.Listen(localAddrV1)
+	require.NoError(t, err)
+	udpAddr, _, err := quicreuse.FromQuicMultiaddr(localAddrV1)
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	require.Equal(t, 2, len(tpt.listeners[udpAddr.String()]))
-
-	ln.Close()
 	require.Equal(t, 1, len(tpt.listeners[udpAddr.String()]))
-	ln2.Close()
+	ln.Close()
 	require.Equal(t, 0, len(tpt.listeners[udpAddr.String()]))
 
 }

--- a/p2p/transport/quic/transport_test.go
+++ b/p2p/transport/quic/transport_test.go
@@ -30,13 +30,10 @@ func TestQUICProtocol(t *testing.T) {
 	defer tr.(io.Closer).Close()
 
 	protocols := tr.Protocols()
-	if len(protocols) > 2 {
-		t.Fatalf("expected at most two protocols, got %v", protocols)
+	if len(protocols) > 1 {
+		t.Fatalf("expected at most one protocol, got %v", protocols)
 	}
-	if protocols[0] != ma.P_QUIC {
-		t.Fatalf("expected the supported protocol to be draft 29 QUIC, got %d", protocols[0])
-	}
-	if protocols[1] != ma.P_QUIC_V1 {
+	if protocols[0] != ma.P_QUIC_V1 {
 		t.Fatalf("expected the supported protocol to be QUIC v1, got %d", protocols[0])
 	}
 }
@@ -48,11 +45,11 @@ func TestCanDial(t *testing.T) {
 	invalid := []string{
 		"/ip4/127.0.0.1/udp/1234",
 		"/ip4/5.5.5.5/tcp/1234",
-		"/dns/google.com/udp/443/quic",
+		"/dns/google.com/udp/443/quic-v1",
 	}
 	valid := []string{
-		"/ip4/127.0.0.1/udp/1234/quic",
-		"/ip4/5.5.5.5/udp/0/quic",
+		"/ip4/127.0.0.1/udp/1234/quic-v1",
+		"/ip4/5.5.5.5/udp/0/quic-v1",
 	}
 	for _, s := range invalid {
 		invalidAddr, err := ma.NewMultiaddr(s)

--- a/p2p/transport/quicreuse/config.go
+++ b/p2p/transport/quicreuse/config.go
@@ -17,7 +17,7 @@ var quicConfig = &quic.Config{
 		return false
 	},
 	KeepAlivePeriod: 15 * time.Second,
-	Versions:        []quic.VersionNumber{quic.VersionDraft29, quic.Version1},
+	Versions:        []quic.VersionNumber{quic.Version1},
 	// We don't use datagrams (yet), but this is necessary for WebTransport
 	EnableDatagrams: true,
 	// The multiaddress encodes the QUIC version, thus there's no need to send Version Negotiation packets.

--- a/p2p/transport/quicreuse/connmgr_test.go
+++ b/p2p/transport/quicreuse/connmgr_test.go
@@ -39,18 +39,6 @@ func checkClosed(t *testing.T, cm *ConnManager) {
 	require.Eventually(t, func() bool { return !isGarbageCollectorRunning() }, 200*time.Millisecond, 10*time.Millisecond)
 }
 
-func TestListenQUICDraft29Disabled(t *testing.T) {
-	cm, err := NewConnManager([32]byte{}, DisableDraft29(), DisableReuseport())
-	require.NoError(t, err)
-	defer cm.Close()
-	_, err = cm.ListenQUIC(ma.StringCast("/ip4/127.0.0.1/udp/0/quic"), &tls.Config{}, nil)
-	require.EqualError(t, err, "can't listen on `/quic` multiaddr (QUIC draft 29 version) when draft 29 support is disabled")
-	ln, err := cm.ListenQUIC(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"), &tls.Config{NextProtos: []string{"proto"}}, nil)
-	require.NoError(t, err)
-	require.NoError(t, ln.Close())
-	require.False(t, isGarbageCollectorRunning())
-}
-
 func TestListenOnSameProto(t *testing.T) {
 	t.Run("with reuseport", func(t *testing.T) {
 		testListenOnSameProto(t, true)

--- a/p2p/transport/quicreuse/listener.go
+++ b/p2p/transport/quicreuse/listener.go
@@ -38,20 +38,13 @@ type quicListener struct {
 	protocols   map[string]protoConf
 }
 
-func newQuicListener(tr refCountedQuicTransport, quicConfig *quic.Config, enableDraft29 bool) (*quicListener, error) {
+func newQuicListener(tr refCountedQuicTransport, quicConfig *quic.Config) (*quicListener, error) {
 	localMultiaddrs := make([]ma.Multiaddr, 0, 2)
 	a, err := ToQuicMultiaddr(tr.LocalAddr(), quic.Version1)
 	if err != nil {
 		return nil, err
 	}
 	localMultiaddrs = append(localMultiaddrs, a)
-	if enableDraft29 {
-		a, err := ToQuicMultiaddr(tr.LocalAddr(), quic.VersionDraft29)
-		if err != nil {
-			return nil, err
-		}
-		localMultiaddrs = append(localMultiaddrs, a)
-	}
 	cl := &quicListener{
 		protocols: map[string]protoConf{},
 		running:   make(chan struct{}),

--- a/p2p/transport/quicreuse/options.go
+++ b/p2p/transport/quicreuse/options.go
@@ -9,16 +9,6 @@ func DisableReuseport() Option {
 	}
 }
 
-// DisableDraft29 disables support for QUIC draft-29.
-// This option should be set, unless support for this legacy QUIC version is needed for backwards compatibility.
-// Support for QUIC draft-29 is already deprecated and will be removed in the future, see https://github.com/libp2p/go-libp2p/issues/1841.
-func DisableDraft29() Option {
-	return func(m *ConnManager) error {
-		m.enableDraft29 = false
-		return nil
-	}
-}
-
 // EnableMetrics enables Prometheus metrics collection.
 func EnableMetrics() Option {
 	return func(m *ConnManager) error {

--- a/p2p/transport/quicreuse/quic_multiaddr.go
+++ b/p2p/transport/quicreuse/quic_multiaddr.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	quicV1MA      = ma.StringCast("/quic-v1")
-	quicDraft29MA = ma.StringCast("/quic")
+	quicV1MA = ma.StringCast("/quic-v1")
 )
 
 func ToQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, error) {
@@ -20,8 +19,6 @@ func ToQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, err
 		return nil, err
 	}
 	switch version {
-	case quic.VersionDraft29:
-		return udpMA.Encapsulate(quicDraft29MA), nil
 	case quic.Version1:
 		return udpMA.Encapsulate(quicV1MA), nil
 	default:
@@ -34,9 +31,6 @@ func FromQuicMultiaddr(addr ma.Multiaddr) (*net.UDPAddr, quic.VersionNumber, err
 	var partsBeforeQUIC []ma.Multiaddr
 	ma.ForEach(addr, func(c ma.Component) bool {
 		switch c.Protocol().Code {
-		case ma.P_QUIC:
-			version = quic.VersionDraft29
-			return false
 		case ma.P_QUIC_V1:
 			version = quic.Version1
 			return false

--- a/p2p/transport/quicreuse/quic_multiaddr_test.go
+++ b/p2p/transport/quicreuse/quic_multiaddr_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestConvertToQuicMultiaddr(t *testing.T) {
 	addr := &net.UDPAddr{IP: net.IPv4(192, 168, 0, 42), Port: 1337}
-	maddr, err := ToQuicMultiaddr(addr, quic.VersionDraft29)
+	maddr, err := ToQuicMultiaddr(addr, quic.Version1)
 	require.NoError(t, err)
-	require.Equal(t, maddr.String(), "/ip4/192.168.0.42/udp/1337/quic")
+	require.Equal(t, maddr.String(), "/ip4/192.168.0.42/udp/1337/quic-v1")
 }
 
 func TestConvertToQuicV1Multiaddr(t *testing.T) {
@@ -21,16 +21,6 @@ func TestConvertToQuicV1Multiaddr(t *testing.T) {
 	maddr, err := ToQuicMultiaddr(addr, quic.Version1)
 	require.NoError(t, err)
 	require.Equal(t, maddr.String(), "/ip4/192.168.0.42/udp/1337/quic-v1")
-}
-
-func TestConvertFromQuicDraft29Multiaddr(t *testing.T) {
-	maddr, err := ma.NewMultiaddr("/ip4/192.168.0.42/udp/1337/quic")
-	require.NoError(t, err)
-	udpAddr, v, err := FromQuicMultiaddr(maddr)
-	require.NoError(t, err)
-	require.Equal(t, udpAddr.IP, net.IPv4(192, 168, 0, 42))
-	require.Equal(t, udpAddr.Port, 1337)
-	require.Equal(t, v, quic.VersionDraft29)
 }
 
 func TestConvertFromQuicV1Multiaddr(t *testing.T) {

--- a/test-plans/cmd/ping/main.go
+++ b/test-plans/cmd/ping/main.go
@@ -98,9 +98,6 @@ func main() {
 	case "tcp":
 		options = append(options, libp2p.Transport(tcp.NewTCPTransport))
 		listenAddr = fmt.Sprintf("/ip4/%s/tcp/0", ip)
-	case "quic":
-		options = append(options, libp2p.Transport(libp2pquic.NewTransport))
-		listenAddr = fmt.Sprintf("/ip4/%s/udp/0/quic", ip)
 	case "quic-v1":
 		options = append(options, libp2p.Transport(libp2pquic.NewTransport))
 		listenAddr = fmt.Sprintf("/ip4/%s/udp/0/quic-v1", ip)

--- a/test-plans/ping-version.json
+++ b/test-plans/ping-version.json
@@ -5,7 +5,6 @@
         "tcp",
         "ws",
         "wss",
-        "quic",
         "quic-v1",
         "webtransport"
     ],


### PR DESCRIPTION
This does the minimal amount of changes to drop draft29 without updating quic-go.

I'm thinking, for now at least, that we'll leave machinery of the multiversion QUIC for a couple of reasons:

1. It'll make adding support for QUIC-v2 very easy.
  a. This would mostly be greasing exercise to avoid ossification on `quic-v1`. There's nothing QUIC-v2 gives us that we don't have with QUIC-v1.
2. It'll avoid us from reinventing this if we re-introduce this. This is tricky code and this code works and has been deployed for a bit.
3. It's stable as is, and a refactor would introduce more variables to the next release (already quite big with quic-go changes).