### PR TITLE
cleanup: add continue in case of failure in the (*BasicHost).Addrs certhash loop

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -792,10 +792,11 @@ func (h *BasicHost) Addrs() []ma.Multiaddr {
 				continue
 			}
 			addrWithCerthash, added := tpt.AddCertHashes(addr)
-			addrs[i] = addrWithCerthash
 			if !added {
 				log.Debug("Couldn't add certhashes to webtransport multiaddr because we aren't listening on webtransport")
+				continue
 			}
+			addrs[i] = addrWithCerthash
 		}
 	}
 	return addrs


### PR DESCRIPTION
This does not do change anything because the transport always returns the same multiaddr you passed in in case of failure, it just looks wrong and relies on a obscure detail of the webtransport's AddCertHashes function, while this does not.