### PR TITLE
perf: do not copy the addresses in (*BasicHost).Addrs

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -54,6 +54,7 @@ var (
 
 // AddrsFactory functions can be passed to New in order to override
 // addresses returned by Addrs.
+// AddrsFactories must not keep a reference to the returned slice.
 type AddrsFactory func([]ma.Multiaddr) []ma.Multiaddr
 
 // BasicHost is the basic implementation of the host.Host interface. This
@@ -778,11 +779,6 @@ func (h *BasicHost) Addrs() []ma.Multiaddr {
 	if !ok {
 		return addrs
 	}
-
-	// Copy addrs slice since we'll be modifying it.
-	addrsOld := addrs
-	addrs = make([]ma.Multiaddr, len(addrsOld))
-	copy(addrs, addrsOld)
 
 	for i, addr := range addrs {
 		if ok, n := libp2pwebtransport.IsWebtransportMultiaddr(addr); ok && n == 0 {


### PR DESCRIPTION
We do not need to copy the addresses here because AllAddrs already copies and returns a unique slice. We assume that AddrsFactory will do the same and add documentaion saying so.