### PR TITLE
ci: limit interop tests runs to core folders

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -1,9 +1,22 @@
 name: Interoperability Testing
 on:
+  workflow_dispatch:
   pull_request:
+    paths:
+      - 'config/**'
+      - 'core/**'
+      - 'internal/**'
+      - 'p2p/**'
+      - 'test-plans/**'
   push:
     branches:
       - "master"
+    paths:
+      - 'config/**'
+      - 'core/**'
+      - 'internal/**'
+      - 'p2p/**'
+      - 'test-plans/**'
 
 jobs:
   run-multidim-interop:


### PR DESCRIPTION
Avoid running the interop tests on code changes to directories that do not need testing.
Ref: https://github.com/libp2p/test-plans/pull/272