### PR TITLE
metrics: fix resource manager dashboard name

### DIFF
--- a/dashboards/resource-manager/resource-manager.json
+++ b/dashboards/resource-manager/resource-manager.json
@@ -1811,7 +1811,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Resource Manager",
+  "title": "go-libp2p Resource Manager",
   "uid": "MgmGIjjnj",
   "version": 1,
   "weekStart": ""


### PR DESCRIPTION
Introduced in https://github.com/libp2p/go-libp2p/pull/2512 where I prefixed all dashboard names with `go-` 

