### PR TITLE
identify: disable racy test when running with race detector

### DIFF
--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -107,6 +107,9 @@ func emitAddrChangeEvt(t *testing.T, h host.Host) {
 // this is because it used to be concurrent. Now, Dial wait till the
 // id service is done.
 func TestIDService(t *testing.T) {
+	if race.WithRace() {
+		t.Skip("This test modifies peerstore.RecentlyConnectedAddrTTL, which is racy.")
+	}
 	// This test is highly timing dependent, waiting on timeouts/expiration.
 	oldTTL := peerstore.RecentlyConnectedAddrTTL
 	peerstore.RecentlyConnectedAddrTTL = 500 * time.Millisecond


### PR DESCRIPTION
I suspect there's another test that's not shutting down cleanly, but I don't want to spend a lot of time debugging this.