### PR TITLE
host: disable black hole detection on autonat dialer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -419,6 +419,11 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			PeerKey:            autonatPrivKey,
 			Peerstore:          ps,
 			DialRanker:         swarm.NoDelayDialRanker,
+			SwarmOpts: []swarm.Option{
+				// It is better to disable black hole detection and just attempt a dial for autonat
+				swarm.WithUDPBlackHoleConfig(false, 0, 0),
+				swarm.WithIPv6BlackHoleConfig(false, 0, 0),
+			},
 		}
 
 		dialer, err := autoNatCfg.makeSwarm(eventbus.NewBus(), false)


### PR DESCRIPTION
If the autonat server receives too many requests from private nodes, this can cause the autonat server to incorrectly skip QUIC or IPv6 dial back requests. 

Fixes: #2530 