### PR TITLE
basichost: don't wait for Identify

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -736,20 +736,8 @@ func (h *BasicHost) Connect(ctx context.Context, pi peer.AddrInfo) error {
 // the connection once it has been opened.
 func (h *BasicHost) dialPeer(ctx context.Context, p peer.ID) error {
 	log.Debugf("host %s dialing %s", h.ID(), p)
-	c, err := h.Network().DialPeer(ctx, p)
-	if err != nil {
+	if _, err := h.Network().DialPeer(ctx, p); err != nil {
 		return fmt.Errorf("failed to dial: %w", err)
-	}
-
-	// TODO: Consider removing this? On one hand, it's nice because we can
-	// assume that things like the agent version are usually set when this
-	// returns. On the other hand, we don't _really_ need to wait for this.
-	//
-	// This is mostly here to preserve existing behavior.
-	select {
-	case <-h.ids.IdentifyWait(c):
-	case <-ctx.Done():
-		return fmt.Errorf("identify failed to complete: %w", ctx.Err())
 	}
 
 	log.Debugf("host %s finished dialing %s", h.ID(), p)

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/connmgr"
@@ -646,12 +647,32 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
 
-	pref, err := h.preferredProtocol(p, pids)
-	if err != nil {
-		_ = s.Reset()
-		return nil, err
-	}
+	// If pids contains only a single protocol, optimistically use that protocol (i.e. don't wait for
+	// multistream negotiation).
+	var pref protocol.ID
+	if len(pids) == 1 {
+		pref = pids[0]
+	} else if len(pids) > 1 {
+		// Wait for any in-progress identifies on the connection to finish.
+		// This is faster than negotiating.
+		// If the other side doesn't support identify, that's fine. This will just be a no-op.
+		select {
+		case <-h.ids.IdentifyWait(s.Conn()):
+		case <-ctx.Done():
+			_ = s.Reset()
+			return nil, fmt.Errorf("identify failed to complete: %w", ctx.Err())
+		}
 
+		// If Identify has finished, we know which protocols the peer supports.
+		// We don't need to do a multistream negotiation.
+		// Instead, we just pick the first supported protocol.
+		var err error
+		pref, err = h.preferredProtocol(p, pids)
+		if err != nil {
+			_ = s.Reset()
+			return nil, err
+		}
+	}
 	if pref != "" {
 		if err := s.SetProtocol(pref); err != nil {
 			return nil, err
@@ -1025,14 +1046,26 @@ func (h *BasicHost) Close() error {
 type streamWrapper struct {
 	network.Stream
 	rw io.ReadWriteCloser
+
+	calledRead atomic.Bool
 }
 
 func (s *streamWrapper) Read(b []byte) (int, error) {
-	return s.rw.Read(b)
+	n, err := s.rw.Read(b)
+	if s.calledRead.CompareAndSwap(false, true) {
+		if errors.Is(err, network.ErrReset) {
+			return n, msmux.ErrNotSupported[protocol.ID]{Protos: []protocol.ID{s.Protocol()}}
+		}
+	}
+	return n, err
 }
 
 func (s *streamWrapper) Write(b []byte) (int, error) {
-	return s.rw.Write(b)
+	n, err := s.rw.Write(b)
+	if s.calledRead.Load() && errors.Is(err, network.ErrReset) {
+		return n, msmux.ErrNotSupported[protocol.ID]{Protos: []protocol.ID{s.Protocol()}}
+	}
+	return n, err
 }
 
 func (s *streamWrapper) Close() error {

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -646,18 +646,6 @@ func (h *BasicHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.I
 		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
 
-	// Wait for any in-progress identifies on the connection to finish. This
-	// is faster than negotiating.
-	//
-	// If the other side doesn't support identify, that's fine. This will
-	// just be a no-op.
-	select {
-	case <-h.ids.IdentifyWait(s.Conn()):
-	case <-ctx.Done():
-		_ = s.Reset()
-		return nil, fmt.Errorf("identify failed to complete: %w", ctx.Err())
-	}
-
 	pref, err := h.preferredProtocol(p, pids)
 	if err != nil {
 		_ = s.Reset()

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -713,13 +713,12 @@ func TestHostAddrChangeDetection(t *testing.T) {
 }
 
 func TestNegotiationCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	h1, h2 := getHostPair(t)
 	defer h1.Close()
 	defer h2.Close()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// pre-negotiation so we can make the negotiation hang.
 	h2.Network().SetStreamHandler(func(s network.Stream) {
 		<-ctx.Done() // wait till the test is done.
@@ -731,7 +730,7 @@ func TestNegotiationCancel(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		s, err := h1.NewStream(ctx2, h2.ID(), "/testing")
+		s, err := h1.NewStream(ctx2, h2.ID(), "/testing", "/testing2")
 		if s != nil {
 			errCh <- fmt.Errorf("expected to fail negotiation")
 			return

--- a/p2p/protocol/circuitv2/client/reservation.go
+++ b/p2p/protocol/circuitv2/client/reservation.go
@@ -89,7 +89,7 @@ func Reserve(ctx context.Context, h host.Host, ai peer.AddrInfo) (*Reservation, 
 
 	if err := rd.ReadMsg(&msg); err != nil {
 		s.Reset()
-		return nil, ReservationError{Status: pbv2.Status_CONNECTION_FAILED, Reason: "error reading reservation response message: %w", err: err}
+		return nil, ReservationError{Status: pbv2.Status_CONNECTION_FAILED, Reason: "error reading reservation response message", err: err}
 	}
 
 	if msg.GetType() != pbv2.HopMessage_STATUS {

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -340,9 +340,10 @@ func TestFailuresOnResponder(t *testing.T) {
 			defer relay.Close()
 
 			s, err := h2.NewStream(network.WithUseTransient(context.Background(), "holepunch"), h1.ID(), holepunch.Protocol)
-			require.NoError(t, err)
-
-			go tc.initiator(s)
+			// h1 will reset the stream. This might or might not happen before multistream has finished.
+			if err == nil {
+				go tc.initiator(s)
+			}
 
 			getTracerError := func(tr *mockEventTracer) []string {
 				var errs []string

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -123,7 +123,8 @@ func TestDirectDialWorks(t *testing.T) {
 	require.Empty(t, h1.Network().ConnsToPeer(h2.ID()))
 	require.NoError(t, h1ps.DirectConnect(h2.ID()))
 	require.GreaterOrEqual(t, len(h1.Network().ConnsToPeer(h2.ID())), 1)
-	require.GreaterOrEqual(t, len(h2.Network().ConnsToPeer(h1.ID())), 1)
+	// h1 might finish the handshake first, but h2 should see the connection shortly after
+	require.Eventually(t, func() bool { return len(h2.Network().ConnsToPeer(h1.ID())) > 0 }, time.Second, 25*time.Millisecond)
 	events := tr.getEvents()
 	require.Len(t, events, 1)
 	require.Equal(t, holepunch.DirectDialEvtT, events[0].Type)
@@ -488,6 +489,7 @@ func makeRelayedHosts(t *testing.T, h1opt, h2opt []holepunch.Option, addHolePunc
 		ID:    h2.ID(),
 		Addrs: []ma.Multiaddr{raddr},
 	}))
+	require.Eventually(t, func() bool { return len(h2.Network().ConnsToPeer(h1.ID())) > 0 }, time.Second, 50*time.Millisecond)
 	return
 }
 

--- a/p2p/test/quic/quic_test.go
+++ b/p2p/test/quic/quic_test.go
@@ -61,6 +61,7 @@ func TestQUICAndWebTransport(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, h2.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}))
+	require.Eventually(t, func() bool { return len(h1.Network().ConnsToPeer(h2.ID())) > 0 }, time.Second, 25*time.Millisecond)
 	for _, conns := range [][]network.Conn{h2.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h2.ID())} {
 		require.Len(t, conns, 1)
 		if _, err := conns[0].LocalMultiaddr().ValueForProtocol(ma.P_WEBTRANSPORT); err == nil {
@@ -78,6 +79,7 @@ func TestQUICAndWebTransport(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, h3.Connect(ctx, peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}))
+	require.Eventually(t, func() bool { return len(h1.Network().ConnsToPeer(h3.ID())) > 0 }, time.Second, 25*time.Millisecond)
 	for _, conns := range [][]network.Conn{h3.Network().ConnsToPeer(h1.ID()), h1.Network().ConnsToPeer(h3.ID())} {
 		require.Len(t, conns, 1)
 		if _, err := conns[0].LocalMultiaddr().ValueForProtocol(ma.P_WEBTRANSPORT); err != nil {

--- a/p2p/test/transport/gating_test.go
+++ b/p2p/test/transport/gating_test.go
@@ -181,7 +181,8 @@ func TestInterceptAccept(t *testing.T) {
 			}
 
 			h1.Peerstore().AddAddrs(h2.ID(), h2.Addrs(), time.Hour)
-			_, err := h1.NewStream(ctx, h2.ID(), protocol.TestingID)
+			// use two protocols here, so we actually enter multistream negotiation
+			_, err := h1.NewStream(ctx, h2.ID(), protocol.TestingID, protocol.TestingID)
 			require.Error(t, err)
 			if _, err := h2.Addrs()[0].ValueForProtocol(ma.P_WEBRTC_DIRECT); err != nil {
 				// WebRTC rejects connection attempt before an error can be sent to the client.
@@ -218,7 +219,8 @@ func TestInterceptSecuredIncoming(t *testing.T) {
 				}),
 			)
 			h1.Peerstore().AddAddrs(h2.ID(), h2.Addrs(), time.Hour)
-			_, err := h1.NewStream(ctx, h2.ID(), protocol.TestingID)
+			// use two protocols here, so we actually enter multistream negotiation
+			_, err := h1.NewStream(ctx, h2.ID(), protocol.TestingID, protocol.TestingID)
 			require.Error(t, err)
 			require.NotErrorIs(t, err, context.DeadlineExceeded)
 		})
@@ -254,7 +256,8 @@ func TestInterceptUpgradedIncoming(t *testing.T) {
 				}),
 			)
 			h1.Peerstore().AddAddrs(h2.ID(), h2.Addrs(), time.Hour)
-			_, err := h1.NewStream(ctx, h2.ID(), protocol.TestingID)
+			// use two protocols here, so we actually enter multistream negotiation
+			_, err := h1.NewStream(ctx, h2.ID(), protocol.TestingID, protocol.TestingID)
 			require.Error(t, err)
 			require.NotErrorIs(t, err, context.DeadlineExceeded)
 		})

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -549,14 +549,19 @@ func TestListenerStreamResets(t *testing.T) {
 			}))
 
 			h1.SetStreamHandler("reset", func(s network.Stream) {
+				// Make sure the multistream negotiation actually succeeds before resetting.
+				// This is necessary because we don't have stream error codes yet.
+				s.Read(make([]byte, 4))
+				s.Write([]byte("pong"))
+				s.Read(make([]byte, 4))
 				s.Reset()
 			})
 
 			s, err := h2.NewStream(context.Background(), h1.ID(), "reset")
-			if err != nil {
-				require.ErrorIs(t, err, network.ErrReset)
-				return
-			}
+			require.NoError(t, err)
+			s.Write([]byte("ping"))
+			s.Read(make([]byte, 4))
+			s.Write([]byte("ping"))
 
 			_, err = s.Read([]byte{0})
 			require.ErrorIs(t, err, network.ErrReset)


### PR DESCRIPTION
By not waiting for Identify to finish we save 1 RTT during connection establishment. Establishing a QUIC connection now only takes a single roundtrip.

Multistream is (again) giving us a hard time here, mostly due to https://github.com/multiformats/go-multistream/issues/20, and due to the lack of stream reset error codes. The situation is expected to improve once we introduce and roll out error codes (https://github.com/libp2p/specs/issues/479).