### PR TITLE
libp2phttp: don't strip `/` suffix when mounting handler

### DIFF
--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -370,7 +370,9 @@ func (h *Host) SetHTTPHandlerAtPath(p protocol.ID, path string, handler http.Han
 	}
 	h.WellKnownHandler.AddProtocolMeta(p, ProtocolMeta{Path: path})
 	h.serveMuxInit()
-	h.ServeMux.Handle(path, http.StripPrefix(path, handler))
+	// Do not trim the trailing / from path
+	// This allows us to serve `/a/b` when we mount a handler for `/b` at path `/a`
+	h.ServeMux.Handle(path, http.StripPrefix(strings.TrimSuffix(path, "/"), handler))
 }
 
 // PeerMetadataGetter lets RoundTrippers implement a specific way of caching a peer's protocol mapping.


### PR DESCRIPTION
This allows us to serve `/a/b` when we mount a `http.ServeMux` handler for `/b` on a libp2phost at path `/a`.
Currently this is a 404 as `/a/b` will reach the handler for `/b` with the url `b` as we strip `/a/`.
The paths on a `ServeMux` have to begin with `/` as `cleanPath` [here](https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/http/server.go;l=2345) will add the prefix `/` and then the comparison [here](https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/http/server.go;l=2475-2479) will redirect to the cleaned path. This redirect will cause a 404. See the added test and linked issue for details. 

There is an annoying case [though](https://github.com/libp2p/go-libp2p/pull/2552/files#r1314250807), 

closes: #2545 
