### PR TITLE
examples: stop using deprecated peer.ID.Pretty

### DIFF
--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -111,7 +111,7 @@ func main() {
 	// This function is called when a peer initiates a connection and starts a stream with this peer.
 	host.SetStreamHandler(protocol.ID(cfg.ProtocolID), handleStream)
 
-	fmt.Printf("\n[*] Your Multiaddress Is: /ip4/%s/tcp/%v/p2p/%s\n", cfg.listenHost, cfg.listenPort, host.ID().Pretty())
+	fmt.Printf("\n[*] Your Multiaddress Is: /ip4/%s/tcp/%v/p2p/%s\n", cfg.listenHost, cfg.listenPort, host.ID())
 
 	peerChan := initMDNS(host, cfg.RendezvousString)
 	for { // allows multiple peers to join

--- a/examples/chat/chat.go
+++ b/examples/chat/chat.go
@@ -187,7 +187,7 @@ func startPeer(ctx context.Context, h host.Host, streamHandler network.StreamHan
 		return
 	}
 
-	log.Printf("Run './chat -d /ip4/127.0.0.1/tcp/%v/p2p/%s' on another console.\n", port, h.ID().Pretty())
+	log.Printf("Run './chat -d /ip4/127.0.0.1/tcp/%v/p2p/%s' on another console.\n", port, h.ID())
 	log.Println("You can replace 127.0.0.1 with public IP as well.")
 	log.Println("Waiting for incoming connection")
 	log.Println()

--- a/examples/chat/chat_test.go
+++ b/examples/chat/chat_test.go
@@ -49,7 +49,7 @@ func TestMain(t *testing.T) {
 			cancel() // end the test
 		})
 
-		dest := fmt.Sprintf("/ip4/127.0.0.1/tcp/%v/p2p/%s", port1, h1.ID().Pretty())
+		dest := fmt.Sprintf("/ip4/127.0.0.1/tcp/%v/p2p/%s", port1, h1.ID())
 
 		h2, err := makeHost(port2, rand.Reader)
 		if err != nil {

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -88,7 +88,7 @@ func makeBasicHost(listenPort int, insecure bool, randseed int64) (host.Host, er
 
 func getHostAddress(ha host.Host) string {
 	// Build host multiaddress
-	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", ha.ID().Pretty()))
+	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", ha.ID()))
 
 	// Now we can build a full multiaddress to reach this host
 	// by encapsulating both addresses:

--- a/examples/http-proxy/proxy.go
+++ b/examples/http-proxy/proxy.go
@@ -144,7 +144,7 @@ func (p *ProxyService) Serve() {
 // Streams are multiplexed over single connections so, unlike connections
 // themselves, they are cheap to create and dispose of.
 func (p *ProxyService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("proxying request for %s to peer %s\n", r.URL, p.dest.Pretty())
+	fmt.Printf("proxying request for %s to peer %s\n", r.URL, p.dest)
 	// We need to send the request to the remote libp2p peer, so
 	// we open a stream to it
 	stream, err := p.host.NewStream(context.Background(), p.dest, Protocol)

--- a/examples/pubsub/basic-chat-with-rendezvous/main.go
+++ b/examples/pubsub/basic-chat-with-rendezvous/main.go
@@ -95,9 +95,9 @@ func discoverPeers(ctx context.Context, h host.Host) {
 			}
 			err := h.Connect(ctx, peer)
 			if err != nil {
-				fmt.Println("Failed connecting to ", peer.ID.Pretty(), ", error:", err)
+				fmt.Printf("Failed connecting to %s, error: %s\n", peer.ID, err)
 			} else {
-				fmt.Println("Connected to:", peer.ID.Pretty())
+				fmt.Println("Connected to:", peer.ID)
 				anyConnected = true
 			}
 		}

--- a/examples/pubsub/chat/README.md
+++ b/examples/pubsub/chat/README.md
@@ -132,7 +132,7 @@ to the `pubsub.Topic`:
 func (cr *ChatRoom) Publish(message string) error {
 	m := ChatMessage{
 		Message:    message,
-		SenderID:   cr.self.Pretty(),
+		SenderID:   cr.self.String(),
 		SenderNick: cr.nick,
 	}
 	msgBytes, err := json.Marshal(m)

--- a/examples/pubsub/chat/chatroom.go
+++ b/examples/pubsub/chat/chatroom.go
@@ -71,7 +71,7 @@ func JoinChatRoom(ctx context.Context, ps *pubsub.PubSub, selfID peer.ID, nickna
 func (cr *ChatRoom) Publish(message string) error {
 	m := ChatMessage{
 		Message:    message,
-		SenderID:   cr.self.Pretty(),
+		SenderID:   cr.self.String(),
 		SenderNick: cr.nick,
 	}
 	msgBytes, err := json.Marshal(m)

--- a/examples/pubsub/chat/main.go
+++ b/examples/pubsub/chat/main.go
@@ -80,7 +80,7 @@ func defaultNick(p peer.ID) string {
 
 // shortID returns the last 8 chars of a base58-encoded peer id.
 func shortID(p peer.ID) string {
-	pretty := p.Pretty()
+	pretty := p.String()
 	return pretty[len(pretty)-8:]
 }
 
@@ -93,10 +93,10 @@ type discoveryNotifee struct {
 // the PubSub system will automatically start interacting with them if they also
 // support PubSub.
 func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
-	fmt.Printf("discovered new peer %s\n", pi.ID.Pretty())
+	fmt.Printf("discovered new peer %s\n", pi.ID)
 	err := n.h.Connect(context.Background(), pi)
 	if err != nil {
-		fmt.Printf("error connecting to peer %s: %s\n", pi.ID.Pretty(), err)
+		fmt.Printf("error connecting to peer %s: %s\n", pi.ID, err)
 	}
 }
 

--- a/examples/routed-echo/main.go
+++ b/examples/routed-echo/main.go
@@ -83,7 +83,7 @@ func makeRoutedHost(listenPort int, randseed int64, bootstrapPeers []peer.AddrIn
 	}
 
 	// Build host multiaddress
-	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", routedHost.ID().Pretty()))
+	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", routedHost.ID()))
 
 	// Now we can build a full multiaddress to reach this host
 	// by encapsulating both addresses:
@@ -94,7 +94,7 @@ func makeRoutedHost(listenPort int, randseed int64, bootstrapPeers []peer.AddrIn
 		log.Println(addr.Encapsulate(hostAddr))
 	}
 
-	log.Printf("Now run \"./routed-echo -l %d -d %s%s\" on a different terminal\n", listenPort+1, routedHost.ID().Pretty(), globalFlag)
+	log.Printf("Now run \"./routed-echo -l %d -d %s%s\" on a different terminal\n", listenPort+1, routedHost.ID(), globalFlag)
 
 	return routedHost, nil
 }


### PR DESCRIPTION
The peerID Pretty method is already deprecated, switch it to call String method.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)