### PR TITLE
core/peer: remove deprecated ID.Pretty method

### DIFF
--- a/core/peer/addrinfo.go
+++ b/core/peer/addrinfo.go
@@ -102,7 +102,7 @@ func AddrInfoToP2pAddrs(pi *AddrInfo) ([]ma.Multiaddr, error) {
 
 func (pi *AddrInfo) Loggable() map[string]interface{} {
 	return map[string]interface{}{
-		"peerID": pi.ID.Pretty(),
+		"peerID": pi.ID.String(),
 		"addrs":  pi.Addrs,
 	}
 }

--- a/core/peer/addrinfo_test.go
+++ b/core/peer/addrinfo_test.go
@@ -3,9 +3,9 @@ package peer_test
 import (
 	"testing"
 
-	ma "github.com/multiformats/go-multiaddr"
-
 	. "github.com/libp2p/go-libp2p/core/peer"
+
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 var (
@@ -115,7 +115,7 @@ func TestAddrInfosFromP2pAddrs(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, info := range infos {
-		exaddrs, ok := expected[info.ID.Pretty()]
+		exaddrs, ok := expected[info.ID.String()]
 		if !ok {
 			t.Fatalf("didn't expect peer %s", info.ID)
 		}
@@ -129,7 +129,7 @@ func TestAddrInfosFromP2pAddrs(t *testing.T) {
 				t.Fatalf("expected %s, got %s", exaddrs[i], addr)
 			}
 		}
-		delete(expected, info.ID.Pretty())
+		delete(expected, info.ID.String())
 	}
 }
 
@@ -144,7 +144,7 @@ func TestAddrInfoJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if addrInfo.ID != testID {
-		t.Fatalf("expected ID to equal %s, got %s", testID.Pretty(), addrInfo.ID.Pretty())
+		t.Fatalf("expected ID to equal %s, got %s", testID, addrInfo.ID)
 	}
 	if len(addrInfo.Addrs) != 1 || !addrInfo.Addrs[0].Equal(maddrFull) {
 		t.Fatalf("expected addrs to match %v, got %v", maddrFull, addrInfo.Addrs)

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -41,12 +41,6 @@ const maxInlineKeyLength = 42
 // hash output as a multihash. See IDFromPublicKey for details.
 type ID string
 
-// Pretty returns a base58-encoded string representation of the ID.
-// Deprecated: use String() instead.
-func (id ID) Pretty() string {
-	return id.String()
-}
-
 // Loggable returns a pretty peer ID string in loggable JSON format.
 func (id ID) Loggable() map[string]interface{} {
 	return map[string]interface{}{

--- a/p2p/host/autonat/svc.go
+++ b/p2p/host/autonat/svc.go
@@ -68,7 +68,7 @@ func (as *autoNATService) handleStream(s network.Stream) {
 	defer s.Close()
 
 	pid := s.Conn().RemotePeer()
-	log.Debugf("New stream from %s", pid.Pretty())
+	log.Debugf("New stream from %s", pid)
 
 	r := pbio.NewDelimitedReader(s, maxMsgSize)
 	w := pbio.NewDelimitedWriter(s)
@@ -78,14 +78,14 @@ func (as *autoNATService) handleStream(s network.Stream) {
 
 	err := r.ReadMsg(&req)
 	if err != nil {
-		log.Debugf("Error reading message from %s: %s", pid.Pretty(), err.Error())
+		log.Debugf("Error reading message from %s: %s", pid, err.Error())
 		s.Reset()
 		return
 	}
 
 	t := req.GetType()
 	if t != pb.Message_DIAL {
-		log.Debugf("Unexpected message from %s: %s (%d)", pid.Pretty(), t.String(), t)
+		log.Debugf("Unexpected message from %s: %s (%d)", pid, t.String(), t)
 		s.Reset()
 		return
 	}
@@ -96,7 +96,7 @@ func (as *autoNATService) handleStream(s network.Stream) {
 
 	err = w.WriteMsg(&res)
 	if err != nil {
-		log.Debugf("Error writing response to %s: %s", pid.Pretty(), err.Error())
+		log.Debugf("Error writing response to %s: %s", pid, err.Error())
 		s.Reset()
 		return
 	}
@@ -234,7 +234,7 @@ func (as *autoNATService) doDial(pi peer.AddrInfo) *pb.Message_DialResponse {
 
 	conn, err := as.config.dialer.DialPeer(ctx, pi.ID)
 	if err != nil {
-		log.Debugf("error dialing %s: %s", pi.ID.Pretty(), err.Error())
+		log.Debugf("error dialing %s: %s", pi.ID, err.Error())
 		// wait for the context to timeout to avoid leaking timing information
 		// this renders the service ineffective as a port scanner
 		<-ctx.Done()

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -736,7 +736,7 @@ func (rf *relayFinder) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	for p := range rf.relays {
 		addrs := cleanupAddressSet(rf.host.Peerstore().Addrs(p))
 		relayAddrCnt += len(addrs)
-		circuit := ma.StringCast(fmt.Sprintf("/p2p/%s/p2p-circuit", p.Pretty()))
+		circuit := ma.StringCast(fmt.Sprintf("/p2p/%s/p2p-circuit", p))
 		for _, addr := range addrs {
 			pub := addr.Encapsulate(circuit)
 			raddrs = append(raddrs, pub)

--- a/p2p/host/peerstore/pstoreds/addr_book.go
+++ b/p2p/host/peerstore/pstoreds/addr_book.go
@@ -362,7 +362,7 @@ func (ab *dsAddrBook) storeSignedPeerRecord(p peer.ID, envelope *record.Envelope
 func (ab *dsAddrBook) GetPeerRecord(p peer.ID) *record.Envelope {
 	pr, err := ab.loadRecord(p, true, false)
 	if err != nil {
-		log.Errorf("unable to load record for peer %s: %v", p.Pretty(), err)
+		log.Errorf("unable to load record for peer %s: %v", p, err)
 		return nil
 	}
 	pr.RLock()
@@ -372,7 +372,7 @@ func (ab *dsAddrBook) GetPeerRecord(p peer.ID) *record.Envelope {
 	}
 	state, _, err := record.ConsumeEnvelope(pr.CertifiedRecord.Raw, peer.PeerRecordEnvelopeDomain)
 	if err != nil {
-		log.Errorf("error unmarshaling stored signed peer record for peer %s: %v", p.Pretty(), err)
+		log.Errorf("error unmarshaling stored signed peer record for peer %s: %v", p, err)
 		return nil
 	}
 	return state
@@ -398,7 +398,7 @@ func (ab *dsAddrBook) SetAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duratio
 func (ab *dsAddrBook) UpdateAddrs(p peer.ID, oldTTL time.Duration, newTTL time.Duration) {
 	pr, err := ab.loadRecord(p, true, false)
 	if err != nil {
-		log.Errorf("failed to update ttls for peer %s: %s\n", p.Pretty(), err)
+		log.Errorf("failed to update ttls for peer %s: %s\n", p, err)
 		return
 	}
 
@@ -423,7 +423,7 @@ func (ab *dsAddrBook) UpdateAddrs(p peer.ID, oldTTL time.Duration, newTTL time.D
 func (ab *dsAddrBook) Addrs(p peer.ID) []ma.Multiaddr {
 	pr, err := ab.loadRecord(p, true, true)
 	if err != nil {
-		log.Warn("failed to load peerstore entry for peer %v while querying addrs, err: %v", p, err)
+		log.Warnf("failed to load peerstore entry for peer %s while querying addrs, err: %v", p, err)
 		return nil
 	}
 
@@ -466,7 +466,7 @@ func (ab *dsAddrBook) ClearAddrs(p peer.ID) {
 
 	key := addrBookBase.ChildString(b32.RawStdEncoding.EncodeToString([]byte(p)))
 	if err := ab.ds.Delete(context.TODO(), key); err != nil {
-		log.Errorf("failed to clear addresses for peer %s: %v", p.Pretty(), err)
+		log.Errorf("failed to clear addresses for peer %s: %v", p, err)
 	}
 }
 
@@ -477,7 +477,7 @@ func (ab *dsAddrBook) setAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duratio
 
 	pr, err := ab.loadRecord(p, true, false)
 	if err != nil {
-		return fmt.Errorf("failed to load peerstore entry for peer %v while setting addrs, err: %v", p, err)
+		return fmt.Errorf("failed to load peerstore entry for peer %s while setting addrs, err: %v", p, err)
 	}
 
 	pr.Lock()

--- a/p2p/host/peerstore/pstoreds/addr_book_gc.go
+++ b/p2p/host/peerstore/pstoreds/addr_book_gc.go
@@ -215,7 +215,7 @@ func (gc *dsAddrBookGc) purgeLookahead() {
 			cached.Lock()
 			if cached.clean(gc.ab.clock.Now()) {
 				if err = cached.flush(batch); err != nil {
-					log.Warnf("failed to flush entry modified by GC for peer: &v, err: %v", id.Pretty(), err)
+					log.Warnf("failed to flush entry modified by GC for peer: %s, err: %v", id, err)
 				}
 			}
 			dropOrReschedule(gcKey, cached)
@@ -241,7 +241,7 @@ func (gc *dsAddrBookGc) purgeLookahead() {
 		if record.clean(gc.ab.clock.Now()) {
 			err = record.flush(batch)
 			if err != nil {
-				log.Warnf("failed to flush entry modified by GC for peer: &v, err: %v", id.Pretty(), err)
+				log.Warnf("failed to flush entry modified by GC for peer: %s, err: %v", id, err)
 			}
 		}
 		dropOrReschedule(gcKey, record)
@@ -353,7 +353,7 @@ func (gc *dsAddrBookGc) populateLookahead() {
 			}
 			gcKey := gcLookaheadBase.ChildString(fmt.Sprintf("%d/%s", cached.Addrs[0].Expiry, idb32))
 			if err = batch.Put(context.TODO(), gcKey, []byte{}); err != nil {
-				log.Warnf("failed while inserting GC entry for peer: %v, err: %v", id.Pretty(), err)
+				log.Warnf("failed while inserting GC entry for peer: %s, err: %v", id, err)
 			}
 			cached.RUnlock()
 			continue
@@ -363,17 +363,17 @@ func (gc *dsAddrBookGc) populateLookahead() {
 
 		val, err := gc.ab.ds.Get(context.TODO(), ds.RawKey(result.Key))
 		if err != nil {
-			log.Warnf("failed which getting record from store for peer: %v, err: %v", id.Pretty(), err)
+			log.Warnf("failed which getting record from store for peer: %s, err: %v", id, err)
 			continue
 		}
 		if err := proto.Unmarshal(val, record); err != nil {
-			log.Warnf("failed while unmarshalling record from store for peer: %v, err: %v", id.Pretty(), err)
+			log.Warnf("failed while unmarshalling record from store for peer: %s, err: %v", id, err)
 			continue
 		}
 		if len(record.Addrs) > 0 && record.Addrs[0].Expiry <= until {
 			gcKey := gcLookaheadBase.ChildString(fmt.Sprintf("%d/%s", record.Addrs[0].Expiry, idb32))
 			if err = batch.Put(context.TODO(), gcKey, []byte{}); err != nil {
-				log.Warnf("failed while inserting GC entry for peer: %v, err: %v", id.Pretty(), err)
+				log.Warnf("failed while inserting GC entry for peer: %s, err: %v", id, err)
 			}
 		}
 	}

--- a/p2p/host/peerstore/pstoreds/keybook.go
+++ b/p2p/host/peerstore/pstoreds/keybook.go
@@ -38,7 +38,7 @@ func (kb *dsKeyBook) PubKey(p peer.ID) ic.PubKey {
 	if value, err := kb.ds.Get(context.TODO(), key); err == nil {
 		pk, err = ic.UnmarshalPublicKey(value)
 		if err != nil {
-			log.Errorf("error when unmarshalling pubkey from datastore for peer %s: %s\n", p.Pretty(), err)
+			log.Errorf("error when unmarshalling pubkey from datastore for peer %s: %s\n", p, err)
 		}
 	} else if err == ds.ErrNotFound {
 		pk, err = p.ExtractPublicKey()
@@ -47,20 +47,20 @@ func (kb *dsKeyBook) PubKey(p peer.ID) ic.PubKey {
 		case peer.ErrNoPublicKey:
 			return nil
 		default:
-			log.Errorf("error when extracting pubkey from peer ID for peer %s: %s\n", p.Pretty(), err)
+			log.Errorf("error when extracting pubkey from peer ID for peer %s: %s\n", p, err)
 			return nil
 		}
 		pkb, err := ic.MarshalPublicKey(pk)
 		if err != nil {
-			log.Errorf("error when turning extracted pubkey into bytes for peer %s: %s\n", p.Pretty(), err)
+			log.Errorf("error when turning extracted pubkey into bytes for peer %s: %s\n", p, err)
 			return nil
 		}
 		if err := kb.ds.Put(context.TODO(), key, pkb); err != nil {
-			log.Errorf("error when adding extracted pubkey to peerstore for peer %s: %s\n", p.Pretty(), err)
+			log.Errorf("error when adding extracted pubkey to peerstore for peer %s: %s\n", p, err)
 			return nil
 		}
 	} else {
-		log.Errorf("error when fetching pubkey from datastore for peer %s: %s\n", p.Pretty(), err)
+		log.Errorf("error when fetching pubkey from datastore for peer %s: %s\n", p, err)
 	}
 
 	return pk
@@ -74,11 +74,11 @@ func (kb *dsKeyBook) AddPubKey(p peer.ID, pk ic.PubKey) error {
 
 	val, err := ic.MarshalPublicKey(pk)
 	if err != nil {
-		log.Errorf("error while converting pubkey byte string for peer %s: %s\n", p.Pretty(), err)
+		log.Errorf("error while converting pubkey byte string for peer %s: %s\n", p, err)
 		return err
 	}
 	if err := kb.ds.Put(context.TODO(), peerToKey(p, pubSuffix), val); err != nil {
-		log.Errorf("error while updating pubkey in datastore for peer %s: %s\n", p.Pretty(), err)
+		log.Errorf("error while updating pubkey in datastore for peer %s: %s\n", p, err)
 		return err
 	}
 	return nil
@@ -107,11 +107,11 @@ func (kb *dsKeyBook) AddPrivKey(p peer.ID, sk ic.PrivKey) error {
 
 	val, err := ic.MarshalPrivateKey(sk)
 	if err != nil {
-		log.Errorf("error while converting privkey byte string for peer %s: %s\n", p.Pretty(), err)
+		log.Errorf("error while converting privkey byte string for peer %s: %s\n", p, err)
 		return err
 	}
 	if err := kb.ds.Put(context.TODO(), peerToKey(p, privSuffix), val); err != nil {
-		log.Errorf("error while updating privkey in datastore for peer %s: %s\n", p.Pretty(), err)
+		log.Errorf("error while updating privkey in datastore for peer %s: %s\n", p, err)
 	}
 	return err
 }

--- a/p2p/host/peerstore/test/utils.go
+++ b/p2p/host/peerstore/test/utils.go
@@ -38,7 +38,7 @@ func RandomPeer(b *testing.B, addrCount int) *peerpair {
 	}
 
 	for i := 0; i < addrCount; i++ {
-		if addrs[i], err = ma.NewMultiaddr(fmt.Sprintf(aFmt, i, pid.Pretty())); err != nil {
+		if addrs[i], err = ma.NewMultiaddr(fmt.Sprintf(aFmt, i, pid)); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/p2p/net/connmgr/decay.go
+++ b/p2p/net/connmgr/decay.go
@@ -337,7 +337,7 @@ func (t *decayingTag) Remove(p peer.ID) error {
 	default:
 		return fmt.Errorf(
 			"unable to remove decaying tag for peer %s, tag %s; queue full (len=%d)",
-			p.String(), t.name, len(t.trkr.removeTagCh))
+			p, t.name, len(t.trkr.removeTagCh))
 	}
 }
 

--- a/p2p/net/connmgr/decay.go
+++ b/p2p/net/connmgr/decay.go
@@ -320,7 +320,7 @@ func (t *decayingTag) Bump(p peer.ID, delta int) error {
 	default:
 		return fmt.Errorf(
 			"unable to bump decaying tag for peer %s, tag %s, delta %d; queue full (len=%d)",
-			p.Pretty(), t.name, delta, len(t.trkr.bumpTagCh))
+			p, t.name, delta, len(t.trkr.bumpTagCh))
 	}
 }
 
@@ -337,7 +337,7 @@ func (t *decayingTag) Remove(p peer.ID) error {
 	default:
 		return fmt.Errorf(
 			"unable to remove decaying tag for peer %s, tag %s; queue full (len=%d)",
-			p.Pretty(), t.name, len(t.trkr.removeTagCh))
+			p.String(), t.name, len(t.trkr.removeTagCh))
 	}
 }
 

--- a/p2p/net/gostream/gostream_test.go
+++ b/p2p/net/gostream/gostream_test.go
@@ -51,7 +51,7 @@ func TestServerClient(t *testing.T) {
 		}
 		defer listener.Close()
 
-		if listener.Addr().String() != srvHost.ID().Pretty() {
+		if listener.Addr().String() != srvHost.ID().String() {
 			t.Error("bad listener address")
 			return
 		}
@@ -91,11 +91,11 @@ func TestServerClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if clientConn.LocalAddr().String() != clientHost.ID().Pretty() {
+	if clientConn.LocalAddr().String() != clientHost.ID().String() {
 		t.Fatal("Bad LocalAddr")
 	}
 
-	if clientConn.RemoteAddr().String() != srvHost.ID().Pretty() {
+	if clientConn.RemoteAddr().String() != srvHost.ID().String() {
 		t.Fatal("Bad RemoteAddr")
 	}
 

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -353,7 +353,7 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 			// TODO Send disconnect with reason here
 			err := tc.Close()
 			if err != nil {
-				log.Warnf("failed to close connection with peer %s and addr %s; err: %s", p.Pretty(), addr, err)
+				log.Warnf("failed to close connection with peer %s and addr %s; err: %s", p, addr, err)
 			}
 			return nil, ErrGaterDisallowedConnection
 		}

--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -49,7 +49,7 @@ func (c *Conn) IsClosed() bool {
 
 func (c *Conn) ID() string {
 	// format: <first 10 chars of peer id>-<global conn ordinal>
-	return fmt.Sprintf("%s-%d", c.RemotePeer().Pretty()[0:10], c.id)
+	return fmt.Sprintf("%s-%d", c.RemotePeer().String()[:10], c.id)
 }
 
 // Close closes this connection.
@@ -147,9 +147,9 @@ func (c *Conn) String() string {
 		"<swarm.Conn[%T] %s (%s) <-> %s (%s)>",
 		c.conn.Transport(),
 		c.conn.LocalMultiaddr(),
-		c.conn.LocalPeer().Pretty(),
+		c.conn.LocalPeer(),
 		c.conn.RemoteMultiaddr(),
-		c.conn.RemotePeer().Pretty(),
+		c.conn.RemotePeer(),
 	)
 }
 

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -254,7 +254,7 @@ func (s *Swarm) dialPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 	}
 
 	if s.gater != nil && !s.gater.InterceptPeerDial(p) {
-		log.Debugf("gater disallowed outbound connection to peer %s", p.Pretty())
+		log.Debugf("gater disallowed outbound connection to peer %s", p)
 		return nil, &DialError{Peer: p, Cause: ErrGaterDisallowedConnection}
 	}
 
@@ -343,7 +343,7 @@ func (s *Swarm) addrsForDial(ctx context.Context, p peer.ID) (goodAddrs []ma.Mul
 
 func (s *Swarm) resolveAddrs(ctx context.Context, pi peer.AddrInfo) ([]ma.Multiaddr, error) {
 	proto := ma.ProtocolWithCode(ma.P_P2P).Name
-	p2paddr, err := ma.NewMultiaddr("/" + proto + "/" + pi.ID.Pretty())
+	p2paddr, err := ma.NewMultiaddr("/" + proto + "/" + pi.ID.String())
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/net/swarm/swarm_dial_test.go
+++ b/p2p/net/swarm/swarm_dial_test.go
@@ -167,8 +167,8 @@ func TestAddrResolution(t *testing.T) {
 	addr1 := ma.StringCast("/dnsaddr/example.com")
 	addr2 := ma.StringCast("/ip4/192.0.2.1/tcp/123")
 
-	p2paddr2 := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p1.Pretty())
-	p2paddr3 := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p2.Pretty())
+	p2paddr2 := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p1.String())
+	p2paddr3 := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p2.String())
 
 	backend := &madns.MockResolver{
 		TXT: map[string][]string{"_dnsaddr.example.com": {
@@ -209,11 +209,11 @@ func TestAddrResolutionRecursive(t *testing.T) {
 	}
 	addr1 := ma.StringCast("/dnsaddr/example.com")
 	addr2 := ma.StringCast("/ip4/192.0.2.1/tcp/123")
-	p2paddr1 := ma.StringCast("/dnsaddr/example.com/p2p/" + p1.Pretty())
-	p2paddr2 := ma.StringCast("/dnsaddr/example.com/p2p/" + p2.Pretty())
-	p2paddr1i := ma.StringCast("/dnsaddr/foo.example.com/p2p/" + p1.Pretty())
-	p2paddr2i := ma.StringCast("/dnsaddr/bar.example.com/p2p/" + p2.Pretty())
-	p2paddr1f := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p1.Pretty())
+	p2paddr1 := ma.StringCast("/dnsaddr/example.com/p2p/" + p1.String())
+	p2paddr2 := ma.StringCast("/dnsaddr/example.com/p2p/" + p2.String())
+	p2paddr1i := ma.StringCast("/dnsaddr/foo.example.com/p2p/" + p1.String())
+	p2paddr2i := ma.StringCast("/dnsaddr/bar.example.com/p2p/" + p2.String())
+	p2paddr1f := ma.StringCast("/ip4/192.0.2.1/tcp/123/p2p/" + p1.String())
 
 	backend := &madns.MockResolver{
 		TXT: map[string][]string{

--- a/p2p/security/tls/cmd/tlsdiag/client.go
+++ b/p2p/security/tls/cmd/tlsdiag/client.go
@@ -33,7 +33,7 @@ func StartClient() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf(" Peer ID: %s\n", id.Pretty())
+	fmt.Printf(" Peer ID: %s\n", id)
 	tp, err := libp2ptls.New(libp2ptls.ID, priv, nil)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func StartClient() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Authenticated server: %s\n", sconn.RemotePeer().Pretty())
+	fmt.Printf("Authenticated server: %s\n", sconn.RemotePeer())
 	data, err := io.ReadAll(sconn)
 	if err != nil {
 		return err

--- a/p2p/security/tls/cmd/tlsdiag/server.go
+++ b/p2p/security/tls/cmd/tlsdiag/server.go
@@ -26,7 +26,7 @@ func StartServer() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf(" Peer ID: %s\n", id.Pretty())
+	fmt.Printf(" Peer ID: %s\n", id)
 	tp, err := libp2ptls.New(libp2ptls.ID, priv, nil)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func StartServer() error {
 	}
 	fmt.Printf("Listening for new connections on %s\n", ln.Addr())
 	fmt.Printf("Now run the following command in a separate terminal:\n")
-	fmt.Printf("\tgo run cmd/tlsdiag.go client -p %d -id %s\n", *port, id.Pretty())
+	fmt.Printf("\tgo run cmd/tlsdiag.go client -p %d -id %s\n", *port, id)
 
 	for {
 		conn, err := ln.Accept()
@@ -61,7 +61,7 @@ func handleConn(tp *libp2ptls.Transport, conn net.Conn) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Authenticated client: %s\n", sconn.RemotePeer().Pretty())
+	fmt.Printf("Authenticated client: %s\n", sconn.RemotePeer())
 	fmt.Fprintf(sconn, "Hello client!")
 	fmt.Printf("Closing connection to %s\n", conn.RemoteAddr())
 	return sconn.Close()

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -46,7 +46,7 @@ func createPeer(t *testing.T) (peer.ID, ic.PrivKey) {
 	require.NoError(t, err)
 	id, err := peer.IDFromPrivateKey(priv)
 	require.NoError(t, err)
-	t.Logf("using a %s key: %s", priv.Type(), id.Pretty())
+	t.Logf("using a %s key: %s", priv.Type(), id)
 	return id, priv
 }
 

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -55,7 +55,7 @@ func createPeer(t *testing.T) (peer.ID, ic.PrivKey) {
 	require.NoError(t, err)
 	id, err := peer.IDFromPrivateKey(priv)
 	require.NoError(t, err)
-	t.Logf("using a %s key: %s", priv.Type(), id.Pretty())
+	t.Logf("using a %s key: %s", priv.Type(), id)
 	return id, priv
 }
 


### PR DESCRIPTION
This method has been deprecated for more than a year now.