### PR TITLE
fixing NAT establish mapping logic

### DIFF
--- a/p2p/net/nat/nat.go
+++ b/p2p/net/nat/nat.go
@@ -236,6 +236,16 @@ func (nat *NAT) establishMapping(ctx context.Context, protocol string, internalP
 	if err != nil || externalPort == 0 {
 		// TODO: log.Event
 		if err != nil {
+			natInstance, errorDiscover := discoverGateway(ctx)
+			if errorDiscover == nil {
+				var extAddr netip.Addr
+				extIP, errorGetAddress := natInstance.GetExternalAddress()
+				if errorGetAddress == nil {
+					extAddr, _ = netip.AddrFromSlice(extIP)
+				}
+				nat.extAddr = extAddr
+				nat.nat = natInstance
+			}
 			log.Warnf("failed to establish port mapping: %s", err)
 		} else {
 			log.Warnf("failed to establish port mapping: newport = 0")


### PR DESCRIPTION
If the router's Internet connection is interrupted and then restored, upnp ports are not reopened. With this code, if an error occurs, an attempt is made to retrieve the ip address and all the necessary data to re-announce the upnp ports.
https://github.com/libp2p/go-libp2p/issues/2502