### PR TITLE
debug interop failure

### DIFF
--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -80,7 +80,7 @@ func (p *PingService) PingHandler(s network.Stream) {
 			errCh <- err
 			return
 		}
-
+		//		time.Sleep(5 * time.Second)
 		_, err = s.Write(buf)
 		if err != nil {
 			errCh <- err

--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -66,7 +66,7 @@ func (p *PingService) PingHandler(s network.Stream) {
 			log.Debug("ping timeout")
 		case err, ok := <-errCh:
 			if ok {
-				log.Debug(err)
+				log.Error("ping exit:", err)
 			} else {
 				log.Error("ping loop failed without error")
 			}

--- a/p2p/transport/webrtc/stream.go
+++ b/p2p/transport/webrtc/stream.go
@@ -170,6 +170,7 @@ func (s *stream) processIncomingFlag(flag *pb.Message_Flag) {
 		if s.receiveState == receiveStateReceiving {
 			s.receiveState = receiveStateDataRead
 		}
+		log.Errorln("received FIN", s.id)
 	case pb.Message_STOP_SENDING:
 		if s.sendState == sendStateSending {
 			s.sendState = sendStateReset

--- a/test-plans/ping-version.json
+++ b/test-plans/ping-version.json
@@ -2,11 +2,6 @@
     "id": "go-libp2p-head",
     "containerImageID": "go-libp2p-head",
     "transports": [
-        "tcp",
-        "ws",
-        "wss",
-        "quic-v1",
-        "webtransport",
         "webrtc-direct"
     ],
     "secureChannels": [


### PR DESCRIPTION
Exact issue:
Chrome -> go-libp2p: PING
Chrome -> go-libp2p: CloseWrite(FIN)
go-libp2p reads PING
go-libp2p -> Chrome: PING
go-libp2p reads FIN
go-libp2p closes data channel

Now there is a race between onMessage event handler on chrome and onClose event handler on chrome. Depending on what’s fired first the test succeeds or fails.