### PR TITLE
webrtc: reuse port when dialing

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	libp2pwebtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -796,6 +797,22 @@ func (h *BasicHost) Addrs() []ma.Multiaddr {
 			addrWithCerthash, added := tpt.AddCertHashes(addr)
 			if !added {
 				log.Debug("Couldn't add certhashes to webtransport multiaddr because we aren't listening on webtransport")
+				continue
+			}
+			addrs[i] = addrWithCerthash
+		}
+	}
+
+	for i, addr := range addrs {
+		if ok, n := libp2pwebrtc.IsWebRTCDirectMultiaddr(addr); ok && n == 0 {
+			t := s.TransportForListening(addr)
+			tpt, ok := t.(addCertHasher)
+			if !ok {
+				continue
+			}
+			addrWithCerthash, added := tpt.AddCertHashes(addr)
+			if !added {
+				log.Debug("Couldn't add certhashes to webrtc-direct multiaddress")
 				continue
 			}
 			addrs[i] = addrWithCerthash

--- a/p2p/transport/webrtc/reuseudpmux.go
+++ b/p2p/transport/webrtc/reuseudpmux.go
@@ -1,0 +1,97 @@
+package libp2pwebrtc
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/p2p/transport/webrtc/udpmux"
+	"github.com/libp2p/go-netroute"
+)
+
+// reuseUDPMux provides ability to reuse listening udpMux for dialing. This helps with address
+// discovery for nodes that don't have access to their public ip address
+type reuseUDPMux struct {
+	mu          sync.RWMutex
+	loopback    map[int]*udpmux.UDPMux
+	specific    map[string]map[int]*udpmux.UDPMux // IP.String() => Port => Mux
+	unspecified map[int]*udpmux.UDPMux
+}
+
+// Put stores mux for reuse later in Get calls.
+func (r *reuseUDPMux) Put(mux *udpmux.UDPMux) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, a := range mux.GetListenAddresses() {
+		udpAddr, err := net.ResolveUDPAddr(a.Network(), a.String())
+		if err != nil {
+			return fmt.Errorf("udpmux ResolveUDPAddr failed for %s: %w", a, err)
+		}
+		if udpAddr.IP.IsLoopback() {
+			r.loopback[udpAddr.Port] = mux
+			continue
+		}
+		if udpAddr.IP.IsUnspecified() {
+			r.unspecified[udpAddr.Port] = mux
+			continue
+		}
+		if r.specific[udpAddr.IP.String()] == nil {
+			r.specific[udpAddr.IP.String()] = make(map[int]*udpmux.UDPMux)
+		}
+		r.specific[udpAddr.IP.String()][udpAddr.Port] = mux
+	}
+	return nil
+}
+
+// Get retrieves a mux capable of dialing addr. Returns nil if no capable mux is present. If
+// multiple muxes capable of dialing addr are available, it returns one arbitrarily
+func (r *reuseUDPMux) Get(addr *net.UDPAddr) *udpmux.UDPMux {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if addr.IP.IsLoopback() {
+		for _, m := range r.loopback {
+			return m
+		}
+	}
+	if len(r.specific) > 0 {
+		if router, err := netroute.New(); err == nil {
+			if _, _, preferredSrc, err := router.Route(addr.IP); err == nil {
+				if len(r.specific[preferredSrc.String()]) != 0 {
+					for _, m := range r.specific[preferredSrc.String()] {
+						return m
+					}
+				}
+			}
+		}
+	}
+	for _, m := range r.unspecified {
+		return m
+	}
+	return nil
+}
+
+// Delete removes a mux from the reuse pool.
+func (r *reuseUDPMux) Delete(mux *udpmux.UDPMux) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for p, m := range r.loopback {
+		if mux == m {
+			delete(r.loopback, p)
+		}
+	}
+	for p, m := range r.unspecified {
+		if mux == m {
+			delete(r.unspecified, p)
+		}
+	}
+	for ip, mp := range r.specific {
+		for p, m := range mp {
+			if m == mux {
+				delete(mp, p)
+			}
+		}
+		if len(mp) == 0 {
+			delete(r.specific, ip)
+		}
+	}
+}

--- a/p2p/transport/webrtc/reuseudpmux_test.go
+++ b/p2p/transport/webrtc/reuseudpmux_test.go
@@ -1,0 +1,80 @@
+package libp2pwebrtc
+
+import (
+	"net"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/p2p/transport/webrtc/udpmux"
+	"github.com/stretchr/testify/require"
+)
+
+func newReuseUDPMux(t *testing.T) reuseUDPMux {
+	return reuseUDPMux{
+		loopback:    make(map[int]*udpmux.UDPMux),
+		specific:    make(map[string]map[int]*udpmux.UDPMux),
+		unspecified: make(map[int]*udpmux.UDPMux),
+	}
+}
+
+func udpAddr(t *testing.T, s string) *net.UDPAddr {
+	a, err := net.ResolveUDPAddr("udp", s)
+	require.NoError(t, err)
+	return a
+}
+
+func TestReuseUDPMuxLoopback(t *testing.T) {
+	socket, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	require.NoError(t, err)
+	defer socket.Close()
+	r := newReuseUDPMux(t)
+
+	mux := r.Get(udpAddr(t, "127.0.0.1:1"))
+	require.Nil(t, mux)
+
+	originalMux := udpmux.NewUDPMux(socket)
+	err = r.Put(originalMux)
+	require.NoError(t, err)
+
+	mux = r.Get(udpAddr(t, "127.0.0.1:1"))
+	require.Equal(t, originalMux, mux)
+
+	mux = r.Get(udpAddr(t, "1.2.3.4:1"))
+	require.Nil(t, mux)
+
+	r.Delete(originalMux)
+	mux = r.Get(udpAddr(t, "127.0.0.1:1"))
+	require.Nil(t, mux)
+}
+
+func TestReuseUDPMuxUnspecified(t *testing.T) {
+	s1, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	require.NoError(t, err)
+	defer s1.Close()
+
+	s2, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	require.NoError(t, err)
+	defer s2.Close()
+
+	r := newReuseUDPMux(t)
+
+	loMux := udpmux.NewUDPMux(s1)
+	err = r.Put(loMux)
+	require.NoError(t, err)
+
+	mux := r.Get(udpAddr(t, "1.2.3.4:1"))
+	require.Nil(t, mux)
+
+	unMux := udpmux.NewUDPMux(s2)
+	err = r.Put(unMux)
+	require.NoError(t, err)
+
+	mux = r.Get(udpAddr(t, "127.0.0.1:1"))
+	require.Equal(t, loMux, mux)
+
+	mux = r.Get(udpAddr(t, "1.2.3.4:1"))
+	require.Equal(t, unMux, mux)
+
+	r.Delete(loMux)
+	mux = r.Get(udpAddr(t, "127.0.0.1:1"))
+	require.Equal(t, unMux, mux)
+}

--- a/p2p/transport/webrtc/udpmux/mux_test.go
+++ b/p2p/transport/webrtc/udpmux/mux_test.go
@@ -187,6 +187,7 @@ func TestMuxedConnection(t *testing.T) {
 	connCount := 3
 
 	ufrags := []string{"a", "b", "c"}
+
 	var mu sync.Mutex
 	addrUfragMap := make(map[string]string)
 	for _, ufrag := range ufrags {
@@ -196,6 +197,7 @@ func TestMuxedConnection(t *testing.T) {
 				mu.Lock()
 				addrUfragMap[cc.LocalAddr().String()] = ufrag
 				mu.Unlock()
+				addrUfragMap[cc.LocalAddr().String()] = ufrag
 				setupMapping(t, ufrag, cc, m)
 				for j := 0; j < msgCount; j++ {
 					cc.WriteTo([]byte(ufrag), c.LocalAddr())


### PR DESCRIPTION
depends on #2586 

fixes: #2592 

The fix turned out much simpler that I'd expected. Reusing the udp mux for dialing is straightforward. 

Here we only reuse the listening udpmux. If not listening, a new mux is created everytime we dial.

Adds certhashes to discovered /webrtc-direct addresses. Unfortunately this is impossible to unit test currently. I'll manually verify this for now. The situation is the same for webtransport. 