### PR TITLE
examples: remove unused 'SetStreamHandler'

### DIFF
--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -125,18 +125,6 @@ func runSender(ctx context.Context, ha host.Host, targetPeer string) {
 	fullAddr := getHostAddress(ha)
 	log.Printf("I am %s\n", fullAddr)
 
-	// Set a stream handler on host A. /echo/1.0.0 is
-	// a user-defined protocol name.
-	ha.SetStreamHandler("/echo/1.0.0", func(s network.Stream) {
-		log.Println("sender received new stream")
-		if err := doEcho(s); err != nil {
-			log.Println(err)
-			s.Reset()
-		} else {
-			s.Close()
-		}
-	})
-
 	// Turn the targetPeer into a multiaddr.
 	maddr, err := ma.NewMultiaddr(targetPeer)
 	if err != nil {


### PR DESCRIPTION
in this echo case, sender is no need to SetStreamHandler, the sender node only used to interact with listener node.