### PR TITLE
webrtcprivate: add transport integration tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -395,6 +395,10 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			cfg.AutoRelayOpts = append(mtOpts, cfg.AutoRelayOpts...)
 		}
 
+		if cfg.WebRTCPrivate {
+			cfg.AutoRelayOpts = append(cfg.AutoRelayOpts, autorelay.WithWebRTCSupport())
+		}
+
 		ar, err = autorelay.NewAutoRelay(h, cfg.AutoRelayOpts...)
 		if err != nil {
 			return nil, err

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -517,3 +517,49 @@ func TestNoBusyLoop0MinInterval(t *testing.T) {
 	val := atomic.LoadUint64(&calledTimes)
 	require.Less(t, val, uint64(2))
 }
+
+func TestRelayAddrs(t *testing.T) {
+	const numCandidates = 3
+	var called bool
+	peerChan := make(chan peer.AddrInfo, numCandidates)
+	for i := 0; i < numCandidates; i++ {
+		r := newRelay(t)
+		t.Cleanup(func() { r.Close() })
+		peerChan <- peer.AddrInfo{ID: r.ID(), Addrs: r.Addrs()}
+	}
+	close(peerChan)
+
+	h := newPrivateNode(t,
+		func(_ context.Context, num int) <-chan peer.AddrInfo {
+			require.False(t, called, "expected the peer source callback to only have been called once")
+			called = true
+			require.Equal(t, numCandidates, num)
+			return peerChan
+		},
+		autorelay.WithMaxCandidates(numCandidates),
+		autorelay.WithNumRelays(1),
+		autorelay.WithBootDelay(0),
+		autorelay.WithMinInterval(time.Hour),
+	)
+	defer h.Close()
+
+	require.Eventually(
+		t,
+		func() bool {
+			if numRelays(h) <= 0 {
+				return false
+			}
+			addrs := h.Addrs()
+			var foundCircuit, foundWebRTC bool
+			for _, addr := range addrs {
+				_, cerr := addr.ValueForProtocol(ma.P_CIRCUIT)
+				_, werr := addr.ValueForProtocol(ma.P_WEBRTC)
+				foundCircuit = foundCircuit || cerr == nil
+				foundWebRTC = foundWebRTC || (cerr == nil && werr == nil)
+			}
+			return foundCircuit && foundWebRTC
+		},
+		5*time.Second,
+		100*time.Millisecond,
+	)
+}

--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -42,6 +42,9 @@ type config struct {
 	setMinCandidates bool
 	// see WithMetricsTracer
 	metricsTracer MetricsTracer
+
+	// see WithWebRTCSupport
+	webRTCSupport bool
 }
 
 var defaultConfig = config{
@@ -228,6 +231,14 @@ func WithMinInterval(interval time.Duration) Option {
 func WithMetricsTracer(mt MetricsTracer) Option {
 	return func(c *config) error {
 		c.metricsTracer = mt
+		return nil
+	}
+}
+
+// WithWebRTCSupport configures autorelay to advertise webrtc addresses from host
+func WithWebRTCSupport() Option {
+	return func(c *config) error {
+		c.webRTCSupport = true
 		return nil
 	}
 }

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -742,7 +742,7 @@ func (rf *relayFinder) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 		for _, addr := range addrs {
 			pub := addr.Encapsulate(circuit)
 			raddrs = append(raddrs, pub)
-			if isBrowserDialableAddr(addr) {
+			if rf.conf.webRTCSupport && isBrowserDialableAddr(addr) {
 				waddr := pub.Encapsulate(webrtc)
 				raddrs = append(raddrs, waddr)
 				relayAddrCnt++

--- a/p2p/test/transport/rcmgr_test.go
+++ b/p2p/test/transport/rcmgr_test.go
@@ -25,7 +25,8 @@ func TestResourceManagerIsUsed(t *testing.T) {
 			for _, testDialer := range []bool{true, false} {
 				t.Run(tc.Name+fmt.Sprintf(" test_dialer=%v", testDialer), func(t *testing.T) {
 					if strings.Contains(tc.Name, "WebRTCPrivate") {
-						t.Skip("webrtcprivate needs different handling because of the relay required for connection setup")
+						testResourceManagerIsUsedWebRTCPrivate(t, tc, testDialer)
+						return
 					}
 					var reservedMemory, releasedMemory atomic.Int32
 					defer func() {
@@ -140,4 +141,300 @@ func TestResourceManagerIsUsed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testResourceManagerIsUsedWebRTCPrivate(t *testing.T, tc TransportTestCase, testDialer bool) {
+	t.Helper()
+	if testDialer {
+		testResourceManagerIsUsedWebRTCPrivateDialer(t, tc)
+	} else {
+		testResourceManagerIsUsedWebRTCPrivateListener(t, tc)
+	}
+}
+
+func testResourceManagerIsUsedWebRTCPrivateDialer(t *testing.T, tc TransportTestCase) {
+	t.Helper()
+	var reservedMemory, releasedMemory atomic.Int32
+	defer func() {
+		require.Equal(t, reservedMemory.Load(), releasedMemory.Load())
+		require.NotEqual(t, 0, reservedMemory.Load())
+	}()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
+	rcmgr.EXPECT().Close()
+
+	listener := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true})
+	dialer := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true, ResourceManager: rcmgr})
+
+	getPeerScope := func() *mocknetwork.MockPeerScope {
+		peerScope := mocknetwork.NewMockPeerScope(ctrl)
+		peerScope.EXPECT().ReserveMemory(gomock.Any(), gomock.Any()).AnyTimes().Do(func(amount int, pri uint8) {
+			reservedMemory.Add(int32(amount))
+		})
+		peerScope.EXPECT().ReleaseMemory(gomock.Any()).AnyTimes().Do(func(amount int) {
+			releasedMemory.Add(int32(amount))
+		})
+		peerScope.EXPECT().BeginSpan().AnyTimes().DoAndReturn(func() (network.ResourceScopeSpan, error) {
+			s := mocknetwork.NewMockResourceScopeSpan(ctrl)
+			s.EXPECT().BeginSpan().AnyTimes().Return(mocknetwork.NewMockResourceScopeSpan(ctrl), nil)
+			// No need to track these memory reservations since we assert that Done is called
+			s.EXPECT().ReserveMemory(gomock.Any(), gomock.Any())
+			s.EXPECT().Done()
+			return s, nil
+		})
+		return peerScope
+	}
+
+	relayPeerScope := getPeerScope()
+	listenerPeerScope := getPeerScope()
+
+	// getRelayConnScope creates a connection scope for the connection to the relay node and the circuitv2 connection
+	// to the listener
+	getRelayConnScope := func() *mocknetwork.MockConnManagementScope {
+		var connPeer atomic.Pointer[peer.ID]
+		connScope := mocknetwork.NewMockConnManagementScope(ctrl)
+		connScope.EXPECT().SetPeer(gomock.Any()).AnyTimes().Do(func(p peer.ID) {
+			connPeer.Store(&p)
+		})
+		connScope.EXPECT().PeerScope().AnyTimes().DoAndReturn(func() *mocknetwork.MockPeerScope {
+			if connPeer.Load() == nil || *connPeer.Load() == listener.ID() {
+				return listenerPeerScope
+			}
+			return relayPeerScope
+		})
+		connScope.EXPECT().Done().MinTimes(1)
+		return connScope
+	}
+
+	// TODO: Fix addresses on rcmgr calls
+
+	var calledSetPeer atomic.Bool
+	// connScope is the scope to be used for the final connection over /webrtc to the peer
+	connScope := mocknetwork.NewMockConnManagementScope(ctrl)
+	connScope.EXPECT().SetPeer(listener.ID()).Do(func(peer.ID) {
+		calledSetPeer.Store(true)
+	})
+	connScope.EXPECT().PeerScope().AnyTimes().DoAndReturn(func() network.PeerScope {
+		if calledSetPeer.Load() {
+			return listenerPeerScope
+		}
+		return nil
+	})
+	connScope.EXPECT().Done().MinTimes(1)
+
+	var allStreamsDone sync.WaitGroup
+
+	// Dial to relay node and then to listener over circtuiv2
+	rcmgr.EXPECT().OpenConnection(network.DirOutbound, gomock.Any(), gomock.Any()).MaxTimes(2).Return(getRelayConnScope(), nil)
+
+	rcmgr.EXPECT().OpenStream(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(id peer.ID, dir network.Direction) (network.StreamManagementScope, error) {
+		streamScope := mocknetwork.NewMockStreamManagementScope(ctrl)
+		// No need to track these memory reservations since we assert that Done is called
+		streamScope.EXPECT().ReserveMemory(gomock.Any(), gomock.Any()).AnyTimes()
+		streamScope.EXPECT().ReleaseMemory(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().BeginSpan().AnyTimes().DoAndReturn(func() (network.ResourceScopeSpan, error) {
+			s := mocknetwork.NewMockResourceScopeSpan(ctrl)
+			s.EXPECT().BeginSpan().AnyTimes().Return(mocknetwork.NewMockResourceScopeSpan(ctrl), nil)
+			s.EXPECT().Done()
+			return s, nil
+		})
+		streamScope.EXPECT().SetService(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().SetProtocol(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().Done()
+		return streamScope, nil
+	})
+
+	// Now handle /webrtc connection establishment
+	rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, gomock.Any()).Return(connScope, nil)
+	rcmgr.EXPECT().OpenStream(listener.ID(), gomock.Any()).AnyTimes().DoAndReturn(func(id peer.ID, dir network.Direction) (network.StreamManagementScope, error) {
+		allStreamsDone.Add(1)
+		streamScope := mocknetwork.NewMockStreamManagementScope(ctrl)
+		// No need to track these memory reservations since we assert that Done is called
+		streamScope.EXPECT().ReserveMemory(gomock.Any(), gomock.Any()).AnyTimes()
+		streamScope.EXPECT().ReleaseMemory(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().BeginSpan().AnyTimes().DoAndReturn(func() (network.ResourceScopeSpan, error) {
+			s := mocknetwork.NewMockResourceScopeSpan(ctrl)
+			s.EXPECT().BeginSpan().AnyTimes().Return(mocknetwork.NewMockResourceScopeSpan(ctrl), nil)
+			s.EXPECT().Done()
+			return s, nil
+		})
+
+		streamScope.EXPECT().SetService(gomock.Any()).MaxTimes(1)
+		streamScope.EXPECT().SetProtocol(gomock.Any())
+
+		streamScope.EXPECT().Done().Do(func() {
+			allStreamsDone.Done()
+		})
+		return streamScope, nil
+	})
+
+	require.NoError(t, dialer.Connect(context.Background(), peer.AddrInfo{
+		ID:    listener.ID(),
+		Addrs: listener.Addrs(),
+	}))
+
+	// Wait for any in progress identifies to finish.
+	// We shouldn't have to do this, but basic host currently
+	// always does an identify.
+	<-dialer.(interface{ IDService() identify.IDService }).IDService().IdentifyWait(dialer.Network().ConnsToPeer(listener.ID())[0])
+	<-listener.(interface{ IDService() identify.IDService }).IDService().IdentifyWait(listener.Network().ConnsToPeer(dialer.ID())[0])
+	<-ping.Ping(context.Background(), dialer, listener.ID())
+	err := dialer.Network().ClosePeer(listener.ID())
+	require.NoError(t, err)
+
+	// Wait a bit for any pending .Adds before we call .Wait to avoid a data race.
+	// This shouldn't be necessary since it should be impossible
+	// for an OpenStream to happen *after* a ClosePeer, however
+	// in practice it does and leads to test flakiness.
+	time.Sleep(10 * time.Millisecond)
+	allStreamsDone.Wait()
+	dialer.Close()
+	listener.Close()
+}
+
+func testResourceManagerIsUsedWebRTCPrivateListener(t *testing.T, tc TransportTestCase) {
+	t.Helper()
+	var reservedMemory, releasedMemory atomic.Int32
+	defer func() {
+		require.Equal(t, reservedMemory.Load(), releasedMemory.Load())
+		require.NotEqual(t, 0, reservedMemory.Load())
+	}()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
+	rcmgr.EXPECT().Close()
+
+	var listener, dialer host.Host
+
+	getPeerScope := func() *mocknetwork.MockPeerScope {
+		peerScope := mocknetwork.NewMockPeerScope(ctrl)
+		peerScope.EXPECT().ReserveMemory(gomock.Any(), gomock.Any()).AnyTimes().Do(func(amount int, pri uint8) {
+			reservedMemory.Add(int32(amount))
+		})
+		peerScope.EXPECT().ReleaseMemory(gomock.Any()).AnyTimes().Do(func(amount int) {
+			releasedMemory.Add(int32(amount))
+		})
+		peerScope.EXPECT().BeginSpan().AnyTimes().DoAndReturn(func() (network.ResourceScopeSpan, error) {
+			s := mocknetwork.NewMockResourceScopeSpan(ctrl)
+			s.EXPECT().BeginSpan().AnyTimes().Return(mocknetwork.NewMockResourceScopeSpan(ctrl), nil)
+			// No need to track these memory reservations since we assert that Done is called
+			s.EXPECT().ReserveMemory(gomock.Any(), gomock.Any())
+			s.EXPECT().Done()
+			return s, nil
+		})
+		return peerScope
+	}
+
+	relayPeerScope := getPeerScope()
+	dialerPeerScope := getPeerScope()
+
+	// getRelayConnScope creates a connection scope for the connection to the relay node and the circuitv2 connection
+	// from the dialer
+	getRelayConnScope := func() *mocknetwork.MockConnManagementScope {
+		var connPeer atomic.Pointer[peer.ID]
+		connScope := mocknetwork.NewMockConnManagementScope(ctrl)
+		connScope.EXPECT().SetPeer(gomock.Any()).AnyTimes().Do(func(p peer.ID) {
+			connPeer.Store(&p)
+		})
+		connScope.EXPECT().PeerScope().AnyTimes().DoAndReturn(func() *mocknetwork.MockPeerScope {
+			// Nil returns from DoAndReturn are typed. This causes problems with nil
+			// checks. So we return dialerPeerScope when PeerScope is called before
+			// SetPeer. This happens on circuitv2 connection upgrade.
+			if connPeer.Load() == nil || *connPeer.Load() == dialer.ID() {
+				return dialerPeerScope
+			}
+			return relayPeerScope
+		})
+		connScope.EXPECT().Done().MinTimes(1)
+		return connScope
+	}
+
+	// Connection to the relay node
+	rcmgr.EXPECT().OpenConnection(network.DirOutbound, gomock.Any(), gomock.Any()).Return(getRelayConnScope(), nil)
+	rcmgr.EXPECT().OpenStream(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(id peer.ID, dir network.Direction) (network.StreamManagementScope, error) {
+		streamScope := mocknetwork.NewMockStreamManagementScope(ctrl)
+		// No need to track these memory reservations since we assert that Done is called
+		streamScope.EXPECT().ReserveMemory(gomock.Any(), gomock.Any()).AnyTimes()
+		streamScope.EXPECT().ReleaseMemory(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().BeginSpan().AnyTimes().DoAndReturn(func() (network.ResourceScopeSpan, error) {
+			s := mocknetwork.NewMockResourceScopeSpan(ctrl)
+			s.EXPECT().BeginSpan().AnyTimes().Return(mocknetwork.NewMockResourceScopeSpan(ctrl), nil)
+			s.EXPECT().Done()
+			return s, nil
+		})
+		streamScope.EXPECT().SetService(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().SetProtocol(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().Done()
+		return streamScope, nil
+	})
+
+	listener = tc.HostGenerator(t, TransportTestCaseOpts{ResourceManager: rcmgr})
+	dialer = tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true, NoRcmgr: true})
+
+	var calledSetPeer atomic.Bool
+	connScope := mocknetwork.NewMockConnManagementScope(ctrl)
+	connScope.EXPECT().SetPeer(dialer.ID()).Do(func(peer.ID) {
+		calledSetPeer.Store(true)
+	})
+	connScope.EXPECT().PeerScope().AnyTimes().DoAndReturn(func() network.PeerScope {
+		if calledSetPeer.Load() {
+			return dialerPeerScope
+		}
+		return nil
+	})
+	connScope.EXPECT().Done().MinTimes(1)
+
+	var allStreamsDone sync.WaitGroup
+	gomock.InOrder(
+		// Incoming circuit-v2 connection for signaling stream
+		rcmgr.EXPECT().OpenConnection(network.DirInbound, gomock.Any(), gomock.Any()).Return(getRelayConnScope(), nil),
+		// /webrtc connection
+		rcmgr.EXPECT().OpenConnection(network.DirInbound, true, gomock.Any()).Return(connScope, nil),
+	)
+	rcmgr.EXPECT().OpenStream(dialer.ID(), gomock.Any()).AnyTimes().DoAndReturn(func(id peer.ID, dir network.Direction) (network.StreamManagementScope, error) {
+		allStreamsDone.Add(1)
+		streamScope := mocknetwork.NewMockStreamManagementScope(ctrl)
+		// No need to track these memory reservations since we assert that Done is called
+		streamScope.EXPECT().ReserveMemory(gomock.Any(), gomock.Any()).AnyTimes()
+		streamScope.EXPECT().ReleaseMemory(gomock.Any()).AnyTimes()
+		streamScope.EXPECT().BeginSpan().AnyTimes().DoAndReturn(func() (network.ResourceScopeSpan, error) {
+			s := mocknetwork.NewMockResourceScopeSpan(ctrl)
+			s.EXPECT().BeginSpan().AnyTimes().Return(mocknetwork.NewMockResourceScopeSpan(ctrl), nil)
+			s.EXPECT().Done()
+			return s, nil
+		})
+
+		streamScope.EXPECT().SetService(gomock.Any()).MaxTimes(1)
+		streamScope.EXPECT().SetProtocol(gomock.Any())
+
+		streamScope.EXPECT().Done().Do(func() {
+			allStreamsDone.Done()
+		})
+		return streamScope, nil
+	})
+
+	require.NoError(t, dialer.Connect(context.Background(), peer.AddrInfo{
+		ID:    listener.ID(),
+		Addrs: listener.Addrs(),
+	}))
+	// Wait for any in progress identifies to finish.
+	// We shouldn't have to do this, but basic host currently
+	// always does an identify.
+	<-dialer.(interface{ IDService() identify.IDService }).IDService().IdentifyWait(dialer.Network().ConnsToPeer(listener.ID())[0])
+	<-listener.(interface{ IDService() identify.IDService }).IDService().IdentifyWait(listener.Network().ConnsToPeer(dialer.ID())[0])
+	<-ping.Ping(context.Background(), dialer, listener.ID())
+	err := dialer.Network().ClosePeer(listener.ID())
+	require.NoError(t, err)
+
+	// Wait a bit for any pending .Adds before we call .Wait to avoid a data race.
+	// This shouldn't be necessary since it should be impossible
+	// for an OpenStream to happen *after* a ClosePeer, however
+	// in practice it does and leads to test flakiness.
+	time.Sleep(10 * time.Millisecond)
+	allStreamsDone.Wait()
+	dialer.Close()
+	listener.Close()
 }

--- a/p2p/test/transport/rcmgr_test.go
+++ b/p2p/test/transport/rcmgr_test.go
@@ -208,8 +208,6 @@ func testResourceManagerIsUsedWebRTCPrivateDialer(t *testing.T, tc TransportTest
 		return connScope
 	}
 
-	// TODO: Fix addresses on rcmgr calls
-
 	var calledSetPeer atomic.Bool
 	// connScope is the scope to be used for the final connection over /webrtc to the peer
 	connScope := mocknetwork.NewMockConnManagementScope(ctrl)
@@ -247,7 +245,7 @@ func testResourceManagerIsUsedWebRTCPrivateDialer(t *testing.T, tc TransportTest
 	})
 
 	// Now handle /webrtc connection establishment
-	rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, gomock.Any()).Return(connScope, nil)
+	rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, listener.Addrs()[0]).Return(connScope, nil)
 	rcmgr.EXPECT().OpenStream(listener.ID(), gomock.Any()).AnyTimes().DoAndReturn(func(id peer.ID, dir network.Direction) (network.StreamManagementScope, error) {
 		allStreamsDone.Add(1)
 		streamScope := mocknetwork.NewMockStreamManagementScope(ctrl)
@@ -392,7 +390,8 @@ func testResourceManagerIsUsedWebRTCPrivateListener(t *testing.T, tc TransportTe
 		// Incoming circuit-v2 connection for signaling stream
 		rcmgr.EXPECT().OpenConnection(network.DirInbound, gomock.Any(), gomock.Any()).Return(getRelayConnScope(), nil),
 		// /webrtc connection
-		rcmgr.EXPECT().OpenConnection(network.DirInbound, true, gomock.Any()).Return(connScope, nil),
+		// The remote multiaddr is the same as our
+		rcmgr.EXPECT().OpenConnection(network.DirInbound, true, listener.Addrs()[0]).Return(connScope, nil),
 	)
 	rcmgr.EXPECT().OpenStream(dialer.ID(), gomock.Any()).AnyTimes().DoAndReturn(func(id peer.ID, dir network.Direction) (network.StreamManagementScope, error) {
 		allStreamsDone.Add(1)

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -22,10 +22,12 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/sec"
+	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
@@ -204,6 +206,10 @@ func (h *webrtcHost) Close() error {
 		h.r.Close()
 	}
 	return nil
+}
+
+func (h *webrtcHost) IDService() identify.IDService {
+	return h.Host.(*basichost.BasicHost).IDService()
 }
 
 func TestPing(t *testing.T) {

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -366,9 +366,6 @@ func TestManyStreams(t *testing.T) {
 	const streamCount = 128
 	for _, tc := range transportsToTest {
 		t.Run(tc.Name, func(t *testing.T) {
-			if strings.Contains(tc.Name, "WebRTC") {
-				t.Skip("Pion doesn't correctly handle large queues of streams.")
-			}
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{NoRcmgr: true})
 			h2 := tc.HostGenerator(t, TransportTestCaseOpts{NoListen: true, NoRcmgr: true})
 			defer h1.Close()

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -712,7 +712,7 @@ func TestDiscoverPeerIDFromSecurityNegotiation(t *testing.T) {
 	for _, tc := range transportsToTest {
 		t.Run(tc.Name, func(t *testing.T) {
 			if strings.Contains(tc.Name, "WebRTCPrivate") {
-				t.Skip("webrtcprivate needs different handling because of the relay required for connection setup")
+				t.Skip("inapplicable for webrtc private to private since the connection is established over an authenticated channel")
 			}
 
 			h1 := tc.HostGenerator(t, TransportTestCaseOpts{})

--- a/p2p/transport/webrtc/connection.go
+++ b/p2p/transport/webrtc/connection.go
@@ -25,7 +25,8 @@ import (
 
 var _ tpt.CapableConn = &connection{}
 
-const maxAcceptQueueLen = 10
+// maxAcceptQueueLen is the number of waiting streams.
+const maxAcceptQueueLen = 256
 
 const maxDataChannelID = 1 << 10
 

--- a/p2p/transport/webrtcprivate/transport.go
+++ b/p2p/transport/webrtcprivate/transport.go
@@ -39,7 +39,7 @@ const (
 	disconnectedTimeout = 20 * time.Second
 	failedTimeout       = 30 * time.Second
 	keepaliveTimeout    = 15 * time.Second
-	maxAcceptQueueLen   = 10
+	maxAcceptQueueLen   = 256
 )
 
 var (

--- a/p2p/transport/webrtcprivate/transport.go
+++ b/p2p/transport/webrtcprivate/transport.go
@@ -34,6 +34,7 @@ import (
 const (
 	name                = "webrtcprivate"
 	maxMsgSize          = 4096
+	receiveMTU          = 1500
 	connectTimeout      = time.Minute
 	SignalingProtocol   = "/webrtc-signaling"
 	disconnectedTimeout = 20 * time.Second
@@ -458,6 +459,7 @@ func (t *transport) NewPeerConnection() (*webrtc.PeerConnection, error) {
 	s.SetICETimeouts(disconnectedTimeout, failedTimeout, keepaliveTimeout)
 	s.DetachDataChannels()
 	s.SetIncludeLoopbackCandidate(true)
+	s.SetReceiveMTU(receiveMTU)
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(s))
 	return api.NewPeerConnection(t.webrtcConfig)
 }

--- a/p2p/transport/webrtcprivate/transport_test.go
+++ b/p2p/transport/webrtcprivate/transport_test.go
@@ -56,7 +56,7 @@ func newWebRTCHost(t *testing.T) *webrtcHost {
 }
 
 func newRelayedHost(t *testing.T) *relayedHost {
-	rh := blankhost.NewBlankHost(swarmt.GenSwarm(t))
+	rh := blankhost.NewBlankHost(swarmt.GenSwarm(t, swarmt.OptDisableTCP))
 	rr := relay.DefaultResources()
 	rr.MaxCircuits = 100
 	_, err := relay.New(rh, relay.WithResources(rr))
@@ -135,9 +135,9 @@ func TestConnectionProperties(t *testing.T) {
 			require.NoError(t, err)
 		}
 		testAddr(ca.LocalMultiaddr())
-		testAddr(ca.RemoteMultiaddr())
 		testAddr(cb.LocalMultiaddr())
-		testAddr(cb.RemoteMultiaddr())
+		require.Equal(t, ca.RemoteMultiaddr(), b.Addr, "%s\n%s", ca.RemoteMultiaddr(), b.Addr)
+		require.Equal(t, cb.RemoteMultiaddr(), b.Addr, "%s\n%s", cb.RemoteMultiaddr(), b.Addr)
 	})
 
 	t.Run("ConnectionState", func(t *testing.T) {

--- a/p2p/transport/webrtcprivate/transport_test.go
+++ b/p2p/transport/webrtcprivate/transport_test.go
@@ -47,7 +47,6 @@ func newWebRTCHost(t *testing.T) *webrtcHost {
 	upg := swarmt.GenUpgrader(t, as, nil)
 	err := client.AddTransport(a, upg)
 	require.NoError(t, err)
-
 	ta, err := newTransport(a, nil, nil)
 	require.NoError(t, err)
 	return &webrtcHost{

--- a/p2p/transport/webrtcprivate/transport_test.go
+++ b/p2p/transport/webrtcprivate/transport_test.go
@@ -47,6 +47,7 @@ func newWebRTCHost(t *testing.T) *webrtcHost {
 	upg := swarmt.GenUpgrader(t, as, nil)
 	err := client.AddTransport(a, upg)
 	require.NoError(t, err)
+
 	ta, err := newTransport(a, nil, nil)
 	require.NoError(t, err)
 	return &webrtcHost{


### PR DESCRIPTION
Depends on: #2576 

The code duplication is unfortunate, but this is reasonable for now. When we have circuit v2 transport integration tests, we can refactor this. 