### PR TITLE
Spell Check: Fix typos

### DIFF
--- a/p2p/host/resource-manager/README.md
+++ b/p2p/host/resource-manager/README.md
@@ -541,7 +541,7 @@ works best.
 
 ## Examples
 
-Here we consider some concrete examples that can ellucidate the abstract
+Here we consider some concrete examples that can elucidate the abstract
 design as described so far.
 
 ### Stream Lifetime
@@ -578,7 +578,7 @@ More specifically the following constraints apply:
 - the peer scope, where the limits for the peer at the other end of the stream
   apply.
 - the service scope, where the limits of the specific service owning the stream apply.
-- the protcol scope, where the limits of the specific protocol for the stream apply.
+- the protocol scope, where the limits of the specific protocol for the stream apply.
 
 
 The resource transfer that happens in the `SetProtocol` and `SetService`

--- a/p2p/host/resource-manager/docs/allowlist.md
+++ b/p2p/host/resource-manager/docs/allowlist.md
@@ -47,7 +47,7 @@ creates the connection resource scope using the allowlisted specific system and
 transient resource scopes. If it wasn't an allowlisted multiaddr it fails as
 before.
 
-When an allowlisted connection is tied to a peer id and transfered with
+When an allowlisted connection is tied to a peer id and transferred with
 `ConnManagementScope.SetPeer`, we check if that peer id matches the expected
 value in the allowlist (if it exists). If it does not match, we attempt to
 transfer this resource to the normal system and peer scope. If that transfer


### PR DESCRIPTION
Typos: 

ellucidate --> elucidate
protcol --> protocol
transfered --> transferred