### PR TITLE
Fix missing deprecation tag

### DIFF
--- a/options.go
+++ b/options.go
@@ -579,6 +579,7 @@ func PrometheusRegisterer(reg prometheus.Registerer) Option {
 // DialRanker configures libp2p to use d as the dial ranker. To enable smart
 // dialing use `swarm.DefaultDialRanker`. use `swarm.NoDelayDialRanker` to
 // disable smart dialing.
+//
 // Deprecated: use SwarmOpts(swarm.WithDialRanker(d)) instead
 func DialRanker(d network.DialRanker) Option {
 	return func(cfg *Config) error {


### PR DESCRIPTION
The pkg.go.dev website shows `DEPRECATED` tags for functions that are marked as deprecated, but the libp2p `DialRanker` function is missing a newline before the `// Deprecated:` line. As a result, even though the function is deprecated, pkg.go.dev does not tag/label it as deprecated.

This also affects language servers such as gopls.
With gopls enabled in VSCode (using the Go extension), deprecated functions are indicated with a strikethough. This strikethrough does not appear for `DialRanker` because of the missing newline.

I published my own module to test this.
See: https://pkg.go.dev/github.com/librick/go-deprecated@v0.1.0/deprecated