### PR TITLE
Update docs from RSA to Ed25519

### DIFF
--- a/libp2p.go
+++ b/libp2p.go
@@ -42,7 +42,7 @@ func ChainOptions(opts ...Option) Option {
 // - If no security transport is provided, the host uses the go-libp2p's noise
 // and/or tls encrypted transport to encrypt all traffic;
 //
-// - If no peer identity is provided, it generates a random RSA 2048 key-pair
+// - If no peer identity is provided, it generates a random Ed25519 key-pair
 // and derives a new identity from it;
 //
 // - If no peerstore is provided, the host is initialized with an empty


### PR DESCRIPTION
The docs for libp2p's `func New` say:
>If no peer identity is provided, it generates a random RSA 2048
key-pair and derives a new identity from it

Maybe I'm misinterpreting the docs, but I've observed that the default is actually Ed25519:
```go
node, err := libp2p.New()
if err != nil {
    panic(err)
}
fmt.Printf("Peer ID key type: %s\n", node.Peerstore().PrivKey(node.ID()).Type())
```
Which prints "Peer ID key type: Ed25519".

This is further supported by the [Peer Id spec](https://github.com/libp2p/specs/blob/d2106f43e878ae4c3a1c6465a7c329835290fe22/peer-ids/peer-ids.md?plain=1#L119):
>Implementations MUST support Ed25519. Implementations SHOULD support RSA…

This commit updates the function docs to express that the default is Ed25519, not RSA.