### PR TITLE
circuitv2: don't check ASN for private addrs

### DIFF
--- a/p2p/protocol/circuitv2/relay/constraints.go
+++ b/p2p/protocol/circuitv2/relay/constraints.go
@@ -74,7 +74,10 @@ func (c *constraints) AddReservation(p peer.ID, a ma.Multiaddr) error {
 
 	var asnReservations []time.Time
 	var asn string
-	if ip.To4() == nil {
+	// Only public addresses have an ASN. Skip checking ASN for private addresses as
+	// initialising the ASN store is a costly operation. Skipping this check reduces a lot of
+	// flakiness in tests
+	if ip.To4() == nil && manet.IsPublicAddr(a) {
 		asn, _ = asnutil.Store.AsnForIPv6(ip)
 		if asn != "" {
 			asnReservations = c.asns[asn]


### PR DESCRIPTION
This is responsible for some of the flakiness of the autorelay testsuite. Loading the ASN table takes a lot of time. I think we can optimise the underlying library but this change is harmless since localhost / private addresses wouldn't be associated with an ASN. 