### PR TITLE
chore: add resource manager dashboard to docker-compose

### DIFF
--- a/dashboards/docker-compose.base.yml
+++ b/dashboards/docker-compose.base.yml
@@ -26,3 +26,4 @@ services:
       - ./identify/identify.json:/var/lib/grafana/dashboards/identify.json
       - ./relaysvc/relaysvc.json:/var/lib/grafana/dashboards/relaysvc.json
       - ./swarm/swarm.json:/var/lib/grafana/dashboards/swarm.json
+      - ./resource-manager/resource-manager.json:/var/lib/grafana/dashboards/resource-manager.json


### PR DESCRIPTION
The existing Grafana dashboard for resource manager wasn't mapped into the Grafana Docker container.