### PR TITLE
quic: add support for TLS certificate templates & extra validation

### DIFF
--- a/p2p/security/tls/crypto_test.go
+++ b/p2p/security/tls/crypto_test.go
@@ -31,7 +31,7 @@ func TestNewIdentityCertificates(t *testing.T) {
 	})
 
 	t.Run("NewIdentity with custom template", func(t *testing.T) {
-		tmpl, err := certTemplate()
+		tmpl, err := CertTemplate()
 		assert.NoError(t, err)
 
 		tmpl.Subject.CommonName = cn

--- a/p2p/security/tls/transport_test.go
+++ b/p2p/security/tls/transport_test.go
@@ -144,7 +144,7 @@ func TestHandshakeSucceeds(t *testing.T) {
 	// Use transports with custom TLS certificates
 
 	// override client identity to use a custom certificate
-	clientCertTmlp, err := certTemplate()
+	clientCertTmlp, err := CertTemplate()
 	require.NoError(t, err)
 
 	clientCertTmlp.Subject.CommonName = "client.test.name"
@@ -154,7 +154,7 @@ func TestHandshakeSucceeds(t *testing.T) {
 	require.NoError(t, err)
 
 	// override server identity to use a custom certificate
-	serverCertTmpl, err := certTemplate()
+	serverCertTmpl, err := CertTemplate()
 	require.NoError(t, err)
 
 	serverCertTmpl.Subject.CommonName = "server.test.name"


### PR DESCRIPTION
In some cases, it may be desirable to isolate some p2p networks, for example, test networks where nodes shouldn't be able to join the main network by accident. Talking about QUIC in particular, #1432 is probably not going to be implemented soon, so this PR is a stopgap solution, enabling custom TLS certificate templates for QUIC connections, and also a way to verify them. This way, the networks that need to be isolated might use a TLS extension (or something more hacky such as email, which is used in the test) to store a network-specific value that must be the same among the peers.

This is in no way a security feature, but rather just a safeguard against possible test network deployment mistakes.

I'm not entirely sure this approach is correct, e.g. it might be that connection gating should be used for the checks, but right now the underlying QUIC connection with its cert chain cannot be accessed from the gater, from what I see.

It might be also that instead of such a generic approach with cert templates and verification as exported transport options, we might just pass some "cookie" value which must be the same among peers as a QUIC transport option, if you think that is preferable, I can update this PR.