### PR TITLE
rcmgr: fix connmgr connection limit conflict warning

### DIFF
--- a/p2p/host/resource-manager/extapi.go
+++ b/p2p/host/resource-manager/extapi.go
@@ -147,5 +147,5 @@ func (r *resourceManager) Stat() (result ResourceManagerStat) {
 }
 
 func (r *resourceManager) GetConnLimit() int {
-	return r.limits.GetConnLimits().GetConnTotalLimit()
+	return r.limits.GetSystemLimits().GetConnTotalLimit()
 }


### PR DESCRIPTION
closes: #2628 

The ConnLimit is associated with Connection scope and always has connection limit 1 because within a connection scope you only need 1 connection. 

The correct system connection limit is provided by the system scope. 


Thanks! @juligasa