### PR TITLE
swarm: remove /ip6zone component from listen addresses

### DIFF
--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -47,6 +47,7 @@ func TestDialBadAddrs(t *testing.T) {
 
 	test(m("/ip6/fe80::1"))                // link local
 	test(m("/ip6/fe80::100"))              // link local
+	test(m("/ip6zone/eth0/ip6/fe80::100")) // ip6zone
 	test(m("/ip4/127.0.0.1/udp/1234/utp")) // utp
 }
 


### PR DESCRIPTION
Fixes #2659.

/ip6zone addresses shouldn't be advertised. This PR adds logic to remove the ip6zone component from addresses returned by `Swarm.ListenAddresses` and `Swarm.InterfaceListenAddresses`.

@jclab-joseph Does this solve your problem?

**TODO: add tests**