### PR TITLE
chore: update go security policy url

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There's a few things you can do right now to help out:
 ## Supported Go Versions
 
 We test against and support the two most recent major releases of Go. This is
-informed by Go's own [security policy](https://go.dev/security).
+informed by Go's own [security policy](https://go.dev/doc/security/policy).
 
 # Notable Users
 Some notable users of go-libp2p are:


### PR DESCRIPTION
This existing link has a redirect loop. The new link is the actual security policy url that includes the two latest go version guideline. 