### PR TITLE
examples: call NewStream from only one side

### DIFF
--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -118,7 +118,7 @@ func main() {
 		peer := <-peerChan // will block until we discover a peer
 		if peer.ID > host.ID() {
 			// if other end peer id greater than us, don't connect to it, just wait for it to connect us
-			fmt.Println("Found peer:", peer, " id is greater than us, wait for it connect us")
+			fmt.Println("Found peer:", peer, " id is greater than us, wait for it to connect to us")
 			continue
 		}
 		fmt.Println("Found peer:", peer, ", connecting")

--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -116,7 +116,12 @@ func main() {
 	peerChan := initMDNS(host, cfg.RendezvousString)
 	for { // allows multiple peers to join
 		peer := <-peerChan // will block until we discover a peer
-		fmt.Println("Found peer:", peer, ", connecting")
+		if peer.ID > host.ID() {
+			// if other end peer id greater than us, don't connect to it, just wait for it to connect us
+			fmt.Println("Found peer:", peer, " id is greater than us, wait for it connect us")
+			continue
+		}
+		fmt.Println("Found peer:", peer, ", connecting to it")
 
 		if err := host.Connect(ctx, peer); err != nil {
 			fmt.Println("Connection failed:", err)

--- a/examples/chat-with-mdns/main.go
+++ b/examples/chat-with-mdns/main.go
@@ -121,7 +121,7 @@ func main() {
 			fmt.Println("Found peer:", peer, " id is greater than us, wait for it connect us")
 			continue
 		}
-		fmt.Println("Found peer:", peer, ", connecting to it")
+		fmt.Println("Found peer:", peer, ", connecting")
 
 		if err := host.Connect(ctx, peer); err != nil {
 			fmt.Println("Connection failed:", err)


### PR DESCRIPTION
Close #2418 

Add a simply logic(by compare peer id) to avoid call `NewStream` from both side.

----
## Screenshots

![image](https://github.com/libp2p/go-libp2p/assets/25278203/1dcfcae5-ef69-4f8f-95cf-6fd7ef34417a)

![image](https://github.com/libp2p/go-libp2p/assets/25278203/1f47131c-3689-4e36-b3b5-a8a878e26cb5)

![image](https://github.com/libp2p/go-libp2p/assets/25278203/33783976-75fb-4b22-9765-9e29d4b41d68)

