### PR TITLE
libp2phttp: fix flaky ExampleHost_listenOnHTTPTransportAndStreams

### DIFF
--- a/p2p/http/example_test.go
+++ b/p2p/http/example_test.go
@@ -61,6 +61,8 @@ func ExampleHost_listenOnHTTPTransportAndStreams() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer serverStreamHost.Close()
+
 	server := libp2phttp.Host{
 		InsecureAllowHTTP: true, // For our example, we'll allow insecure HTTP
 		ListenAddrs:       []ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/50124/http")},


### PR DESCRIPTION
This fails once a while with addr in use error