### PR TITLE
chore: remove unused GenerateEKeyPair function

### DIFF
--- a/core/crypto/key_test.go
+++ b/core/crypto/key_test.go
@@ -291,15 +291,3 @@ func testKeyEquals(t *testing.T, k Key) {
 		t.Fatal("Keys should not equal.")
 	}
 }
-
-func TestUnknownCurveErrors(t *testing.T) {
-	_, _, err := GenerateEKeyPair("P-256")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, _, err = GenerateEKeyPair("error-please")
-	if err == nil {
-		t.Fatal("expected invalid key type to error")
-	}
-}


### PR DESCRIPTION
This was used for SECIO which has been long deprecated. 