### PR TITLE
webrtc: close mux when closing listener

### DIFF
--- a/p2p/transport/webrtc/stream_test.go
+++ b/p2p/transport/webrtc/stream_test.go
@@ -366,7 +366,7 @@ func TestStreamCloseAfterFINACK(t *testing.T) {
 	select {
 	case <-done:
 		t.Fatalf("Close should not have completed without processing FIN_ACK")
-	case <-time.After(2 * time.Second):
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	b := make([]byte, 1)

--- a/p2p/transport/webrtc/udpmux/mux.go
+++ b/p2p/transport/webrtc/udpmux/mux.go
@@ -255,6 +255,9 @@ func ufragFromSTUNMessage(msg *stun.Message) (string, error) {
 	return string(attr[index+1:]), nil
 }
 
+// RemoveConnByUfrag removes the connection associated with the ufrag and all the
+// addresses associated with that connection. This method is called by pion when
+// a peerconnection is closed.
 func (mux *UDPMux) RemoveConnByUfrag(ufrag string) {
 	if ufrag == "" {
 		return


### PR DESCRIPTION
There is currently a leak in the webrtc listener. When the listener is closed the udp mux readloop just keeps running.

depends on #2716 