### PR TITLE
Add reuseport functionality to websocket protocol (v2)

### DIFF
--- a/p2p/transport/websocket/addrs_test.go
+++ b/p2p/transport/websocket/addrs_test.go
@@ -69,7 +69,8 @@ func TestConvertWebsocketMultiaddrToNetAddr(t *testing.T) {
 }
 
 func TestListeningOnDNSAddr(t *testing.T) {
-	ln, err := newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil)
+	wt := &WebsocketTransport{}
+	ln, err := wt.newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil)
 	require.NoError(t, err)
 	addr := ln.Multiaddr()
 	first, rest := ma.SplitFirst(addr)

--- a/p2p/transport/websocket/reuseport.go
+++ b/p2p/transport/websocket/reuseport.go
@@ -1,0 +1,9 @@
+package websocket
+
+import (
+	"github.com/libp2p/go-reuseport"
+)
+
+func reuseportIsAvailable() bool {
+	return reuseport.Available()
+}

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -572,7 +572,7 @@ func TestReusePortOnDial(t *testing.T) {
 	require.NoError(t, err)
 	defer l.Close()
 
-	// Take a note of the port on which we listen. This should be the address from which we dial too.
+	// Take a note of the multiaddress on which we listen. This should be the address from which we dial too.
 	expectedAddr := l.Multiaddr()
 
 	done := make(chan struct{})
@@ -583,6 +583,7 @@ func TestReusePortOnDial(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
+		// The meat of this test - verify that the connection was received from the same port as the listen port recorded above.
 		remote := conn.RemoteMultiaddr()
 		require.Equal(t, expectedAddr, remote)
 	}()
@@ -590,10 +591,6 @@ func TestReusePortOnDial(t *testing.T) {
 	conn, err := tpt.Dial(context.Background(), cliListen.Multiaddr(), clientID)
 	require.NoError(t, err)
 	defer conn.Close()
-
-	stream, err := conn.OpenStream(context.Background())
-	require.NoError(t, err)
-	defer stream.Close()
 
 	<-done
 }


### PR DESCRIPTION
This PR adds the reuseport functionality for websocket protocol.

The `TestReusePortOnDial` tests this implementation by starting to listen on a random port, then dialing another endpoint and verifying that the dial used the same port we were previously listening on.

`TestReusePortOnListen` starts two listeners and twenty dialers and (on Linux) verifies that requests were distributed among both listeners; on Windows and MacOS we can't make such guarantees, so we just verify that everything worked, and all requests were indeed handled.

This PR offers an alternative implementation and operates in the same space as https://github.com/libp2p/go-libp2p/pull/2261.
Kudos to @chaitanyaprem for his work, I have implemented his documentation references and was inspired by his test for multiple listeners and connection distribution.

The tests for websocket implementation are somewhat noisy (on master too), I don't think warnings like those below stem from these changes:
```
2024/02/24 17:11:16 http: TLS handshake error from 127.0.0.1:51918: remote error: tls: bad certificate
2024/02/24 17:11:16 http: TLS handshake error from 127.0.0.1:39826: remote error: tls: bad certificate
2024/02/24 17:11:17 http: TLS handshake error from 127.0.0.1:52002: read tcp4 127.0.0.1:38471->127.0.0.1:52002: use of closed network connection
2024/02/24 17:11:17 http: TLS handshake error from 127.0.0.1:34080: read tcp4 127.0.0.1:46259->127.0.0.1:34080: use of closed network connection
2024/02/24 17:11:17 http: TLS handshake error from 127.0.0.1:38720: remote error: tls: bad certificate
2024/02/24 17:11:18 http: TLS handshake error from 127.0.0.1:60538: remote error: tls: bad certificate
```

