### PR TITLE
webrtc: close data channels cleanly

### DIFF
--- a/p2p/transport/webrtc/connection.go
+++ b/p2p/transport/webrtc/connection.go
@@ -175,7 +175,7 @@ func (c *connection) AcceptStream() (network.MuxedStream, error) {
 	case <-c.ctx.Done():
 		return nil, c.closeErr
 	case dc := <-c.acceptQueue:
-		str := newStream(dc.channel, dc.stream, maxRTT,func() { c.removeStream(*dc.channel.ID()) }, c.onDataChannelClose)
+		str := newStream(dc.channel, dc.stream, maxRTT, func() { c.removeStream(*dc.channel.ID()) }, c.onDataChannelClose)
 		if err := c.addStream(str); err != nil {
 			str.Reset()
 			return nil, err
@@ -215,6 +215,7 @@ func (c *connection) onDataChannelClose(remoteClosed bool) {
 	if !remoteClosed {
 		if c.invalidDataChannelClosures.Add(1) > maxInvalidDataChannelClosures {
 			c.closeOnce.Do(func() {
+				log.Error("closing connection as peer is not closing datachannels: ", c.RemotePeer(), c.RemoteMultiaddr())
 				c.closeWithError(errors.New("peer is not closing datachannels"))
 			})
 		}

--- a/p2p/transport/webrtc/listener.go
+++ b/p2p/transport/webrtc/listener.go
@@ -257,7 +257,7 @@ func (l *listener) setupConnection(
 	if err != nil {
 		return nil, err
 	}
-	handshakeChannel := newStream(w.HandshakeDataChannel, rwc, func() {})
+	handshakeChannel := newStream(w.HandshakeDataChannel, rwc, maxRTT, nil, nil)
 	// we do not yet know A's peer ID so accept any inbound
 	remotePubKey, err := l.transport.noiseHandshake(ctx, w.PeerConnection, handshakeChannel, "", crypto.SHA256, true)
 	if err != nil {

--- a/p2p/transport/webrtc/stream.go
+++ b/p2p/transport/webrtc/stream.go
@@ -257,7 +257,7 @@ func (s *stream) spawnControlMessageReader() {
 				}
 
 				// The stream is closed. Wait for 1RTT before erroring
-				if s.isClosed && endTime.IsZero() {
+				if s.sendState == sendStateDataSent && endTime.IsZero() {
 					endTime = time.Now().Add(s.rtt)
 				}
 				s.setDataChannelReadDeadline(endTime)

--- a/p2p/transport/webrtc/stream_read.go
+++ b/p2p/transport/webrtc/stream_read.go
@@ -103,6 +103,10 @@ func (s *stream) setDataChannelReadDeadline(t time.Time) error {
 func (s *stream) CloseRead() error {
 	s.mx.Lock()
 	defer s.mx.Unlock()
+	return s.closeReadUnlocked()
+}
+
+func (s *stream) closeReadUnlocked() error {
 	var err error
 	if s.receiveState == receiveStateReceiving && s.closeForShutdownErr == nil {
 		err = s.writer.WriteMsg(&pb.Message{Flag: pb.Message_STOP_SENDING.Enum()})

--- a/p2p/transport/webrtc/transport.go
+++ b/p2p/transport/webrtc/transport.go
@@ -366,7 +366,7 @@ func (t *WebRTCTransport) dial(ctx context.Context, scope network.ConnManagement
 	if err != nil {
 		return nil, err
 	}
-	channel := newStream(w.HandshakeDataChannel, detached, func() {})
+	channel := newStream(w.HandshakeDataChannel, detached, maxRTT, nil, nil)
 
 	remotePubKey, err := t.noiseHandshake(ctx, w.PeerConnection, channel, p, remoteHashFunction, false)
 	if err != nil {


### PR DESCRIPTION
WebRTC data channel close is a synchronous close procedure. We close our outgoing stream, in response the peer is expected to close its outgoing stream. If the peer doesn't close its side of the stream we will end up with a memory leak where the SCTP transport keeps reference to the stream. So we check the number of invalid data channel closures and when this goes over a threshold we close the connection.

For our custom purposes we can fork SCTP and implement a unilateral stream Reset which is feasible because we anyway have a state machine on top of the data channels. But for a RFC compliant SCTP implementation, this is how the spec is supposed to work. SCTP stream numbers are limited (uint16) so we do need to reuse the stream ids forcing us to use a synchronous close mechanism.