### PR TITLE
autonat: Clean up after close

### DIFF
--- a/leaky_tests/leaky_test.go
+++ b/leaky_tests/leaky_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBadTransportConstructor(t *testing.T) {
@@ -17,10 +16,4 @@ func TestBadTransportConstructor(t *testing.T) {
 	if !strings.Contains(err.Error(), "_test.go") {
 		t.Error("expected error to contain debugging info")
 	}
-}
-
-func TestAutoNATService(t *testing.T) {
-	h, err := libp2p.New(libp2p.EnableNATService())
-	require.NoError(t, err)
-	h.Close()
 }

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -370,6 +370,12 @@ func TestRoutedHost(t *testing.T) {
 	require.Equal(t, []peer.ID{id}, mockRouter.queried)
 }
 
+func TestAutoNATService(t *testing.T) {
+	h, err := New(EnableNATService())
+	require.NoError(t, err)
+	h.Close()
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(
 		m,

--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -434,6 +434,9 @@ func (as *AmbientAutoNAT) Close() error {
 		as.service.Disable()
 	}
 	<-as.backgroundRunning
+	if as.service != nil {
+		return as.service.Close()
+	}
 	return nil
 }
 
@@ -444,7 +447,7 @@ func (s *StaticAutoNAT) Status() network.Reachability {
 
 func (s *StaticAutoNAT) Close() error {
 	if s.service != nil {
-		s.service.Disable()
+		return s.service.Close()
 	}
 	return nil
 }

--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -431,12 +431,9 @@ func (as *AmbientAutoNAT) getPeerToProbe() peer.ID {
 func (as *AmbientAutoNAT) Close() error {
 	as.ctxCancel()
 	if as.service != nil {
-		as.service.Disable()
-	}
-	<-as.backgroundRunning
-	if as.service != nil {
 		return as.service.Close()
 	}
+	<-as.backgroundRunning
 	return nil
 }
 

--- a/p2p/host/autonat/svc.go
+++ b/p2p/host/autonat/svc.go
@@ -273,6 +273,11 @@ func (as *autoNATService) Disable() {
 	}
 }
 
+func (as *autoNATService) Close() error {
+	as.Disable()
+	return as.config.dialer.Close()
+}
+
 func (as *autoNATService) background(ctx context.Context) {
 	defer close(as.backgroundRunning)
 

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -263,6 +263,11 @@ func (s *Swarm) Close() error {
 	return nil
 }
 
+// Done returns a channel that is closed when the swarm is closed.
+func (s *Swarm) Done() <-chan struct{} {
+	return s.ctx.Done()
+}
+
 func (s *Swarm) close() {
 	s.ctxCancel()
 


### PR DESCRIPTION
Autonat would leave a couple of dangling go routines because it wouldn't close the swarm or the peerstore. Fixes #2743.