### PR TITLE
quic: make server cmd use RFC 9000 instead of draft-29

### DIFF
--- a/p2p/transport/quic/cmd/server/main.go
+++ b/p2p/transport/quic/cmd/server/main.go
@@ -28,7 +28,7 @@ func main() {
 }
 
 func run(port string) error {
-	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/udp/%s/quic", port))
+	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/udp/%s/quic-v1", port))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Support for QUIC draft-29 has been dropped in v0.30.0, however the transport server cmd has still been using draft-29 and thus fails with error `unknown QUIC version` since that release.

This PR makes `p2p/transport/quic/cmd/server/main.go` use RFC 9000, i.e. `/quic-v1` instead of `/quic`, so that the standalone client/server test commands work again.