### PR TITLE
webrtc: add NullResourceManager, fixes panic

### DIFF
--- a/p2p/transport/webrtc/transport.go
+++ b/p2p/transport/webrtc/transport.go
@@ -113,6 +113,9 @@ func New(privKey ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater, rcmgr 
 		log.Error("WebRTC doesn't support private networks yet.")
 		return nil, fmt.Errorf("WebRTC doesn't support private networks yet")
 	}
+	if rcmgr == nil {
+		rcmgr = &network.NullResourceManager{}
+	}
 	localPeerID, err := peer.IDFromPrivateKey(privKey)
 	if err != nil {
 		return nil, fmt.Errorf("get local peer ID: %w", err)


### PR DESCRIPTION
Had issues dialling due to a null network.ResourceManager

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xf76692]

goroutine 183 [running]:
github.com/libp2p/go-libp2p/p2p/transport/webrtc.(*WebRTCTransport).Dial(0xc00014d860, {0x16b4e00, 0xc000325c70}, {0x16c3dc0, 0xc000371e60}, {0xc00039ec60, 0x26})
	/root/go/pkg/mod/github.com/libp2p/go-libp2p@v0.33.1/p2p/transport/webrtc/transport.go:245 +0x52
github.com/libp2p/go-libp2p/p2p/net/swarm.(*Swarm).dialAddr(0xc000465208, {0x16b4e00, 0xc000325c70}, {0xc00039ec60, 0x26}, {0x16c3dc0, 0xc000371e60}, 0xc00026e900)
	/root/go/pkg/mod/github.com/libp2p/go-libp2p@v0.33.1/p2p/net/swarm/swarm_dial.go:545 +0x41d
github.com/libp2p/go-libp2p/p2p/net/swarm.(*dialLimiter).executeDial(0xc0004a6b90, 0xc0003e4dc0)
	/root/go/pkg/mod/github.com/libp2p/go-libp2p@v0.33.1/p2p/net/swarm/limiter.go:213 +0xfd
created by github.com/libp2p/go-libp2p/p2p/net/swarm.(*dialLimiter).addCheckFdLimit in goroutine 179
	/root/go/pkg/mod/github.com/libp2p/go-libp2p@v0.33.1/p2p/net/swarm/limiter.go:163 +0x485
exit status 2
```