### PR TITLE
libp2phttp: Rename well-known resource

### DIFF
--- a/p2p/http/example_test.go
+++ b/p2p/http/example_test.go
@@ -335,11 +335,11 @@ func ExampleWellKnownHandler() {
 	}
 
 	defer listener.Close()
-	// Serve `.well-known/libp2p`. Note, this is handled automatically if you use the libp2phttp.Host.
+	// Serve the well-known resource. Note, this is handled automatically if you use the libp2phttp.Host.
 	go http.Serve(listener, &h)
 
-	// Get the `.well-known/libp2p` resource
-	resp, err := http.Get("http://" + listener.Addr().String() + "/.well-known/libp2p")
+	// Get the well-known resource
+	resp, err := http.Get("http://" + listener.Addr().String() + libp2phttp.WellKnownProtocols)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -205,7 +205,7 @@ func TestRoundTrippers(t *testing.T) {
 				})
 			}
 
-			// Read the .well-known/libp2p resource
+			// Read the well-known resource
 			wk, err := rt.(libp2phttp.PeerMetadataGetter).GetPeerMetadata()
 			require.NoError(t, err)
 
@@ -219,7 +219,7 @@ func TestRoundTrippers(t *testing.T) {
 func TestPlainOldHTTPServer(t *testing.T) {
 	mux := http.NewServeMux()
 	wk := libp2phttp.WellKnownHandler{}
-	mux.Handle("/.well-known/libp2p", &wk)
+	mux.Handle(libp2phttp.WellKnownProtocols, &wk)
 
 	mux.Handle("/ping/", httpping.Ping{})
 	wk.AddProtocolMeta(httpping.PingProtocolID, libp2phttp.ProtocolMeta{Path: "/ping/"})
@@ -270,7 +270,7 @@ func TestPlainOldHTTPServer(t *testing.T) {
 			},
 			getWellKnown: func(t *testing.T) (libp2phttp.PeerMeta, error) {
 				client := http.Client{}
-				resp, err := client.Get("http://" + l.Addr().String() + "/.well-known/libp2p")
+				resp, err := client.Get("http://" + l.Addr().String() + libp2phttp.WellKnownProtocols)
 				require.NoError(t, err)
 
 				b, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
Renaming the well-known libp2p http resource. Context here: https://github.com/libp2p/specs/pull/508#discussion_r1550043195