### PR TITLE
Identify: emit useful events after identification

### DIFF
--- a/core/event/identify.go
+++ b/core/event/identify.go
@@ -1,11 +1,29 @@
 package event
 
-import "github.com/libp2p/go-libp2p/core/peer"
+import (
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/record"
+	"github.com/multiformats/go-multiaddr"
+)
 
 // EvtPeerIdentificationCompleted is emitted when the initial identification round for a peer is completed.
 type EvtPeerIdentificationCompleted struct {
 	// Peer is the ID of the peer whose identification succeeded.
 	Peer peer.ID
+
+	// Conn is the connection we identified.
+	Conn network.Conn
+
+	// ListenAddrs is the list of addresses the peer is listening on.
+	ListenAddrs []multiaddr.Multiaddr
+
+	// Protocols is the list of protocols the peer advertised on this connection.
+	Protocols []protocol.ID
+
+	// SignedPeerRecord is the provided signed peer record of the peer. May be nil.
+	SignedPeerRecord *record.Envelope
 }
 
 // EvtPeerIdentificationFailed is emitted when the initial identification round for a peer failed.

--- a/core/event/identify.go
+++ b/core/event/identify.go
@@ -24,6 +24,17 @@ type EvtPeerIdentificationCompleted struct {
 
 	// SignedPeerRecord is the provided signed peer record of the peer. May be nil.
 	SignedPeerRecord *record.Envelope
+
+	// AgentVersion is like a UserAgent string in browsers, or client version in
+	// bittorrent includes the client name and client.
+	AgentVersion string
+
+	// ProtocolVersion is the protocolVersion field in the identify message
+	ProtocolVersion string
+
+	// ObservedAddr is the our side's connection address as observed by the
+	// peer. This is not verified, the peer could return anything here.
+	ObservedAddr multiaddr.Multiaddr
 }
 
 // EvtPeerIdentificationFailed is emitted when the initial identification round for a peer failed.

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -222,6 +222,8 @@ func assertCorrectEvtPeerIdentificationCompleted(t *testing.T, evtAny interface{
 			otherAddrsStrings[i] = a.String()
 			evtAddrStrings[i] = evt.ListenAddrs[i].String()
 		}
+		slices.Sort(otherAddrsStrings)
+		slices.Sort(evtAddrStrings)
 		require.Equal(t, otherAddrsStrings, evtAddrStrings)
 	}
 

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -213,7 +213,18 @@ func assertCorrectEvtPeerIdentificationCompleted(t *testing.T, evtAny interface{
 	evt := evtAny.(event.EvtPeerIdentificationCompleted)
 	require.NotNil(t, evt.Conn)
 	require.Equal(t, other.ID(), evt.Peer)
-	require.Equal(t, other.Addrs(), evt.ListenAddrs)
+
+	require.Equal(t, len(other.Addrs()), len(evt.ListenAddrs))
+	if len(other.Addrs()) == len(evt.ListenAddrs) {
+		otherAddrsStrings := make([]string, len(other.Addrs()))
+		evtAddrStrings := make([]string, len(evt.ListenAddrs))
+		for i, a := range other.Addrs() {
+			otherAddrsStrings[i] = a.String()
+			evtAddrStrings[i] = evt.ListenAddrs[i].String()
+		}
+		require.Equal(t, otherAddrsStrings, evtAddrStrings)
+	}
+
 	otherProtos := other.Mux().Protocols()
 	slices.Sort(otherProtos)
 	evtProtos := evt.Protocols

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -200,10 +201,32 @@ func TestIDService(t *testing.T) {
 
 	// test that we received the "identify completed" event.
 	select {
-	case <-sub.Out():
+	case evtAny := <-sub.Out():
+		assertCorrectEvtPeerIdentificationCompleted(t, evtAny, h2)
 	case <-time.After(3 * time.Second):
 		t.Fatalf("expected EvtPeerIdentificationCompleted event within 10 seconds; none received")
 	}
+}
+
+func assertCorrectEvtPeerIdentificationCompleted(t *testing.T, evtAny interface{}, other host.Host) {
+	t.Helper()
+	evt := evtAny.(event.EvtPeerIdentificationCompleted)
+	require.NotNil(t, evt.Conn)
+	require.Equal(t, other.ID(), evt.Peer)
+	require.Equal(t, other.Addrs(), evt.ListenAddrs)
+	otherProtos := other.Mux().Protocols()
+	slices.Sort(otherProtos)
+	evtProtos := evt.Protocols
+	slices.Sort(evtProtos)
+	require.Equal(t, otherProtos, evtProtos)
+	idFromSignedRecord, err := peer.IDFromPublicKey(evt.SignedPeerRecord.PublicKey)
+	require.NoError(t, err)
+	require.Equal(t, other.ID(), idFromSignedRecord)
+	require.Equal(t, peer.PeerRecordEnvelopePayloadType, evt.SignedPeerRecord.PayloadType)
+	var peerRecord peer.PeerRecord
+	evt.SignedPeerRecord.TypedRecord(&peerRecord)
+	require.Equal(t, other.ID(), peerRecord.PeerID)
+	require.Equal(t, other.Addrs(), peerRecord.Addrs)
 }
 
 func TestProtoMatching(t *testing.T) {
@@ -665,7 +688,8 @@ func TestLargeIdentifyMessage(t *testing.T) {
 
 	// test that we received the "identify completed" event.
 	select {
-	case <-sub.Out():
+	case evtAny := <-sub.Out():
+		assertCorrectEvtPeerIdentificationCompleted(t, evtAny, h2)
 	case <-time.After(3 * time.Second):
 		t.Fatalf("expected EvtPeerIdentificationCompleted event within 3 seconds; none received")
 	}


### PR DESCRIPTION
Identify has an event that it emits, but it's not very useful in that it will only tell you a peer has been identified, but not tell you anything about that peer. This design is intended to have the user then lookup peer information somewhere else after they get the event. However, that approach is brittle because it relies on identify itself probing in and updating all the "somewhere elses". This issue is highlight in #2754 and #2355.

Instead, Identify should only concern itself with emitting an event about what it has learned. Other services can subscribe to those events and do their appropriate logic. This helps decouple these services from each other.

Relates to #2754 and #2355 

This is a partial fix for #2754. The next step after this is merged is to update GossipSub to make use of these events.