### PR TITLE
Update and fix examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Let us know if you find any issue or if you want to contribute and add a new tut
 - [The libp2p 'host'](./libp2p-host)
 - [Building an http proxy with libp2p](./http-proxy)
 - [An echo host](./echo)
+- [Routed echo host](./routed-echo/)
 - [Multicodecs with protobufs](./multipro)
 - [P2P chat application](./chat)
 - [P2P chat application w/ rendezvous peer discovery](./chat-with-rendezvous)

--- a/examples/chat/chat.go
+++ b/examples/chat/chat.go
@@ -88,16 +88,11 @@ func main() {
 	if *dest == "" {
 		startPeer(ctx, h, handleStream)
 	} else {
-		rw, err := startPeerAndConnect(ctx, h, *dest)
+		_, err := startPeerAndConnect(ctx, h, *dest)
 		if err != nil {
 			log.Println(err)
 			return
 		}
-
-		// Create a thread to read and write data.
-		go writeData(rw)
-		go readData(rw)
-
 	}
 
 	// Wait forever
@@ -229,6 +224,10 @@ func startPeerAndConnect(ctx context.Context, h host.Host, destination string) (
 
 	// Create a buffered stream so that read and writes are non-blocking.
 	rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
+
+	// Create a thread to read and write data.
+	go writeData(rw)
+	go readData(rw)
 
 	return rw, nil
 }

--- a/examples/chat/chat.go
+++ b/examples/chat/chat.go
@@ -88,7 +88,7 @@ func main() {
 	if *dest == "" {
 		startPeer(ctx, h, handleStream)
 	} else {
-		_, err := startPeerAndConnect(ctx, h, *dest)
+		err := startPeerAndConnect(ctx, h, *dest)
 		if err != nil {
 			log.Println(err)
 			return
@@ -188,7 +188,7 @@ func startPeer(ctx context.Context, h host.Host, streamHandler network.StreamHan
 	log.Println()
 }
 
-func startPeerAndConnect(ctx context.Context, h host.Host, destination string) (*bufio.ReadWriter, error) {
+func startPeerAndConnect(ctx context.Context, h host.Host, destination string) error {
 	log.Println("This node's multiaddresses:")
 	for _, la := range h.Addrs() {
 		log.Printf(" - %v\n", la)
@@ -199,14 +199,14 @@ func startPeerAndConnect(ctx context.Context, h host.Host, destination string) (
 	maddr, err := multiaddr.NewMultiaddr(destination)
 	if err != nil {
 		log.Println(err)
-		return nil, err
+		return err
 	}
 
 	// Extract the peer ID from the multiaddr.
 	info, err := peer.AddrInfoFromP2pAddr(maddr)
 	if err != nil {
 		log.Println(err)
-		return nil, err
+		return err
 	}
 
 	// Add the destination's peer multiaddress in the peerstore.
@@ -218,7 +218,7 @@ func startPeerAndConnect(ctx context.Context, h host.Host, destination string) (
 	s, err := h.NewStream(context.Background(), info.ID, "/chat/1.0.0")
 	if err != nil {
 		log.Println(err)
-		return nil, err
+		return err
 	}
 	log.Println("Established connection to destination")
 
@@ -229,5 +229,5 @@ func startPeerAndConnect(ctx context.Context, h host.Host, destination string) (
 	go writeData(rw)
 	go readData(rw)
 
-	return rw, nil
+	return nil
 }

--- a/examples/chat/chat.go
+++ b/examples/chat/chat.go
@@ -48,50 +48,6 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-func handleStream(s network.Stream) {
-	log.Println("Got a new stream!")
-
-	// Create a buffer stream for non-blocking read and write.
-	rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
-
-	go readData(rw)
-	go writeData(rw)
-
-	// stream 's' will stay open until you close it (or the other side closes it).
-}
-
-func readData(rw *bufio.ReadWriter) {
-	for {
-		str, _ := rw.ReadString('\n')
-
-		if str == "" {
-			return
-		}
-		if str != "\n" {
-			// Green console colour: 	\x1b[32m
-			// Reset console colour: 	\x1b[0m
-			fmt.Printf("\x1b[32m%s\x1b[0m> ", str)
-		}
-
-	}
-}
-
-func writeData(rw *bufio.ReadWriter) {
-	stdReader := bufio.NewReader(os.Stdin)
-
-	for {
-		fmt.Print("> ")
-		sendData, err := stdReader.ReadString('\n')
-		if err != nil {
-			log.Println(err)
-			return
-		}
-
-		rw.WriteString(fmt.Sprintf("%s\n", sendData))
-		rw.Flush()
-	}
-}
-
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -146,6 +102,50 @@ func main() {
 
 	// Wait forever
 	select {}
+}
+
+func handleStream(s network.Stream) {
+	log.Println("Got a new stream!")
+
+	// Create a buffer stream for non-blocking read and write.
+	rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
+
+	go readData(rw)
+	go writeData(rw)
+
+	// stream 's' will stay open until you close it (or the other side closes it).
+}
+
+func readData(rw *bufio.ReadWriter) {
+	for {
+		str, _ := rw.ReadString('\n')
+
+		if str == "" {
+			return
+		}
+		if str != "\n" {
+			// Green console colour: 	\x1b[32m
+			// Reset console colour: 	\x1b[0m
+			fmt.Printf("\x1b[32m%s\x1b[0m> ", str)
+		}
+
+	}
+}
+
+func writeData(rw *bufio.ReadWriter) {
+	stdReader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Print("> ")
+		sendData, err := stdReader.ReadString('\n')
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		rw.WriteString(fmt.Sprintf("%s\n", sendData))
+		rw.Flush()
+	}
 }
 
 func makeHost(port int, randomness io.Reader) (host.Host, error) {

--- a/examples/chat/chat.go
+++ b/examples/chat/chat.go
@@ -222,12 +222,7 @@ func startPeerAndConnect(ctx context.Context, h host.Host, destination string) e
 	}
 	log.Println("Established connection to destination")
 
-	// Create a buffered stream so that read and writes are non-blocking.
-	rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
-
-	// Create a thread to read and write data.
-	go writeData(rw)
-	go readData(rw)
+	handleStream(s)
 
 	return nil
 }

--- a/examples/routed-echo/README.md
+++ b/examples/routed-echo/README.md
@@ -27,7 +27,7 @@ From `go-libp2p/examples` base folder:
 2018/02/19 12:22:32 listening for connections
 ```
 
-The listener libp2p host will print its randomly generated Base58 encoded ID string, which combined with the ipfs DHT, can be used to reach the host, despite lacking other connection details.  By default, this example will bootstrap off your local IPFS peer (assuming one is running). If you'd rather bootstrap off the same peers go-ipfs uses, pass the `-global` flag in both terminals.
+The listener libp2p host will print its randomly generated Base58 encoded ID string, which combined with the ipfs DHT, can be used to reach the host, despite lacking other connection details.  By **default**, this example will bootstrap off your **local IPFS peer** (assuming one is running). If you'd rather bootstrap off the same peers go-ipfs uses, pass the `-global` flag in both terminals.
 
 Now, launch another node that talks to the listener:
 


### PR DESCRIPTION
This PR fixes some readmes and examples in the example section 

- libp2p readme example does not work in its current form, which is fixed in this PR
- routed echo example missing in the main readme
- inconsistent style in the examples. Sometimes the main function is in the beginning sometimes at the end. This PR moves the main function in chat.go and proxy.go at the start of the file in line with the other examples.
- in chat.go the handleStream function is not applied consistently. This is fixed.