### PR TITLE
Update: update incomplete readmes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,17 +2,21 @@
 
 In this folder, you can find a variety of examples to help you get started in using go-libp2p. Every example as a specific purpose and some of each incorporate a full tutorial that you can follow through, helping you expand your knowledge about libp2p and p2p networks in general.
 
-Let us know if you find any issue or if you want to contribute and add a new tutorial, feel welcome to submit a pr, thank you!
+Let us know if you find any issue or if you want to contribute and add a new tutorial, feel welcome to submit a PR, thank you!
 
 ## Examples and Tutorials
 
 - [The libp2p 'host'](./libp2p-host)
 - [Building an http proxy with libp2p](./http-proxy)
 - [An echo host](./echo)
+- [Routed echo host](./routed-echo/)
 - [Multicodecs with protobufs](./multipro)
+- [Relay-based P2P Communication](./relay/)
 - [P2P chat application](./chat)
 - [P2P chat application w/ rendezvous peer discovery](./chat-with-rendezvous)
 - [P2P chat application with peer discovery using mdns](./chat-with-mdns)
+- [P2P chat using pubsub](./pubsub)
 - [A chapter based approach to building a libp2p application](./ipfs-camp-2019/) _Created for [IPFS Camp 2019](https://github.com/ipfs/camp/tree/master/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_B)_
+- [View metrics using Prometheus and Grafana](./metrics-and-dashboards)
 
 For js-libp2p examples, check https://github.com/libp2p/js-libp2p-examples

--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -3,4 +3,5 @@
 This directory contains example projects that use [go-libp2p-pubsub](https://github.com/libp2p/go-libp2p-pubsub),
 the Go implementation of libp2p's [Publish / Subscribe system](https://docs.libp2p.io/concepts/publish-subscribe).
 
-The [chat room example](./chat) covers the basics of using the PubSub API to build a peer-to-peer chat application.
+- The [chat room example](./chat) covers the basics of using the PubSub API to build a peer-to-peer chat application.
+- The [pubsub rendezvous example](.basic-chat-with-rendezvous) allows multiple peers to chat among each other using go-libp2p-pubsub using rendezvous names.

--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -4,4 +4,4 @@ This directory contains example projects that use [go-libp2p-pubsub](https://git
 the Go implementation of libp2p's [Publish / Subscribe system](https://docs.libp2p.io/concepts/publish-subscribe).
 
 - The [chat room example](./chat) covers the basics of using the PubSub API to build a peer-to-peer chat application.
-- The [pubsub rendezvous example](.basic-chat-with-rendezvous) allows multiple peers to chat among each other using go-libp2p-pubsub using rendezvous names.
+- The [pubsub rendezvous example](./basic-chat-with-rendezvous) allows multiple peers to chat among each other using go-libp2p-pubsub using rendezvous names.

--- a/examples/relay/README.md
+++ b/examples/relay/README.md
@@ -1,0 +1,15 @@
+# Relay-based P2P Communication Example
+
+## Overview
+This project demonstrates the setup of a relay-based peer-to-peer communication using the libp2p library in Go. It features creating unreachable libp2p hosts and facilitating their communication through a relay node.
+
+## Features
+- Creation of two "unreachable" libp2p hosts.
+- Setup of a relay node to enable communication between these hosts.
+
+## Usage
+
+Run the program 
+   ```bash
+   go run . 
+   ```


### PR DESCRIPTION
This PR addresses the incompleteness of readmes in the examples section.

- The main readme does not list all the examples in the directory
- The pubsub readme does not list all the examples in this subcategory
- the relay example was missing a readme