### PR TITLE
basichost: append certhash for webrtc addresses provided via address factory

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	libp2pwebtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -786,7 +787,9 @@ func (h *BasicHost) Addrs() []ma.Multiaddr {
 	copy(addrs, addrsOld)
 
 	for i, addr := range addrs {
-		if ok, n := libp2pwebtransport.IsWebtransportMultiaddr(addr); ok && n == 0 {
+		wtOK, wtN := libp2pwebtransport.IsWebtransportMultiaddr(addr)
+		webrtcOK, webrtcN := libp2pwebrtc.IsWebRTCDirectMultiaddr(addr)
+		if (wtOK && wtN == 0) || (webrtcOK && webrtcN == 0) {
 			t := s.TransportForListening(addr)
 			tpt, ok := t.(addCertHasher)
 			if !ok {

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -797,7 +797,7 @@ func (h *BasicHost) Addrs() []ma.Multiaddr {
 			}
 			addrWithCerthash, added := tpt.AddCertHashes(addr)
 			if !added {
-				log.Debug("Couldn't add certhashes to webtransport multiaddr because we aren't listening on webtransport")
+				log.Debugf("Couldn't add certhashes to multiaddr: %s", addr)
 				continue
 			}
 			addrs[i] = addrWithCerthash

--- a/p2p/transport/webrtc/transport.go
+++ b/p2p/transport/webrtc/transport.go
@@ -40,15 +40,12 @@ import (
 	"github.com/libp2p/go-msgio"
 
 	ma "github.com/multiformats/go-multiaddr"
-	mafmt "github.com/multiformats/go-multiaddr-fmt"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/multiformats/go-multihash"
 
 	"github.com/pion/datachannel"
 	"github.com/pion/webrtc/v3"
 )
-
-var dialMatcher = mafmt.And(mafmt.UDP, mafmt.Base(ma.P_WEBRTC_DIRECT), mafmt.Base(ma.P_CERTHASH))
 
 var webrtcComponent *ma.Component
 
@@ -179,7 +176,8 @@ func (t *WebRTCTransport) Proxy() bool {
 }
 
 func (t *WebRTCTransport) CanDial(addr ma.Multiaddr) bool {
-	return dialMatcher.Matches(addr)
+	isValid, n := IsWebRTCDirectMultiaddr(addr)
+	return isValid && n > 0
 }
 
 // Listen returns a listener for addr.
@@ -514,6 +512,24 @@ func (t *WebRTCTransport) noiseHandshake(ctx context.Context, pc *webrtc.PeerCon
 	return secureConn.RemotePublicKey(), nil
 }
 
+func (t *WebRTCTransport) AddCertHashes(addr ma.Multiaddr) (ma.Multiaddr, bool) {
+	listenerFingerprint, err := t.getCertificateFingerprint()
+	if err != nil {
+		return nil, false
+	}
+
+	encodedLocalFingerprint, err := encodeDTLSFingerprint(listenerFingerprint)
+	if err != nil {
+		return nil, false
+	}
+
+	certComp, err := ma.NewComponent(ma.ProtocolWithCode(ma.P_CERTHASH).Name, encodedLocalFingerprint)
+	if err != nil {
+		return nil, false
+	}
+	return addr.Encapsulate(certComp), true
+}
+
 type netConnWrapper struct {
 	*stream
 }
@@ -600,4 +616,25 @@ func newWebRTCConnection(settings webrtc.SettingEngine, config webrtc.Configurat
 		HandshakeDataChannel: handshakeDataChannel,
 		IncomingDataChannels: incomingDataChannels,
 	}, nil
+}
+
+// IsWebRTCDirectMultiaddr returns whether addr is a /webrtc-direct multiaddr with the count of certhashes
+// in addr
+func IsWebRTCDirectMultiaddr(addr ma.Multiaddr) (bool, int) {
+	components := [2]int{ma.P_UDP, ma.P_WEBRTC_DIRECT}
+	var i int
+	certHashCount := 0
+	ma.ForEach(addr, func(c ma.Component) bool {
+		if i < len(components) && c.Protocol().Code == components[i] {
+			i++
+		}
+		if i == len(components) && c.Protocol().Code == ma.P_CERTHASH {
+			certHashCount++
+		}
+		return true
+	})
+	if i == len(components) {
+		return true, certHashCount
+	}
+	return false, 0
 }

--- a/p2p/transport/webrtc/transport_test.go
+++ b/p2p/transport/webrtc/transport_test.go
@@ -40,6 +40,57 @@ func getTransport(t *testing.T, opts ...Option) (*WebRTCTransport, peer.ID) {
 	return transport, peerID
 }
 
+func TestIsWebRTCDirectMultiaddr(t *testing.T) {
+	invalid := []string{
+		"/ip4/1.2.3.4/tcp/10/",
+		"/ip6/1::3/udp/100/quic-v1/",
+	}
+
+	valid := []struct {
+		addr  string
+		count int
+	}{
+		{
+			addr:  "/ip4/1.2.3.4/udp/1234/webrtc-direct",
+			count: 0,
+		},
+		{
+			addr:  "/dns/test.test/udp/1234/webrtc-direct",
+			count: 0,
+		},
+		{
+			addr:  "/ip4/1.2.3.4/udp/1234/webrtc-direct/certhash/uEiAsGPzpiPGQzSlVHRXrUCT5EkTV7YFrV4VZ3hpEKTd_zg",
+			count: 1,
+		},
+		{
+			addr:  "/ip6/0:0:0:0:0:0:0:1/udp/1234/webrtc-direct/certhash/uEiAsGPzpiPGQzSlVHRXrUCT5EkTV7YFrV4VZ3hpEKTd_zg",
+			count: 1,
+		},
+		{
+			addr:  "/dns/test.test/udp/1234/webrtc-direct/certhash/uEiAsGPzpiPGQzSlVHRXrUCT5EkTV7YFrV4VZ3hpEKTd_zg",
+			count: 1,
+		},
+		{
+			addr:  "/dns/test.test/udp/1234/webrtc-direct/certhash/uEiAsGPzpiPGQzSlVHRXrUCT5EkTV7YFrV4VZ3hpEKTd_zg/certhash/uEiAsGPzpiPGQzSlVHRXrUCT5EkTV7ZGrV4VZ3hpEKTd_zg",
+			count: 2,
+		},
+	}
+
+	for _, addr := range invalid {
+		a := ma.StringCast(addr)
+		isValid, n := IsWebRTCDirectMultiaddr(a)
+		require.Equal(t, 0, n)
+		require.False(t, isValid)
+	}
+
+	for _, tc := range valid {
+		a := ma.StringCast(tc.addr)
+		isValid, n := IsWebRTCDirectMultiaddr(a)
+		require.Equal(t, tc.count, n)
+		require.True(t, isValid)
+	}
+}
+
 func TestTransportWebRTC_CanDial(t *testing.T) {
 	tr, _ := getTransport(t)
 	invalid := []string{
@@ -62,6 +113,21 @@ func TestTransportWebRTC_CanDial(t *testing.T) {
 	for _, addr := range valid {
 		a := ma.StringCast(addr)
 		require.True(t, tr.CanDial(a), addr)
+	}
+}
+
+func TestTransportAddCertHasher(t *testing.T) {
+	tr, _ := getTransport(t)
+	addrs := []string{
+		"/ip4/1.2.3.4/udp/1/webrtc-direct",
+		"/ip6/1::3/udp/2/webrtc-direct",
+	}
+	for _, a := range addrs {
+		addr, added := tr.AddCertHashes(ma.StringCast(a))
+		require.True(t, added)
+		_, err := addr.ValueForProtocol(ma.P_CERTHASH)
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(addr.String(), a))
 	}
 }
 

--- a/p2p/transport/webrtc/transport_test.go
+++ b/p2p/transport/webrtc/transport_test.go
@@ -44,6 +44,7 @@ func TestIsWebRTCDirectMultiaddr(t *testing.T) {
 	invalid := []string{
 		"/ip4/1.2.3.4/tcp/10/",
 		"/ip6/1::3/udp/100/quic-v1/",
+		"/ip4/1.2.3.4/udp/1/quic-v1/webrtc-direct",
 	}
 
 	valid := []struct {


### PR DESCRIPTION
This change is similar to how we append certhashes for webtransport. 