### PR TITLE
Use previous well-known resource

### DIFF
--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -30,7 +30,7 @@ import (
 var log = logging.Logger("libp2phttp")
 
 const ProtocolIDForMultistreamSelect = "/http/1.1"
-const WellKnownProtocols = "/.well-known/libp2p/protocols"
+const WellKnownProtocols = "/.well-known/libp2p"
 const peerMetadataLimit = 8 << 10 // 8KB
 const peerMetadataLRUSize = 256   // How many different peer's metadata to keep in our LRU cache
 


### PR DESCRIPTION
Changing from "/.well-known/libp2p" to "/.well-known/libp2p/protocols" will break the ability to communicate with existing servers deployed without upgrading them first. Since these servers are running in places not under our control, they will not be immediately upgradable. This means that libp2phttp needs to support both the old and the new values, or revert to using the old value.

This PR reverts to using the old resource name, which was changed in #2757.
