### PR TITLE
rcmgr: Backwards compatibility if you wrap default impl

### DIFF
--- a/p2p/host/resource-manager/rcmgr.go
+++ b/p2p/host/resource-manager/rcmgr.go
@@ -316,30 +316,16 @@ func (r *resourceManager) nextStreamId() int64 {
 	return r.streamId
 }
 
-func hasIPInMultiaddr(addr multiaddr.Multiaddr) bool {
-	foundIP := false
-	multiaddr.ForEach(addr, func(c multiaddr.Component) bool {
-		switch c.Protocol().Code {
-		case multiaddr.P_IP4, multiaddr.P_IP6:
-			foundIP = true
-			return false
-		default:
-			return true
-		}
-	})
-	return foundIP
+// OpenConnectionNoIP is deprecated and will be removed in the next release
+func (r *resourceManager) OpenConnectionNoIP(dir network.Direction, usefd bool, endpoint multiaddr.Multiaddr) (network.ConnManagementScope, error) {
+	return r.openConnection(dir, usefd, endpoint, netip.Addr{})
 }
 
 func (r *resourceManager) OpenConnection(dir network.Direction, usefd bool, endpoint multiaddr.Multiaddr) (network.ConnManagementScope, error) {
-	if !hasIPInMultiaddr(endpoint) {
-		// We don't have IP information but we still want to limit the
-		// connection by other scopes.
-		return r.openConnection(dir, usefd, endpoint, netip.Addr{})
-	}
-
 	ip, err := manet.ToIP(endpoint)
 	if err != nil {
-		return nil, err
+		// No IP address
+		return r.openConnection(dir, usefd, endpoint, netip.Addr{})
 	}
 
 	ipAddr, ok := netip.AddrFromSlice(ip)

--- a/p2p/protocol/circuitv2/client/transport.go
+++ b/p2p/protocol/circuitv2/client/transport.go
@@ -48,23 +48,8 @@ func AddTransport(h host.Host, upgrader transport.Upgrader) error {
 var _ transport.Transport = (*Client)(nil)
 var _ io.Closer = (*Client)(nil)
 
-// If the resource manager supports OpenConnectionNoIP, we'll use it to open connections.
-// That's because the swarm is already limiting by IP address at the swarm
-// level, and here we want to limit by everything but the IP.
-// Some ResourceManager implementations may not care about IP addresses, so we
-// do our own interface check to see if they provide this option.
-type rcmgrOpenConnectionNoIPer interface {
-	OpenConnectionNoIP(network.Direction, bool, ma.Multiaddr) (network.ConnManagementScope, error)
-}
-
 func (c *Client) Dial(ctx context.Context, a ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
-	var connScope network.ConnManagementScope
-	var err error
-	if rcmgr, ok := c.host.Network().ResourceManager().(rcmgrOpenConnectionNoIPer); ok {
-		connScope, err = rcmgr.OpenConnectionNoIP(network.DirOutbound, false, a)
-	} else {
-		connScope, err = c.host.Network().ResourceManager().OpenConnection(network.DirOutbound, false, a)
-	}
+	connScope, err := c.host.Network().ResourceManager().OpenConnection(network.DirOutbound, false, a)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I tried to introduce a new method to the ResourceManager without breaking the API. That was a mistake, I should have broken the API because the new method was effectively required.

Users who wrapped the default implementation of the ResourceManager wouldn't get the new method. The circuitv2 transport would not see the new method, and then call the fallback method, which would fail in the default implementation. This is a subtle footgun that could have been avoided by either changing the api or changing the default implementation's fallback method to know not to expect an IP address when doing a circuitv2 connection. This fix does the latter for now to not break the API. Another PR I'll introduce soon will break the API and I'll try to merge that before the next release.
