### PR TITLE
rcmgr: Breaking change. Add OpenConnectionNoIP to interface

### DIFF
--- a/core/network/mocks/mock_resource_manager.go
+++ b/core/network/mocks/mock_resource_manager.go
@@ -71,6 +71,21 @@ func (mr *MockResourceManagerMockRecorder) OpenConnection(arg0, arg1, arg2 any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenConnection", reflect.TypeOf((*MockResourceManager)(nil).OpenConnection), arg0, arg1, arg2)
 }
 
+// OpenConnectionNoIP mocks base method.
+func (m *MockResourceManager) OpenConnectionNoIP(arg0 network.Direction, arg1 bool, arg2 multiaddr.Multiaddr) (network.ConnManagementScope, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenConnectionNoIP", arg0, arg1, arg2)
+	ret0, _ := ret[0].(network.ConnManagementScope)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenConnectionNoIP indicates an expected call of OpenConnectionNoIP.
+func (mr *MockResourceManagerMockRecorder) OpenConnectionNoIP(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenConnectionNoIP", reflect.TypeOf((*MockResourceManager)(nil).OpenConnectionNoIP), arg0, arg1, arg2)
+}
+
 // OpenStream mocks base method.
 func (m *MockResourceManager) OpenStream(arg0 peer.ID, arg1 network.Direction) (network.StreamManagementScope, error) {
 	m.ctrl.T.Helper()

--- a/core/network/rcmgr.go
+++ b/core/network/rcmgr.go
@@ -87,6 +87,11 @@ type ResourceManager interface {
 	// the end of the scope's span.
 	OpenConnection(dir Direction, usefd bool, endpoint multiaddr.Multiaddr) (ConnManagementScope, error)
 
+	// OpenConnectionNoIP is like OpenConnection, but does not use IP
+	// information.  Used when we still want to limit the connection by other
+	// scopes, but don't have IP information. i.e. relaying
+	OpenConnectionNoIP(dir Direction, usefd bool, endpoint multiaddr.Multiaddr) (ConnManagementScope, error)
+
 	// OpenStream creates a new stream scope, initially unnegotiated.
 	// An unnegotiated stream will be initially unattached to any protocol scope
 	// and constrained by the transient scope.
@@ -301,6 +306,9 @@ func (n *NullResourceManager) ViewPeer(p peer.ID, f func(PeerScope) error) error
 	return f(&NullScope{})
 }
 func (n *NullResourceManager) OpenConnection(dir Direction, usefd bool, endpoint multiaddr.Multiaddr) (ConnManagementScope, error) {
+	return &NullScope{}, nil
+}
+func (n *NullResourceManager) OpenConnectionNoIP(dir Direction, usefd bool, endpoint multiaddr.Multiaddr) (ConnManagementScope, error) {
 	return &NullScope{}, nil
 }
 func (n *NullResourceManager) OpenStream(p peer.ID, dir Direction) (StreamManagementScope, error) {

--- a/p2p/host/resource-manager/rcmgr.go
+++ b/p2p/host/resource-manager/rcmgr.go
@@ -316,9 +316,9 @@ func (r *resourceManager) nextStreamId() int64 {
 	return r.streamId
 }
 
-// OpenConnectionNoIP is like OpenConnection, but does not use IP information.
-// Used when we still want to limit the connection by other scopes, but don't
-// have IP information like when we are relaying.
+// OpenConnectionNoIP is like OpenConnection, but does not use IP
+// information.  Used when we still want to limit the connection by other
+// scopes, but don't have IP information. i.e. relaying
 func (r *resourceManager) OpenConnectionNoIP(dir network.Direction, usefd bool, endpoint multiaddr.Multiaddr) (network.ConnManagementScope, error) {
 	return r.openConnection(dir, usefd, endpoint, netip.Addr{})
 }


### PR DESCRIPTION
To merge before we make the next minor release.

This adds a `OpenConnectionNoIP` method to the interface for the resource manager. It's used by users who want a connection scope, but don't have an IP address to tie to the connection. I believe the only user is circuitv2 relays.

The reasons to prefer a new method over changing `OpenConnectionIP` to be circuitv2 aware is:
- The caller should be explicit about not having an IP address.
- The resource manager code should not be aware of circuitv2.