### PR TITLE
rcmgr: Support specific network prefix in conn limiter

### DIFF
--- a/p2p/host/resource-manager/conn_limiter.go
+++ b/p2p/host/resource-manager/conn_limiter.go
@@ -1,13 +1,26 @@
 package rcmgr
 
 import (
+	"math"
 	"net/netip"
+	"slices"
 	"sync"
 )
 
-type ConnLimitPerCIDR struct {
-	// How many leading 1 bits in the mask
-	BitMask   int
+type ConnLimitPerSubnet struct {
+	// This defines how big the subnet is. For example, a /24 subnet has a
+	// BitMask of 24. All IPs that share the same 24 bit prefix are in the same
+	// subnet.  Are in the same subnet, and bound to the same limit.
+	BitMask int
+	// The maximum number of connections allowed for each subnet.
+	ConnCount int
+}
+
+type CIDRLimit struct {
+	// The CIDR prefix for which this limit applies.
+	Network netip.Prefix
+
+	// The maximum number of connections allowed for each subnet.
 	ConnCount int
 }
 
@@ -16,11 +29,11 @@ type ConnLimitPerCIDR struct {
 // down
 var defaultMaxConcurrentConns = 8
 
-var defaultIP4Limit = ConnLimitPerCIDR{
+var defaultIP4Limit = ConnLimitPerSubnet{
 	ConnCount: defaultMaxConcurrentConns,
 	BitMask:   32,
 }
-var defaultIP6Limits = []ConnLimitPerCIDR{
+var defaultIP6Limits = []ConnLimitPerSubnet{
 	{
 		ConnCount: defaultMaxConcurrentConns,
 		BitMask:   56,
@@ -31,30 +44,83 @@ var defaultIP6Limits = []ConnLimitPerCIDR{
 	},
 }
 
-func WithLimitPeersPerCIDR(ipv4 []ConnLimitPerCIDR, ipv6 []ConnLimitPerCIDR) Option {
+var DefaultCIDRLimitV4 = sortCIDRLimits([]CIDRLimit{
+	{
+		// Loopback address for v4 https://datatracker.ietf.org/doc/html/rfc6890#section-2.2.2
+		Network:   netip.MustParsePrefix("127.0.0.0/8"),
+		ConnCount: math.MaxInt, // Unlimited
+	},
+})
+var DefaultCIDRLimitV6 = sortCIDRLimits([]CIDRLimit{
+	{
+		// Loopback address for v6 https://datatracker.ietf.org/doc/html/rfc6890#section-2.2.3
+		Network:   netip.MustParsePrefix("::1/128"),
+		ConnCount: math.MaxInt, // Unlimited
+	},
+})
+
+// CIDR limits must be sorted by most specific to least specific.  This lets us
+// actually use the more specific limits, otherwise only the less specific ones
+// would be matched. e.g. 1.2.3.0/24 must come before 1.2.0.0/16.
+func sortCIDRLimits(limits []CIDRLimit) []CIDRLimit {
+	slices.SortStableFunc(limits, func(a, b CIDRLimit) int {
+		return b.Network.Bits() - a.Network.Bits()
+	})
+	return limits
+}
+
+// WithCIDRLimit sets the limits for the number of connections allowed per CIDR
+// defined address block.
+func WithCIDRLimit(ipv4 []CIDRLimit, ipv6 []CIDRLimit) Option {
 	return func(rm *resourceManager) error {
 		if ipv4 != nil {
-			rm.connLimiter.connLimitPerCIDRIP4 = ipv4
+			rm.connLimiter.cidrLimitV4 = sortCIDRLimits(ipv4)
 		}
 		if ipv6 != nil {
-			rm.connLimiter.connLimitPerCIDRIP6 = ipv6
+			rm.connLimiter.cidrLimitV6 = sortCIDRLimits(ipv6)
+		}
+		return nil
+	}
+}
+
+// WithLimitPeersPerSubnet sets the limits for the number of connections allowed per subnet.
+func WithLimitPeersPerSubnet(ipv4 []ConnLimitPerSubnet, ipv6 []ConnLimitPerSubnet) Option {
+	return func(rm *resourceManager) error {
+		if ipv4 != nil {
+			rm.connLimiter.connLimitPerSubnetV4 = ipv4
+		}
+		if ipv6 != nil {
+			rm.connLimiter.connLimitPerSubnetV6 = ipv6
 		}
 		return nil
 	}
 }
 
 type connLimiter struct {
-	mu                  sync.Mutex
-	connLimitPerCIDRIP4 []ConnLimitPerCIDR
-	connLimitPerCIDRIP6 []ConnLimitPerCIDR
-	ip4connsPerLimit    []map[string]int
-	ip6connsPerLimit    []map[string]int
+	mu sync.Mutex
+
+	// Specific CIDR limits. If these are set, they take precedence over the
+	// subnet limits.
+	// These must be sorted by most specific to least specific.
+	cidrLimitV4    []CIDRLimit
+	cidrLimitV6    []CIDRLimit
+	connsPerCIDRV4 []int
+	connsPerCIDRV6 []int
+
+	// Subnet limits.
+	connLimitPerSubnetV4 []ConnLimitPerSubnet
+	connLimitPerSubnetV6 []ConnLimitPerSubnet
+	ip4connsPerLimit     []map[string]int
+	ip6connsPerLimit     []map[string]int
 }
 
 func newConnLimiter() *connLimiter {
 	return &connLimiter{
-		connLimitPerCIDRIP4: []ConnLimitPerCIDR{defaultIP4Limit},
-		connLimitPerCIDRIP6: defaultIP6Limits,
+		cidrLimitV4: DefaultCIDRLimitV4,
+		cidrLimitV6: DefaultCIDRLimitV6,
+
+		connLimitPerSubnetV4: []ConnLimitPerSubnet{defaultIP4Limit},
+		connLimitPerSubnetV6: defaultIP6Limits,
 	}
 }
 
@@ -62,20 +128,46 @@ func newConnLimiter() *connLimiter {
 func (cl *connLimiter) addConn(ip netip.Addr) bool {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
-	limits := cl.connLimitPerCIDRIP4
-	countsPerLimit := cl.ip4connsPerLimit
+	cidrLimits := cl.cidrLimitV4
+	connsPerCidr := cl.connsPerCIDRV4
+	limits := cl.connLimitPerSubnetV4
+	connsPerLimit := cl.ip4connsPerLimit
 	isIP6 := ip.Is6()
 	if isIP6 {
-		limits = cl.connLimitPerCIDRIP6
-		countsPerLimit = cl.ip6connsPerLimit
+		cidrLimits = cl.cidrLimitV6
+		connsPerCidr = cl.connsPerCIDRV6
+		limits = cl.connLimitPerSubnetV6
+		connsPerLimit = cl.ip6connsPerLimit
 	}
 
-	if len(countsPerLimit) == 0 && len(limits) > 0 {
-		countsPerLimit = make([]map[string]int, len(limits))
+	// Check CIDR limits first
+	if len(connsPerCidr) == 0 && len(cidrLimits) > 0 {
+		// Initialize the counts
+		connsPerCidr = make([]int, len(cidrLimits))
+	}
+
+	for i, limit := range cidrLimits {
+		if limit.Network.Contains(ip) {
+			if connsPerCidr[i]+1 > limit.ConnCount {
+				return false
+			}
+			connsPerCidr[i]++
+			if isIP6 {
+				cl.connsPerCIDRV6 = connsPerCidr
+			} else {
+				cl.connsPerCIDRV4 = connsPerCidr
+			}
+
+			return true
+		}
+	}
+
+	if len(connsPerLimit) == 0 && len(limits) > 0 {
+		connsPerLimit = make([]map[string]int, len(limits))
 		if isIP6 {
-			cl.ip6connsPerLimit = countsPerLimit
+			cl.ip6connsPerLimit = connsPerLimit
 		} else {
-			cl.ip4connsPerLimit = countsPerLimit
+			cl.ip4connsPerLimit = connsPerLimit
 		}
 	}
 
@@ -85,12 +177,12 @@ func (cl *connLimiter) addConn(ip netip.Addr) bool {
 			return false
 		}
 		masked := prefix.String()
-		counts, ok := countsPerLimit[i][masked]
+		counts, ok := connsPerLimit[i][masked]
 		if !ok {
-			if countsPerLimit[i] == nil {
-				countsPerLimit[i] = make(map[string]int)
+			if connsPerLimit[i] == nil {
+				connsPerLimit[i] = make(map[string]int)
 			}
-			countsPerLimit[i][masked] = 0
+			connsPerLimit[i][masked] = 0
 		}
 		if counts+1 > limit.ConnCount {
 			return false
@@ -101,7 +193,7 @@ func (cl *connLimiter) addConn(ip netip.Addr) bool {
 	for i, limit := range limits {
 		prefix, _ := ip.Prefix(limit.BitMask)
 		masked := prefix.String()
-		countsPerLimit[i][masked]++
+		connsPerLimit[i][masked]++
 	}
 
 	return true
@@ -110,12 +202,52 @@ func (cl *connLimiter) addConn(ip netip.Addr) bool {
 func (cl *connLimiter) rmConn(ip netip.Addr) {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
-	limits := cl.connLimitPerCIDRIP4
-	countsPerLimit := cl.ip4connsPerLimit
+	cidrLimits := cl.cidrLimitV4
+	connsPerCidr := cl.connsPerCIDRV4
+	limits := cl.connLimitPerSubnetV4
+	connsPerLimit := cl.ip4connsPerLimit
 	isIP6 := ip.Is6()
 	if isIP6 {
-		limits = cl.connLimitPerCIDRIP6
-		countsPerLimit = cl.ip6connsPerLimit
+		cidrLimits = cl.cidrLimitV6
+		connsPerCidr = cl.connsPerCIDRV6
+		limits = cl.connLimitPerSubnetV6
+		connsPerLimit = cl.ip6connsPerLimit
+	}
+
+	// Check CIDR limits first
+
+	if len(connsPerCidr) == 0 && len(cidrLimits) > 0 {
+		// Initialize just in case. We should have already initialized in
+		// addConn, but if the callers calls rmConn first we don't want to panic
+		connsPerCidr = make([]int, len(cidrLimits))
+	}
+	for i, limit := range cidrLimits {
+		if limit.Network.Contains(ip) {
+			count := connsPerCidr[i]
+			if count <= 0 {
+				log.Errorf("unexpected conn count for ip %s. Was this not added with addConn first?", ip)
+			}
+			connsPerCidr[i]--
+			if isIP6 {
+				cl.connsPerCIDRV6 = connsPerCidr
+			} else {
+				cl.connsPerCIDRV4 = connsPerCidr
+			}
+
+			// Done. We updated the count in the defined CIDR limit.
+			return
+		}
+	}
+
+	if len(connsPerLimit) == 0 && len(limits) > 0 {
+		// Initialize just in case. We should have already initialized in
+		// addConn, but if the callers calls rmConn first we don't want to panic
+		connsPerLimit = make([]map[string]int, len(limits))
+		if isIP6 {
+			cl.ip6connsPerLimit = connsPerLimit
+		} else {
+			cl.ip4connsPerLimit = connsPerLimit
+		}
 	}
 
 	for i, limit := range limits {
@@ -126,15 +258,15 @@ func (cl *connLimiter) rmConn(ip netip.Addr) {
 			continue
 		}
 		masked := prefix.String()
-		counts, ok := countsPerLimit[i][masked]
+		counts, ok := connsPerLimit[i][masked]
 		if !ok || counts == 0 {
 			// Unexpected, but don't panic
 			log.Errorf("unexpected conn count for %s ok=%v count=%v", masked, ok, counts)
 			continue
 		}
-		countsPerLimit[i][masked]--
-		if countsPerLimit[i][masked] == 0 {
-			delete(countsPerLimit[i], masked)
+		connsPerLimit[i][masked]--
+		if connsPerLimit[i][masked] <= 0 {
+			delete(connsPerLimit[i], masked)
 		}
 	}
 }

--- a/p2p/host/resource-manager/conn_limiter_test.go
+++ b/p2p/host/resource-manager/conn_limiter_test.go
@@ -78,7 +78,7 @@ func TestItLimits(t *testing.T) {
 
 	t.Run("IPv4 with localhost", func(t *testing.T) {
 		cl := &connLimiter{
-			cidrLimitV4: DefaultCIDRLimitV4,
+			networkPrefixLimitV4: DefaultNetworkPrefixLimitV4,
 			connLimitPerSubnetV4: []ConnLimitPerSubnet{
 				{BitMask: 0, ConnCount: 1}, // 1 connection for the whole IPv4 space
 			},
@@ -149,10 +149,10 @@ func FuzzConnLimiter(f *testing.F) {
 				addedCount += count
 			}
 		}
-		for _, count := range cl.connsPerCIDRV4 {
+		for _, count := range cl.connsPerNetworkPrefixV4 {
 			addedCount += count
 		}
-		for _, count := range cl.connsPerCIDRV6 {
+		for _, count := range cl.connsPerNetworkPrefixV6 {
 			addedCount += count
 		}
 		if addedCount == 0 && len(addedConns) > 0 {
@@ -174,10 +174,10 @@ func FuzzConnLimiter(f *testing.F) {
 				leftoverCount += count
 			}
 		}
-		for _, count := range cl.connsPerCIDRV4 {
+		for _, count := range cl.connsPerNetworkPrefixV4 {
 			addedCount += count
 		}
-		for _, count := range cl.connsPerCIDRV6 {
+		for _, count := range cl.connsPerNetworkPrefixV6 {
 			addedCount += count
 		}
 		if leftoverCount != 0 {
@@ -186,8 +186,8 @@ func FuzzConnLimiter(f *testing.F) {
 	})
 }
 
-func TestSortedCIDRLimits(t *testing.T) {
-	cidrLimits := []CIDRLimit{
+func TestSortedNetworkPrefixLimits(t *testing.T) {
+	npLimits := []NetworkPrefixLimit{
 		{
 			Network: netip.MustParsePrefix("1.2.0.0/16"),
 		},
@@ -198,8 +198,8 @@ func TestSortedCIDRLimits(t *testing.T) {
 			Network: netip.MustParsePrefix("1.2.3.4/32"),
 		},
 	}
-	cidrLimits = sortCIDRLimits(cidrLimits)
-	sorted := []CIDRLimit{
+	npLimits = sortNetworkPrefixes(npLimits)
+	sorted := []NetworkPrefixLimit{
 		{
 			Network: netip.MustParsePrefix("1.2.3.4/32"),
 		},
@@ -210,5 +210,5 @@ func TestSortedCIDRLimits(t *testing.T) {
 			Network: netip.MustParsePrefix("1.2.0.0/16"),
 		},
 	}
-	require.EqualValues(t, sorted, cidrLimits)
+	require.EqualValues(t, sorted, npLimits)
 }

--- a/p2p/host/resource-manager/conn_limiter_test.go
+++ b/p2p/host/resource-manager/conn_limiter_test.go
@@ -2,7 +2,6 @@ package rcmgr
 
 import (
 	"encoding/binary"
-	"fmt"
 	"net"
 	"net/netip"
 	"testing"
@@ -15,7 +14,7 @@ func TestItLimits(t *testing.T) {
 		ip, err := netip.ParseAddr("1.2.3.4")
 		require.NoError(t, err)
 		cl := newConnLimiter()
-		cl.connLimitPerCIDRIP4[0].ConnCount = 1
+		cl.connLimitPerSubnetV4[0].ConnCount = 1
 		require.True(t, cl.addConn(ip))
 
 		// should fail the second time
@@ -29,10 +28,10 @@ func TestItLimits(t *testing.T) {
 		ip, err := netip.ParseAddr("1:2:3:4::1")
 		require.NoError(t, err)
 		cl := newConnLimiter()
-		original := cl.connLimitPerCIDRIP6[0].ConnCount
-		cl.connLimitPerCIDRIP6[0].ConnCount = 1
+		original := cl.connLimitPerSubnetV6[0].ConnCount
+		cl.connLimitPerSubnetV6[0].ConnCount = 1
 		defer func() {
-			cl.connLimitPerCIDRIP6[0].ConnCount = original
+			cl.connLimitPerSubnetV6[0].ConnCount = original
 		}()
 		require.True(t, cl.addConn(ip))
 
@@ -67,7 +66,6 @@ func TestItLimits(t *testing.T) {
 		for i := 0; i < defaultMaxConcurrentConns*8; i++ {
 			ip := net.ParseIP("ffef:2:3:4::1")
 			binary.BigEndian.PutUint16(ip[5:7], uint16(i))
-			fmt.Println(ip.String())
 			ipAddr := netip.MustParseAddr(ip.String())
 			require.True(t, cl.addConn(ipAddr))
 		}
@@ -76,6 +74,26 @@ func TestItLimits(t *testing.T) {
 		binary.BigEndian.PutUint16(ip[5:7], uint16(defaultMaxConcurrentConns*8+1))
 		ipAddr := netip.MustParseAddr(ip.String())
 		require.False(t, cl.addConn(ipAddr))
+	})
+
+	t.Run("IPv4 with localhost", func(t *testing.T) {
+		cl := &connLimiter{
+			cidrLimitV4: DefaultCIDRLimitV4,
+			connLimitPerSubnetV4: []ConnLimitPerSubnet{
+				{BitMask: 0, ConnCount: 1}, // 1 connection for the whole IPv4 space
+			},
+		}
+
+		ip := netip.MustParseAddr("1.2.3.4")
+		require.True(t, cl.addConn(ip))
+
+		ip = netip.MustParseAddr("4.3.2.1")
+		// should fail the second time, we only allow 1 connection for the whole IPv4 space
+		require.False(t, cl.addConn(ip))
+
+		ip = netip.MustParseAddr("127.0.0.1")
+		// Succeeds because we defined an explicit limit for the loopback subnet
+		require.True(t, cl.addConn(ip))
 	})
 }
 
@@ -131,6 +149,12 @@ func FuzzConnLimiter(f *testing.F) {
 				addedCount += count
 			}
 		}
+		for _, count := range cl.connsPerCIDRV4 {
+			addedCount += count
+		}
+		for _, count := range cl.connsPerCIDRV6 {
+			addedCount += count
+		}
 		if addedCount == 0 && len(addedConns) > 0 {
 			t.Fatalf("added count: %d", addedCount)
 		}
@@ -150,9 +174,41 @@ func FuzzConnLimiter(f *testing.F) {
 				leftoverCount += count
 			}
 		}
+		for _, count := range cl.connsPerCIDRV4 {
+			addedCount += count
+		}
+		for _, count := range cl.connsPerCIDRV6 {
+			addedCount += count
+		}
 		if leftoverCount != 0 {
 			t.Fatalf("leftover count: %d", leftoverCount)
 		}
 	})
+}
 
+func TestSortedCIDRLimits(t *testing.T) {
+	cidrLimits := []CIDRLimit{
+		{
+			Network: netip.MustParsePrefix("1.2.0.0/16"),
+		},
+		{
+			Network: netip.MustParsePrefix("1.2.3.0/28"),
+		},
+		{
+			Network: netip.MustParsePrefix("1.2.3.4/32"),
+		},
+	}
+	cidrLimits = sortCIDRLimits(cidrLimits)
+	sorted := []CIDRLimit{
+		{
+			Network: netip.MustParsePrefix("1.2.3.4/32"),
+		},
+		{
+			Network: netip.MustParsePrefix("1.2.3.0/28"),
+		},
+		{
+			Network: netip.MustParsePrefix("1.2.0.0/16"),
+		},
+	}
+	require.EqualValues(t, sorted, cidrLimits)
 }

--- a/p2p/host/resource-manager/conn_limiter_test.go
+++ b/p2p/host/resource-manager/conn_limiter_test.go
@@ -80,7 +80,7 @@ func TestItLimits(t *testing.T) {
 		cl := &connLimiter{
 			networkPrefixLimitV4: DefaultNetworkPrefixLimitV4,
 			connLimitPerSubnetV4: []ConnLimitPerSubnet{
-				{BitMask: 0, ConnCount: 1}, // 1 connection for the whole IPv4 space
+				{PrefixLength: 0, ConnCount: 1}, // 1 connection for the whole IPv4 space
 			},
 		}
 

--- a/p2p/host/resource-manager/rcmgr.go
+++ b/p2p/host/resource-manager/rcmgr.go
@@ -149,11 +149,11 @@ func NewResourceManager(limits Limiter, opts ...Option) (network.ResourceManager
 	}
 
 	registeredConnLimiterPrefixes := make(map[string]struct{})
-	for _, cidr := range r.connLimiter.cidrLimitV4 {
-		registeredConnLimiterPrefixes[cidr.Network.String()] = struct{}{}
+	for _, npLimit := range r.connLimiter.networkPrefixLimitV4 {
+		registeredConnLimiterPrefixes[npLimit.Network.String()] = struct{}{}
 	}
-	for _, cidr := range r.connLimiter.cidrLimitV6 {
-		registeredConnLimiterPrefixes[cidr.Network.String()] = struct{}{}
+	for _, npLimit := range r.connLimiter.networkPrefixLimitV6 {
+		registeredConnLimiterPrefixes[npLimit.Network.String()] = struct{}{}
 	}
 	for _, network := range allowlist.allowedNetworks {
 		prefix, err := netip.ParsePrefix(network.String())
@@ -163,7 +163,7 @@ func NewResourceManager(limits Limiter, opts ...Option) (network.ResourceManager
 		}
 		if _, ok := registeredConnLimiterPrefixes[prefix.String()]; !ok {
 			// connlimiter doesn't know about this network. Let's fix that
-			r.connLimiter.addCIDRLimit(prefix.Addr().Is6(), CIDRLimit{
+			r.connLimiter.addNetworkPrefixLimit(prefix.Addr().Is6(), NetworkPrefixLimit{
 				Network:   prefix,
 				ConnCount: r.limits.GetAllowlistedSystemLimits().GetConnTotalLimit(),
 			})

--- a/p2p/host/resource-manager/rcmgr.go
+++ b/p2p/host/resource-manager/rcmgr.go
@@ -148,6 +148,28 @@ func NewResourceManager(limits Limiter, opts ...Option) (network.ResourceManager
 		}
 	}
 
+	registeredConnLimiterPrefixes := make(map[string]struct{})
+	for _, cidr := range r.connLimiter.cidrLimitV4 {
+		registeredConnLimiterPrefixes[cidr.Network.String()] = struct{}{}
+	}
+	for _, cidr := range r.connLimiter.cidrLimitV6 {
+		registeredConnLimiterPrefixes[cidr.Network.String()] = struct{}{}
+	}
+	for _, network := range allowlist.allowedNetworks {
+		prefix, err := netip.ParsePrefix(network.String())
+		if err != nil {
+			log.Debugf("failed to parse prefix from allowlist %s, %s", network, err)
+			continue
+		}
+		if _, ok := registeredConnLimiterPrefixes[prefix.String()]; !ok {
+			// connlimiter doesn't know about this network. Let's fix that
+			r.connLimiter.addCIDRLimit(prefix.Addr().Is6(), CIDRLimit{
+				Network:   prefix,
+				ConnCount: r.limits.GetAllowlistedSystemLimits().GetConnTotalLimit(),
+			})
+		}
+	}
+
 	if !r.disableMetrics {
 		var sr TraceReporter
 		sr, err := NewStatsTraceReporter()

--- a/p2p/host/resource-manager/rcmgr_test.go
+++ b/p2p/host/resource-manager/rcmgr_test.go
@@ -1,12 +1,14 @@
 package rcmgr
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/stretchr/testify/require"
 
 	"github.com/multiformats/go-multiaddr"
 )
@@ -1050,4 +1052,61 @@ func TestResourceManagerWithAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestAllowlistAndConnLimiterPlayNice(t *testing.T) {
+	limits := DefaultLimits.AutoScale()
+	limits.allowlistedSystem.Conns = 8
+	limits.allowlistedSystem.ConnsInbound = 8
+	limits.allowlistedSystem.ConnsOutbound = 8
+	t.Run("IPv4", func(t *testing.T) {
+		rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
+			multiaddr.StringCast("/ip4/1.2.3.0/ipcidr/24"),
+		}), WithCIDRLimit([]CIDRLimit{}, []CIDRLimit{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rcmgr.Close()
+
+		// The connLimiter should have the allowlisted cidr
+		require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].Network)
+
+		// The connLimiter should use the limit from the allowlist
+		require.Equal(t, 8, rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].ConnCount)
+	})
+	t.Run("IPv6", func(t *testing.T) {
+		rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
+			multiaddr.StringCast("/ip6/1:2:3::/ipcidr/58"),
+		}), WithCIDRLimit([]CIDRLimit{}, []CIDRLimit{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rcmgr.Close()
+
+		// The connLimiter should have the allowlisted cidr
+		require.Equal(t, netip.MustParsePrefix("1:2:3::/58"), rcmgr.(*resourceManager).connLimiter.cidrLimitV6[0].Network)
+
+		// The connLimiter should use the limit from the allowlist
+		require.Equal(t, 8, rcmgr.(*resourceManager).connLimiter.cidrLimitV6[0].ConnCount)
+	})
+
+	t.Run("Does not override if you set a limit directly", func(t *testing.T) {
+		rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
+			multiaddr.StringCast("/ip4/1.2.3.0/ipcidr/24"),
+		}), WithCIDRLimit([]CIDRLimit{
+			{Network: netip.MustParsePrefix("1.2.3.0/24"), ConnCount: 1},
+		}, []CIDRLimit{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rcmgr.Close()
+
+		// The connLimiter should have it because we set it
+		require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].Network)
+		// should only have one cidr limit
+		require.Equal(t, 1, len(rcmgr.(*resourceManager).connLimiter.cidrLimitV4))
+
+		// The connLimiter should use the limit we defined explicitly
+		require.Equal(t, 1, rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].ConnCount)
+	})
 }

--- a/p2p/host/resource-manager/rcmgr_test.go
+++ b/p2p/host/resource-manager/rcmgr_test.go
@@ -1054,6 +1054,7 @@ func TestResourceManagerWithAllowlist(t *testing.T) {
 	}
 }
 
+// TestAllowlistAndConnLimiterPlayNice checks that the connLimiter learns about network prefix limits from the allowlist.
 func TestAllowlistAndConnLimiterPlayNice(t *testing.T) {
 	limits := DefaultLimits.AutoScale()
 	limits.allowlistedSystem.Conns = 8
@@ -1062,51 +1063,51 @@ func TestAllowlistAndConnLimiterPlayNice(t *testing.T) {
 	t.Run("IPv4", func(t *testing.T) {
 		rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
 			multiaddr.StringCast("/ip4/1.2.3.0/ipcidr/24"),
-		}), WithCIDRLimit([]CIDRLimit{}, []CIDRLimit{}))
+		}), WithNetworkPrefixLimit([]NetworkPrefixLimit{}, []NetworkPrefixLimit{}))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer rcmgr.Close()
 
-		// The connLimiter should have the allowlisted cidr
-		require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].Network)
+		// The connLimiter should have the allowlisted network prefix
+		require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV4[0].Network)
 
 		// The connLimiter should use the limit from the allowlist
-		require.Equal(t, 8, rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].ConnCount)
+		require.Equal(t, 8, rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV4[0].ConnCount)
 	})
 	t.Run("IPv6", func(t *testing.T) {
 		rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
 			multiaddr.StringCast("/ip6/1:2:3::/ipcidr/58"),
-		}), WithCIDRLimit([]CIDRLimit{}, []CIDRLimit{}))
+		}), WithNetworkPrefixLimit([]NetworkPrefixLimit{}, []NetworkPrefixLimit{}))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer rcmgr.Close()
 
-		// The connLimiter should have the allowlisted cidr
-		require.Equal(t, netip.MustParsePrefix("1:2:3::/58"), rcmgr.(*resourceManager).connLimiter.cidrLimitV6[0].Network)
+		// The connLimiter should have the allowlisted network prefix
+		require.Equal(t, netip.MustParsePrefix("1:2:3::/58"), rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV6[0].Network)
 
 		// The connLimiter should use the limit from the allowlist
-		require.Equal(t, 8, rcmgr.(*resourceManager).connLimiter.cidrLimitV6[0].ConnCount)
+		require.Equal(t, 8, rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV6[0].ConnCount)
 	})
 
 	t.Run("Does not override if you set a limit directly", func(t *testing.T) {
 		rcmgr, err := NewResourceManager(NewFixedLimiter(limits), WithAllowlistedMultiaddrs([]multiaddr.Multiaddr{
 			multiaddr.StringCast("/ip4/1.2.3.0/ipcidr/24"),
-		}), WithCIDRLimit([]CIDRLimit{
+		}), WithNetworkPrefixLimit([]NetworkPrefixLimit{
 			{Network: netip.MustParsePrefix("1.2.3.0/24"), ConnCount: 1},
-		}, []CIDRLimit{}))
+		}, []NetworkPrefixLimit{}))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer rcmgr.Close()
 
 		// The connLimiter should have it because we set it
-		require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].Network)
-		// should only have one cidr limit
-		require.Equal(t, 1, len(rcmgr.(*resourceManager).connLimiter.cidrLimitV4))
+		require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV4[0].Network)
+		// should only have one network prefix limit
+		require.Equal(t, 1, len(rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV4))
 
 		// The connLimiter should use the limit we defined explicitly
-		require.Equal(t, 1, rcmgr.(*resourceManager).connLimiter.cidrLimitV4[0].ConnCount)
+		require.Equal(t, 1, rcmgr.(*resourceManager).connLimiter.networkPrefixLimitV4[0].ConnCount)
 	})
 }


### PR DESCRIPTION
Despite the field being called "ConnLimitPerCIDR" you weren't able to define limits for a specific CIDR address block. I've renamed this to ConnLimitPerSubnet to make it clearer that this connection limit applies to each subnet with the same N bit prefix.

I've also added an option to allow defining limits on specific address prefix blocks. If an IP address matches one of these blocks then that limit is used instead of the more generic `ConnLimitPerSubnet`. By default you are allowed unlimited connections from localhost. This should prevent test breakages we've seen.

This does break the existing API. I think that's okay because:
- We just released this API, so hopefully no one is using it yet. Or, if they are, it's fresh on their mind.
- Most users probably just stuck with the defaults. And the defaults here are better.
- The old names were confusing at best.