### PR TITLE
autorelay: define RelayFinder as an interface to support custom RelayFinder

### DIFF
--- a/p2p/host/autorelay/options.go
+++ b/p2p/host/autorelay/options.go
@@ -3,6 +3,7 @@ package autorelay
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -42,6 +43,8 @@ type config struct {
 	setMinCandidates bool
 	// see WithMetricsTracer
 	metricsTracer MetricsTracer
+	// see WithRelayFinder
+	rf RelayFinder
 }
 
 var defaultConfig = config{
@@ -228,6 +231,17 @@ func WithMinInterval(interval time.Duration) Option {
 func WithMetricsTracer(mt MetricsTracer) Option {
 	return func(c *config) error {
 		c.metricsTracer = mt
+		return nil
+	}
+}
+
+// WithRelayFinder configures autorelay to use the given RelayFinder to manage relay connections
+func WithRelayFinder(rf RelayFinder) Option {
+	return func(c *config) error {
+		if rf == nil {
+			return fmt.Errorf("cannot specify RelayFinder")
+		}
+		c.rf = rf
 		return nil
 	}
 }

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -707,14 +707,14 @@ func (rf *relayFinder) selectCandidates() []*candidate {
 	return candidates
 }
 
-// This function is computes the NATed relay addrs when our status is private:
+// RelayAddrs computes the NATed relay addrs when our status is private:
 //   - The public addrs are removed from the address set.
 //   - The non-public addrs are included verbatim so that peers behind the same NAT/firewall
 //     can still dial us directly.
 //   - On top of those, we add the relay-specific addrs for the relays to which we are
 //     connected. For each non-private relay addr, we encapsulate the p2p-circuit addr
 //     through which we can be dialed.
-func (rf *relayFinder) relayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
+func (rf *relayFinder) RelayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	rf.relayMx.Lock()
 	defer rf.relayMx.Unlock()
 


### PR DESCRIPTION
In the previous autoRelay, relayFinder was defined as a structure wrapped in autoRelay

The logic of autoRelay itself is separated from relayFinder. Here we can abstract relayFinder into an interface for decoupling autoRelay and relayFinder.

At the same time, Options are added here for developers to transfer their own implementation of relayFinder.