### PR TITLE
libp2phttp: workaround for ResponseWriter's CloseNotifier

### DIFF
--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -61,7 +61,7 @@ type WellKnownHandler struct {
 
 // streamHostListen returns a net.Listener that listens on libp2p streams for HTTP/1.1 messages.
 func streamHostListen(streamHost host.Host) (net.Listener, error) {
-	return gostream.Listen(streamHost, ProtocolIDForMultistreamSelect)
+	return gostream.Listen(streamHost, ProtocolIDForMultistreamSelect, gostream.IgnoreEOF())
 }
 
 func (h *WellKnownHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -731,6 +731,7 @@ func TestResponseWriterShouldNotHaveCancelledContext(t *testing.T) {
 	closeNotifyCh := make(chan bool, 1)
 	httpHost.SetHTTPHandlerAtPath("/test", "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Legacy code uses this to check if the connection was closed
+		//lint:ignore SA1019 This is a test to assert we do the right thing since Go HTTP stdlib depends on this.
 		ch := w.(http.CloseNotifier).CloseNotify()
 		select {
 		case <-ch:

--- a/p2p/net/gostream/conn.go
+++ b/p2p/net/gostream/conn.go
@@ -2,6 +2,7 @@ package gostream
 
 import (
 	"context"
+	"io"
 	"net"
 
 	"github.com/libp2p/go-libp2p/core/host"
@@ -14,11 +15,20 @@ import (
 // libp2p streams.
 type conn struct {
 	network.Stream
+	ignoreEOF bool
+}
+
+func (c *conn) Read(b []byte) (int, error) {
+	n, err := c.Stream.Read(b)
+	if err != nil && c.ignoreEOF && err == io.EOF {
+		return n, nil
+	}
+	return n, err
 }
 
 // newConn creates a conn given a libp2p stream
-func newConn(s network.Stream) net.Conn {
-	return &conn{s}
+func newConn(s network.Stream, ignoreEOF bool) net.Conn {
+	return &conn{s, ignoreEOF}
 }
 
 // LocalAddr returns the local network address.
@@ -39,5 +49,5 @@ func Dial(ctx context.Context, h host.Host, pid peer.ID, tag protocol.ID) (net.C
 	if err != nil {
 		return nil, err
 	}
-	return newConn(s), nil
+	return newConn(s, false), nil
 }


### PR DESCRIPTION
ResponseWriter implements a deprecated `CloseNotifier` interface. The [implementation](https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/net/http/server.go;l=738) considers any error during a read an indication that the whole connection is closed. One of these errors is EOF.

When we do HTTP over streams, it's normal for an EOF to happen after reading the request (in fact, it's recommended in the spec).

The workaround here is to ignore EOF errors on read when it's a stream we accept a stream (Listener side). This should be fine since we know how to read a full request (doesn't rely on EOF) and if the stream is closed writing will fail