### PR TITLE
webrtc: fix ufrag prefix for dialing

### DIFF
--- a/p2p/transport/webrtc/transport.go
+++ b/p2p/transport/webrtc/transport.go
@@ -415,15 +415,17 @@ func genUfrag() string {
 		uFragAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 		uFragPrefix   = "libp2p+webrtc+v1/"
 		uFragIdLength = 32
-		uFragIdOffset = len(uFragPrefix)
-		uFragLength   = uFragIdOffset + uFragIdLength
+		uFragLength   = len(uFragPrefix) + uFragIdLength
 	)
 
 	seed := [8]byte{}
 	rand.Read(seed[:])
 	r := mrand.New(mrand.NewSource(binary.BigEndian.Uint64(seed[:])))
 	b := make([]byte, uFragLength)
-	for i := uFragIdOffset; i < uFragLength; i++ {
+	for i := 0; i < len(uFragPrefix); i++ {
+		b[i] = uFragPrefix[i]
+	}
+	for i := len(uFragPrefix); i < uFragLength; i++ {
 		b[i] = uFragAlphabet[r.Intn(len(uFragAlphabet))]
 	}
 	return string(b)

--- a/p2p/transport/webrtc/transport_test.go
+++ b/p2p/transport/webrtc/transport_test.go
@@ -860,3 +860,10 @@ func TestMaxInFlightRequests(t *testing.T) {
 	require.Equal(t, count, int(success.Load()), "expected exactly 3 dial successes")
 	require.Equal(t, 1, int(fails.Load()), "expected exactly 1 dial failure")
 }
+
+func TestGenUfrag(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		s := genUfrag()
+		require.True(t, strings.HasPrefix(s, "libp2p+webrtc+v1/"))
+	}
+}


### PR DESCRIPTION
Closes: #2827 

Should we reject connections attempts with ufrag that don't have this prefix? 

I think it is fine to accept all attempts. The purpose of this prefix is to allow us to extend this in the future. So when we do v2 we can make that check aggressive and consider all ufrags without any prefix to be v1. 