### PR TITLE
libp2phttp.Host implements RoundTripper

### DIFF
--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -674,11 +674,15 @@ func (h *Host) RoundTrip(r *http.Request) (*http.Response, error) {
 			// completeness, but I don't expect us to hit it often.
 			rt = rt.Clone()
 			rt.TLSClientConfig.ServerName = parsed.sni
-			defer rt.CloseIdleConnections()
 		}
 
-		r.URL.Scheme = scheme
-		r.URL.Host = parsed.host + ":" + parsed.port
+		// TODO add http-path support
+		url := url.URL{
+			Scheme: scheme,
+			Host:   parsed.host + ":" + parsed.port,
+		}
+
+		r.URL = &url
 		return rt.RoundTrip(r)
 	}
 

--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -628,7 +628,12 @@ func (h *Host) NamespacedClient(p protocol.ID, server peer.AddrInfo, opts ...Rou
 func (h *Host) initDefaultRT() {
 	h.createDefaultClientRoundTripper.Do(func() {
 		if h.DefaultClientRoundTripper == nil {
-			h.DefaultClientRoundTripper = &http.Transport{}
+			tr, ok := http.DefaultTransport.(*http.Transport)
+			if ok {
+				h.DefaultClientRoundTripper = tr
+			} else {
+				h.DefaultClientRoundTripper = &http.Transport{}
+			}
 		}
 	})
 }

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -772,11 +772,17 @@ func TestHTTPHostAsRoundTripper(t *testing.T) {
 		w.Write([]byte("hello"))
 	}))
 
+	// Uncomment when we get the http-path changes in go-multiaddr
+	// // Different protocol.ID and mounted at a different path
+	// serverHttpHost.SetHTTPHandlerAtPath("/hello-again", "/hello", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// 	w.Write([]byte("hello"))
+	// }))
+
 	go serverHttpHost.Serve()
 	defer serverHttpHost.Close()
 
 	testCases := []string{
-		// Version that has an http-path. Will uncomment when we get the changes in go-multiaddr in
+		// Version that has an http-path. Will uncomment when we get the http-path changes in go-multiaddr
 		// "multiaddr:" + serverHost.Addrs()[0].String() + "/http-path/hello",
 	}
 	for _, a := range serverHttpHost.Addrs() {


### PR DESCRIPTION
After working on the js-libp2p API for libp2p+HTTP, I realized it's quite natural to make an HTTP request given a multiaddr URI (who would've guessed?).

This change makes using the HTTP client with libp2p easier and more natural. Instead of having to create a specialized roundtripper for each server, you can now have a single `http.Client` that can make requests to multiple servers. The usage feels very familiar to the classic HTTP api. You can now do this:

```
client := http.Client{Transport: &libp2phttp.Host{ options... }}
client.Get("https://example.com") // Standard way of making an HTTP request
client.Get("multiaddr:/dns/example.com/tls/http") // Same as above, but with a multiaddr scheme
client.Get("multiaddr:/dnsaddr/example.com/p2p/QmFoo") // galaxy brain; make an HTTP request over a libp2p transport
```