### PR TITLE
add peerId compare

### DIFF
--- a/examples/pubsub/chat/main.go
+++ b/examples/pubsub/chat/main.go
@@ -94,6 +94,9 @@ type discoveryNotifee struct {
 // support PubSub.
 func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
 	fmt.Printf("discovered new peer %s\n", pi.ID)
+	if pi.ID > n.h.ID() {
+		return
+	} 
 	err := n.h.Connect(context.Background(), pi)
 	if err != nil {
 		fmt.Printf("error connecting to peer %s: %s\n", pi.ID, err)


### PR DESCRIPTION
add peerId compare, otherwise this program will occasionally cause TLS shake sequence error