### PR TITLE
feat: libp2phttp `/http-path`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-base32 v0.1.0
-	github.com/multiformats/go-multiaddr v0.12.4
+	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multibase v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9
 github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
 github.com/multiformats/go-multiaddr v0.1.1/go.mod h1:aMKBKNEYmzmDmxfX88/vz+J5IU55txyt0p4aiWVohjo=
 github.com/multiformats/go-multiaddr v0.2.0/go.mod h1:0nO36NvPpyV4QzvTLi/lafl2y95ncPj0vFwVF6k6wJ4=
-github.com/multiformats/go-multiaddr v0.12.4 h1:rrKqpY9h+n80EwhhC/kkcunCZZ7URIF8yN1WEUt2Hvc=
-github.com/multiformats/go-multiaddr v0.12.4/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamGa/P5EIXNPLovyhQCII=
+github.com/multiformats/go-multiaddr v0.13.0 h1:BCBzs61E3AGHcYYTv8dqRH43ZfyrqM8RXVPT8t13tLQ=
+github.com/multiformats/go-multiaddr v0.13.0/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamGa/P5EIXNPLovyhQCII=
 github.com/multiformats/go-multiaddr-dns v0.3.1 h1:QgQgR+LQVt3NPTjbrLLpsaT2ufAA2y0Mkk+QRVJbW3A=
 github.com/multiformats/go-multiaddr-dns v0.3.1/go.mod h1:G/245BRQ6FJGmryJCrOuTdB37AMA5AMOVuO6NY3JwTk=
 github.com/multiformats/go-multiaddr-fmt v0.1.0 h1:WLEFClPycPkp4fnIzoFoV9FVd49/eQsuaL3/CWe167E=

--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -499,6 +499,8 @@ func (rt *streamRoundTripper) RoundTrip(r *http.Request) (*http.Response, error)
 	return resp, nil
 }
 
+var errNotRelative = errors.New("not relative")
+
 // relativeMultiaddrURIToAbs takes a relative multiaddr URI and turns it into an
 // absolute one. Useful, for example, when a server gives us a relative URI for a redirect.
 // It allows the following request (the one after redirected) to reach the correct server.
@@ -510,7 +512,7 @@ func relativeMultiaddrURIToAbs(original *url.URL, relative *url.URL) (*url.URL, 
 	// multiaddr://here-instead.
 	if relative.OmitHost {
 		// Not relative (at least we can't tell). Nothing we can do here
-		return nil, errors.New("not relative")
+		return nil, errNotRelative
 	}
 	originalStr := original.RawPath
 	if originalStr == "" {

--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -750,10 +750,10 @@ func (h *Host) RoundTrip(r *http.Request) (*http.Response, error) {
 	if parsed.peer == "" {
 		return nil, fmt.Errorf("no peer ID in multiaddr")
 	}
-	addr, _ = ma.SplitFunc(addr, func(c ma.Component) bool {
-		return c.Protocol().Code == ma.P_P2P
+	withoutHTTPPath, _ := ma.SplitFunc(addr, func(c ma.Component) bool {
+		return c.Protocol().Code == ma.P_HTTP_PATH
 	})
-	h.StreamHost.Peerstore().AddAddrs(parsed.peer, []ma.Multiaddr{addr}, peerstore.TempAddrTTL)
+	h.StreamHost.Peerstore().AddAddrs(parsed.peer, []ma.Multiaddr{withoutHTTPPath}, peerstore.TempAddrTTL)
 
 	// Set the Opaque field to the http-path so that the HTTP request only makes
 	// a reference to that path and not the whole multiaddr uri

--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -758,6 +758,10 @@ func (h *Host) RoundTrip(r *http.Request) (*http.Response, error) {
 	// Set the Opaque field to the http-path so that the HTTP request only makes
 	// a reference to that path and not the whole multiaddr uri
 	r.URL.Opaque = parsed.httpPath
+	if r.Host == "" {
+		// Fill in the host if it's not already set
+		r.Host = parsed.host + ":" + parsed.port
+	}
 	srt := streamRoundTripper{
 		server:       parsed.peer,
 		skipAddAddrs: true,

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -912,12 +912,11 @@ func TestImpliedHostIsSet(t *testing.T) {
 	defer serverHttpHost.Close()
 
 	serverHttpHost.SetHTTPHandlerAtPath("/hi", "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.Host, "localhost") || r.URL.Path != "/" {
-			fmt.Println("Host is", r.Host)
-			w.WriteHeader(http.StatusNotFound)
+		if strings.HasPrefix(r.Host, "localhost") && r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNotFound)
 	}))
 
 	clientStreamHost, err := libp2p.New(libp2p.NoListenAddrs, libp2p.Transport(libp2pquic.NewTransport))

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -885,7 +885,6 @@ func TestRedirects(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.initialURI, func(t *testing.T) {
-			// u := fmt.Sprintf("multiaddr:%s/p2p/%s/http-path/a%%2f", serverHost.Addrs()[0], serverHost.ID())
 			resp, err := client.Get(tc.initialURI)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -894,7 +893,6 @@ func TestRedirects(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "hello", string(body))
 
-			// expectedFinalURI := fmt.Sprintf("multiaddr:%s/p2p/%s/http-path/%%2Fd%%2F", serverHost.Addrs()[0], serverHost.ID())
 			finalReqURL := *resp.Request.URL
 			finalReqURL.Opaque = "" // Clear the opaque so we can compare the URI
 			require.Equal(t, tc.expectedURI, finalReqURL.String())

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -772,27 +772,26 @@ func TestHTTPHostAsRoundTripper(t *testing.T) {
 		w.Write([]byte("hello"))
 	}))
 
-	// Uncomment when we get the http-path changes in go-multiaddr
-	// // Different protocol.ID and mounted at a different path
-	// serverHttpHost.SetHTTPHandlerAtPath("/hello-again", "/hello", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	// 	w.Write([]byte("hello"))
-	// }))
+	// Different protocol.ID and mounted at a different path
+	serverHttpHost.SetHTTPHandlerAtPath("/hello-again", "/hello", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello"))
+	}))
 
 	go serverHttpHost.Serve()
 	defer serverHttpHost.Close()
 
-	testCases := []string{
-		// Version that has an http-path. Will uncomment when we get the http-path changes in go-multiaddr
-		// "multiaddr:" + serverHost.Addrs()[0].String() + "/http-path/hello",
-	}
+	httpPathSuffix := "/http-path/hello2"
+	var testCases []string
 	for _, a := range serverHttpHost.Addrs() {
 		if _, err := a.ValueForProtocol(ma.P_HTTP); err == nil {
 			testCases = append(testCases, "multiaddr:"+a.String())
+			testCases = append(testCases, "multiaddr:"+a.String()+httpPathSuffix)
 			serverPort, err := a.ValueForProtocol(ma.P_TCP)
 			require.NoError(t, err)
 			testCases = append(testCases, "http://127.0.0.1:"+serverPort)
 		} else {
 			testCases = append(testCases, "multiaddr:"+a.String()+"/p2p/"+serverHost.ID().String())
+			testCases = append(testCases, "multiaddr:"+a.String()+"/p2p/"+serverHost.ID().String()+httpPathSuffix)
 		}
 	}
 

--- a/test-plans/go.mod
+++ b/test-plans/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/libp2p/go-libp2p v0.0.0
-	github.com/multiformats/go-multiaddr v0.12.4
+	github.com/multiformats/go-multiaddr v0.13.0
 )
 
 require (

--- a/test-plans/go.sum
+++ b/test-plans/go.sum
@@ -187,8 +187,8 @@ github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9
 github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
 github.com/multiformats/go-multiaddr v0.1.1/go.mod h1:aMKBKNEYmzmDmxfX88/vz+J5IU55txyt0p4aiWVohjo=
 github.com/multiformats/go-multiaddr v0.2.0/go.mod h1:0nO36NvPpyV4QzvTLi/lafl2y95ncPj0vFwVF6k6wJ4=
-github.com/multiformats/go-multiaddr v0.12.4 h1:rrKqpY9h+n80EwhhC/kkcunCZZ7URIF8yN1WEUt2Hvc=
-github.com/multiformats/go-multiaddr v0.12.4/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamGa/P5EIXNPLovyhQCII=
+github.com/multiformats/go-multiaddr v0.13.0 h1:BCBzs61E3AGHcYYTv8dqRH43ZfyrqM8RXVPT8t13tLQ=
+github.com/multiformats/go-multiaddr v0.13.0/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamGa/P5EIXNPLovyhQCII=
 github.com/multiformats/go-multiaddr-dns v0.3.1 h1:QgQgR+LQVt3NPTjbrLLpsaT2ufAA2y0Mkk+QRVJbW3A=
 github.com/multiformats/go-multiaddr-dns v0.3.1/go.mod h1:G/245BRQ6FJGmryJCrOuTdB37AMA5AMOVuO6NY3JwTk=
 github.com/multiformats/go-multiaddr-fmt v0.1.0 h1:WLEFClPycPkp4fnIzoFoV9FVd49/eQsuaL3/CWe167E=


### PR DESCRIPTION
Adds support for multiaddr URIs that contain `/http-path` components. In other words, this works now:

```
client := http.Client{Transport: &libp2phttp.Host{ options... }}
client.Get("multiaddr:/dns/example.com/tls/http/http-path/some%2fpath")
// equivalent to
client.Get("https://example.com/some/path")
// And of course works with any libp2p stream transport:
client.Get("multiaddr:/dnsaddr/example.com/p2p/QmFoo/http-path/some%2fpath")
```