### PR TITLE
fix: Close conn in quic listener when wrapping fails

### DIFF
--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -33,7 +33,6 @@ import (
 	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	"go.uber.org/mock/gomock"
 
-	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
@@ -673,7 +672,7 @@ func TestDiscoverPeerIDFromSecurityNegotiation(t *testing.T) {
 
 			ai := &peer.AddrInfo{
 				ID:    bogusPeerId,
-				Addrs: []multiaddr.Multiaddr{h1.Addrs()[0]},
+				Addrs: []ma.Multiaddr{h1.Addrs()[0]},
 			}
 
 			// Try connecting with the bogus peer ID

--- a/p2p/transport/quic/listener_test.go
+++ b/p2p/transport/quic/listener_test.go
@@ -156,7 +156,7 @@ func TestCleanupConnWhenBlocked(t *testing.T) {
 	}
 
 	// No error yet, let's continue using the conn
-	s.SetReadDeadline(time.Now().Add(1 * time.Second))
+	s.SetReadDeadline(time.Now().Add(10 * time.Second))
 	b := [1]byte{}
 	_, err = s.Read(b[:])
 	if err != nil && errors.As(err, &quicErr) {


### PR DESCRIPTION
When wrapping a quic connection into a transport.CapableConn we wouldn't always close the underlying connection if wrapping failed. This fixes that and adds some tests to ensure all transports do this properly.

I believe this closes #2841 