### PR TITLE
Check err for nil before taking error

### DIFF
--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -137,7 +137,7 @@ func (l *listener) Close() error {
 	l.server.Close()
 	err := l.nl.Close()
 	<-l.closed
-	if strings.Contains(err.Error(), "use of closed network connection") {
+	if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
 		return transport.ErrListenerClosed
 	}
 	return err


### PR DESCRIPTION
When checking `err.Error()` for a value, the code panics if `err` is nil.

Closes #2865 