### PR TITLE
chore: Update connmgr.go/NewConnManager()'s commnet

### DIFF
--- a/p2p/net/connmgr/connmgr.go
+++ b/p2p/net/connmgr/connmgr.go
@@ -104,7 +104,7 @@ func (s *segment) tagInfoFor(p peer.ID, now time.Time) *peerInfo {
 }
 
 // NewConnManager creates a new BasicConnMgr with the provided params:
-// lo and hi are watermarks governing the number of connections that'll be maintained.
+// low and hi are watermarks governing the number of connections that'll be maintained.
 // When the peer count exceeds the 'high watermark', as many peers will be pruned (and
 // their connections terminated) until 'low watermark' peers remain.
 func NewConnManager(low, hi int, opts ...Option) (*BasicConnMgr, error) {


### PR DESCRIPTION
Although not very important, the 'low' used in the variable name and the 'lo' in the comment are different. This is the result of renaming the variable in the comment.