### PR TITLE
feat: WebRTC reuse QUIC conn

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -24,7 +25,9 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	"go.uber.org/goleak"
 
@@ -489,4 +492,68 @@ func TestHostAddrsFactoryAddsCerthashes(t *testing.T) {
 		return false
 	}, 5*time.Second, 50*time.Millisecond)
 	h.Close()
+}
+
+func TestWebRTCReuseAddrWithQUIC(t *testing.T) {
+	order := [][]string{
+		{"/ip4/127.0.0.1/udp/54322/quic-v1", "/ip4/127.0.0.1/udp/54322/webrtc-direct"},
+		{"/ip4/127.0.0.1/udp/54322/webrtc-direct", "/ip4/127.0.0.1/udp/54322/quic-v1"},
+		// We do not support WebRTC automatically reusing QUIC addresses if port is not specified, yet.
+		// {"/ip4/127.0.0.1/udp/0/webrtc-direct", "/ip4/127.0.0.1/udp/0/quic-v1"},
+	}
+	for i, addrs := range order {
+		t.Run("Order "+strconv.Itoa(i), func(t *testing.T) {
+			h1, err := New(ListenAddrStrings(addrs...), Transport(quic.NewTransport), Transport(libp2pwebrtc.New))
+			require.NoError(t, err)
+			defer h1.Close()
+
+			seenPorts := make(map[string]struct{})
+			for _, addr := range h1.Addrs() {
+				s, err := addr.ValueForProtocol(ma.P_UDP)
+				require.NoError(t, err)
+				seenPorts[s] = struct{}{}
+			}
+			require.Len(t, seenPorts, 1)
+
+			quicClient, err := New(NoListenAddrs, Transport(quic.NewTransport))
+			require.NoError(t, err)
+			defer quicClient.Close()
+
+			webrtcClient, err := New(NoListenAddrs, Transport(libp2pwebrtc.New))
+			require.NoError(t, err)
+			defer webrtcClient.Close()
+
+			for _, client := range []host.Host{quicClient, webrtcClient} {
+				err := client.Connect(context.Background(), peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()})
+				require.NoError(t, err)
+			}
+
+			t.Run("quic client can connect", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				p := ping.NewPingService(quicClient)
+				resCh := p.Ping(ctx, h1.ID())
+				res := <-resCh
+				require.NoError(t, res.Error)
+			})
+
+			t.Run("webrtc client can connect", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				p := ping.NewPingService(webrtcClient)
+				resCh := p.Ping(ctx, h1.ID())
+				res := <-resCh
+				require.NoError(t, res.Error)
+			})
+		})
+	}
+
+	t.Run("setup with no reuseport. Should fail", func(t *testing.T) {
+		h1, err := New(ListenAddrStrings(order[0]...), Transport(quic.NewTransport), Transport(libp2pwebrtc.New), QUICReuse(quicreuse.NewConnManager, quicreuse.DisableReuseport()))
+		require.NoError(t, err) // It's a bug/feature that swarm.Listen does not error if at least one transport succeeds in listening.
+		defer h1.Close()
+		// Check that webrtc did fail to listen
+		require.Equal(t, 1, len(h1.Addrs()))
+		require.Contains(t, h1.Addrs()[0].String(), "quic-v1")
+	})
 }

--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/canonicallog"
@@ -12,13 +13,44 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+type OrderedListener interface {
+	// Transports optionally implement this interface to indicate the relative
+	// ordering that listeners should be setup. Some transports may optionally
+	// make use of other listeners if they are setup. e.g. WebRTC may reuse the
+	// same UDP port as QUIC, but only when QUIC is setup first.
+	// lower values are setup first.
+	ListenOrder() int
+}
+
 // Listen sets up listeners for all of the given addresses.
 // It returns as long as we successfully listen on at least *one* address.
 func (s *Swarm) Listen(addrs ...ma.Multiaddr) error {
 	errs := make([]error, len(addrs))
 	var succeeded int
-	for i, a := range addrs {
-		if err := s.AddListenAddr(a); err != nil {
+
+	type addrAndListener struct {
+		addr ma.Multiaddr
+		lTpt transport.Transport
+	}
+	sortedAddrsAndTpts := make([]addrAndListener, 0, len(addrs))
+	for _, a := range addrs {
+		t := s.TransportForListening(a)
+		sortedAddrsAndTpts = append(sortedAddrsAndTpts, addrAndListener{addr: a, lTpt: t})
+	}
+	slices.SortFunc(sortedAddrsAndTpts, func(a, b addrAndListener) int {
+		aOrder := 0
+		bOrder := 0
+		if l, ok := a.lTpt.(OrderedListener); ok {
+			aOrder = l.ListenOrder()
+		}
+		if l, ok := b.lTpt.(OrderedListener); ok {
+			bOrder = l.ListenOrder()
+		}
+		return aOrder - bOrder
+	})
+
+	for i, a := range sortedAddrsAndTpts {
+		if err := s.AddListenAddr(a.addr); err != nil {
 			errs[i] = err
 		} else {
 			succeeded++
@@ -27,11 +59,11 @@ func (s *Swarm) Listen(addrs ...ma.Multiaddr) error {
 
 	for i, e := range errs {
 		if e != nil {
-			log.Warnw("listening failed", "on", addrs[i], "error", errs[i])
+			log.Warnw("listening failed", "on", sortedAddrsAndTpts[i].addr, "error", errs[i])
 		}
 	}
 
-	if succeeded == 0 && len(addrs) > 0 {
+	if succeeded == 0 && len(sortedAddrsAndTpts) > 0 {
 		return fmt.Errorf("failed to listen on any addresses: %s", errs)
 	}
 

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -26,6 +26,8 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
+const ListenOrder = 1
+
 var log = logging.Logger("quic-transport")
 
 var ErrHolePunching = errors.New("hole punching attempted; no active dial")
@@ -101,6 +103,10 @@ func NewTransport(key ic.PrivKey, connManager *quicreuse.ConnManager, psk pnet.P
 
 		listeners: make(map[string][]*virtualListener),
 	}, nil
+}
+
+func (t *transport) ListenOrder() int {
+	return ListenOrder
 }
 
 // Dial dials a new QUIC connection

--- a/p2p/transport/quicreuse/nonquic_packetconn.go
+++ b/p2p/transport/quicreuse/nonquic_packetconn.go
@@ -1,0 +1,74 @@
+package quicreuse
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+// nonQUICPacketConn is a net.PacketConn that can be used to read and write
+// non-QUIC packets on a quic.Transport. This lets us reuse this UDP port for
+// other transports like WebRTC.
+type nonQUICPacketConn struct {
+	owningTransport refCountedQuicTransport
+	tr              *quic.Transport
+	ctx             context.Context
+	ctxCancel       context.CancelFunc
+	readCtx         context.Context
+	readCancel      context.CancelFunc
+}
+
+// Close implements net.PacketConn.
+func (n *nonQUICPacketConn) Close() error {
+	n.ctxCancel()
+
+	// Don't actually close the underlying transport since someone else might be using it.
+	// reuse has it's own gc to close unused transports.
+	n.owningTransport.DecreaseCount()
+	return nil
+}
+
+// LocalAddr implements net.PacketConn.
+func (n *nonQUICPacketConn) LocalAddr() net.Addr {
+	return n.tr.Conn.LocalAddr()
+}
+
+// ReadFrom implements net.PacketConn.
+func (n *nonQUICPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	ctx := n.readCtx
+	if ctx == nil {
+		ctx = n.ctx
+	}
+	return n.tr.ReadNonQUICPacket(ctx, p)
+}
+
+// SetDeadline implements net.PacketConn.
+func (n *nonQUICPacketConn) SetDeadline(t time.Time) error {
+	// Only used for reads.
+	return n.SetReadDeadline(t)
+}
+
+// SetReadDeadline implements net.PacketConn.
+func (n *nonQUICPacketConn) SetReadDeadline(t time.Time) error {
+	if t.IsZero() && n.readCtx != nil {
+		n.readCancel()
+		n.readCtx = nil
+	}
+	n.readCtx, n.readCancel = context.WithDeadline(n.ctx, t)
+	return nil
+}
+
+// SetWriteDeadline implements net.PacketConn.
+func (n *nonQUICPacketConn) SetWriteDeadline(t time.Time) error {
+	// Unused. quic-go doesn't support deadlines for writes.
+	return nil
+}
+
+// WriteTo implements net.PacketConn.
+func (n *nonQUICPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	return n.tr.WriteTo(p, addr)
+}
+
+var _ net.PacketConn = &nonQUICPacketConn{}

--- a/p2p/transport/webrtc/transport_test.go
+++ b/p2p/transport/webrtc/transport_test.go
@@ -29,12 +29,16 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+var netListenUDP ListenUDPFn = func(network string, laddr *net.UDPAddr) (net.PacketConn, error) {
+	return net.ListenUDP(network, laddr)
+}
+
 func getTransport(t *testing.T, opts ...Option) (*WebRTCTransport, peer.ID) {
 	t.Helper()
 	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
 	require.NoError(t, err)
 	rcmgr := &network.NullResourceManager{}
-	transport, err := New(privKey, nil, nil, rcmgr, opts...)
+	transport, err := New(privKey, nil, nil, rcmgr, netListenUDP, opts...)
 	require.NoError(t, err)
 	peerID, err := peer.IDFromPrivateKey(privKey)
 	require.NoError(t, err)
@@ -45,7 +49,7 @@ func getTransport(t *testing.T, opts ...Option) (*WebRTCTransport, peer.ID) {
 func TestNullRcmgrTransport(t *testing.T) {
 	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
 	require.NoError(t, err)
-	transport, err := New(privKey, nil, nil, nil)
+	transport, err := New(privKey, nil, nil, nil, netListenUDP)
 	require.NoError(t, err)
 
 	listenTransport, pid := getTransport(t)


### PR DESCRIPTION
This lets users listen on the same port for WebRTC and QUIC. Kubo folks asked for this as it would be very beneficial to their deployment.

One open question for me is:
- Do we need to make sure this works well with the Observed Address Manager? I think it should just work, but we should double check. Ideally we should know our public webrtc-direct address if we've discovered our public quic address when they use the same port. 