### PR TITLE
ObsAddrManager: Infer external addresses for transports that share the same listening address.

### DIFF
--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -213,6 +213,36 @@ func (o *ObservedAddrManager) AddrsFor(addr ma.Multiaddr) (addrs []ma.Multiaddr)
 	return res
 }
 
+// appendInferredAddrs infers the external address of other transports that
+// share the local thin waist with a transport that we have do observations for.
+//
+// e.g. If we have observations for a QUIC address on port 9000, and we are
+// listening on the same interface and port 9000 for WebTransport, we can infer
+// the external WebTransport address.
+func (o *ObservedAddrManager) appendInferredAddrs(twToObserverSets map[string][]*observerSet, addrs []ma.Multiaddr) []ma.Multiaddr {
+	if twToObserverSets == nil {
+		twToObserverSets = make(map[string][]*observerSet)
+		for localTWStr := range o.externalAddrs {
+			twToObserverSets[localTWStr] = append(twToObserverSets[localTWStr], o.getTopExternalAddrs(localTWStr)...)
+		}
+	}
+	for _, a := range o.listenAddrs() {
+		if _, ok := o.localAddrs[string(a.Bytes())]; ok {
+			// We already have this address in the list
+			continue
+		}
+		a = o.normalize(a)
+		t, err := thinWaistForm(a)
+		if err != nil {
+			continue
+		}
+		for _, s := range twToObserverSets[string(t.TW.Bytes())] {
+			addrs = append(addrs, s.cacheMultiaddr(t.Rest))
+		}
+	}
+	return addrs
+}
+
 // Addrs return all activated observed addresses
 func (o *ObservedAddrManager) Addrs() []ma.Multiaddr {
 	o.mu.RLock()
@@ -228,6 +258,8 @@ func (o *ObservedAddrManager) Addrs() []ma.Multiaddr {
 			addrs = append(addrs, s.cacheMultiaddr(t.Rest))
 		}
 	}
+
+	addrs = o.appendInferredAddrs(m, addrs)
 	return addrs
 }
 


### PR DESCRIPTION
The Observed Address manager can now infer external addresses for transports that share the same listening address if another transport has an observation. 

For example, say I'm listening on UDP 0.0.0.0:4001 for QUIC, WebTransport, and WebRTC. And I learn that my external IP address for QUIC is 5.4.3.2:4001 (as reported by my peers). This means I can infer that my external WebTransport and WebRTC addresses are also 5.4.3.2:4001 since these other transports are using the same underlying socket.

This PR also removes the old hack that inferred WebTransport address. It was hacky because we didn't have access to the connection of external <-> local address like the observed address manager does.