### PR TITLE
fix(discovery): allow FindPeers limit to be 0

### DIFF
--- a/p2p/discovery/routing/routing.go
+++ b/p2p/discovery/routing/routing.go
@@ -56,15 +56,12 @@ func (d *RoutingDiscovery) Advertise(ctx context.Context, ns string, opts ...dis
 }
 
 func (d *RoutingDiscovery) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
-	var options discovery.Options
+	options := discovery.Options{
+		Limit: 100, // default limit if not specified in options
+	}
 	err := options.Apply(opts...)
 	if err != nil {
 		return nil, err
-	}
-
-	limit := options.Limit
-	if limit == 0 {
-		limit = 100 // that's just arbitrary, but FindProvidersAsync needs a count
 	}
 
 	cid, err := nsToCid(ns)
@@ -72,7 +69,7 @@ func (d *RoutingDiscovery) FindPeers(ctx context.Context, ns string, opts ...dis
 		return nil, err
 	}
 
-	return d.FindProvidersAsync(ctx, cid, limit), nil
+	return d.FindProvidersAsync(ctx, cid, options.Limit), nil
 }
 
 func nsToCid(ns string) (cid.Cid, error) {


### PR DESCRIPTION
https://github.com/libp2p/go-libp2p/blob/cb81b3e48cfbda2cec9687d1341841822b58e050/p2p/discovery/routing/routing.go#L58-L76

`FindProvidersAsync` allows a limit of `0` to return all found providers. However, it is impossible to make use of this feature with `FindPeers` since it sets the limit to `100` if it was previously `0`.

This is a non breaking fix, users omitting the `Limit(X)` parameter will continue to have (at most) `100` results returned. Alternatively, we could change the default to return all found peers.

resolves https://github.com/libp2p/go-libp2p/issues/2859