### PR TITLE
examples/chat-with-mdns: default to a random port

### DIFF
--- a/examples/chat-with-mdns/flags.go
+++ b/examples/chat-with-mdns/flags.go
@@ -17,7 +17,7 @@ func parseFlags() *config {
 	flag.StringVar(&c.RendezvousString, "rendezvous", "meetme", "Unique string to identify group of nodes. Share this with your friends to let them connect with you")
 	flag.StringVar(&c.listenHost, "host", "0.0.0.0", "The bootstrap node host listen address\n")
 	flag.StringVar(&c.ProtocolID, "pid", "/chat/1.1.0", "Sets a protocol id for stream headers")
-	flag.IntVar(&c.listenPort, "port", 4001, "node listen port")
+	flag.IntVar(&c.listenPort, "port", 0, "node listen port (0 pick a random unused port)")
 
 	flag.Parse()
 	return c


### PR DESCRIPTION
Make sure it properly works if you start multiple instances on the same machine.