### PR TITLE
metrics: BlackHoleState type public

### DIFF
--- a/p2p/net/swarm/black_hole_detector.go
+++ b/p2p/net/swarm/black_hole_detector.go
@@ -8,15 +8,15 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-type blackHoleState int
+type BlackHoleState int
 
 const (
-	blackHoleStateProbing blackHoleState = iota
+	blackHoleStateProbing BlackHoleState = iota
 	blackHoleStateAllowed
 	blackHoleStateBlocked
 )
 
-func (st blackHoleState) String() string {
+func (st BlackHoleState) String() string {
 	switch st {
 	case blackHoleStateProbing:
 		return "Probing"
@@ -57,7 +57,7 @@ type BlackHoleSuccessCounter struct {
 	// successes is the count of successful dials in outcomes
 	successes int
 	// state is the current state of the detector
-	state blackHoleState
+	state BlackHoleState
 }
 
 // RecordResult records the outcome of a dial. A successful dial in Blocked state will change the
@@ -91,7 +91,7 @@ func (b *BlackHoleSuccessCounter) RecordResult(success bool) {
 }
 
 // HandleRequest returns the result of applying the black hole filter for the request.
-func (b *BlackHoleSuccessCounter) HandleRequest() blackHoleState {
+func (b *BlackHoleSuccessCounter) HandleRequest() BlackHoleState {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -129,7 +129,7 @@ func (b *BlackHoleSuccessCounter) updateState() {
 	}
 }
 
-func (b *BlackHoleSuccessCounter) State() blackHoleState {
+func (b *BlackHoleSuccessCounter) State() BlackHoleState {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -138,7 +138,7 @@ func (b *BlackHoleSuccessCounter) State() blackHoleState {
 
 type blackHoleInfo struct {
 	name            string
-	state           blackHoleState
+	state           BlackHoleState
 	nextProbeAfter  int
 	successFraction float64
 }
@@ -251,7 +251,7 @@ func (d *blackHoleDetector) RecordResult(addr ma.Multiaddr, success bool) {
 	}
 }
 
-func (d *blackHoleDetector) getFilterState(f *BlackHoleSuccessCounter) blackHoleState {
+func (d *blackHoleDetector) getFilterState(f *BlackHoleSuccessCounter) BlackHoleState {
 	if d.readOnly {
 		if f.State() != blackHoleStateAllowed {
 			return blackHoleStateBlocked

--- a/p2p/net/swarm/black_hole_detector_test.go
+++ b/p2p/net/swarm/black_hole_detector_test.go
@@ -59,7 +59,7 @@ func TestBlackHoleSuccessCounterSuccessFraction(t *testing.T) {
 	n := 10
 	tests := []struct {
 		minSuccesses, successes int
-		result                  blackHoleState
+		result                  BlackHoleState
 	}{
 		{minSuccesses: 5, successes: 5, result: blackHoleStateAllowed},
 		{minSuccesses: 3, successes: 3, result: blackHoleStateAllowed},

--- a/p2p/net/swarm/swarm_metrics.go
+++ b/p2p/net/swarm/swarm_metrics.go
@@ -131,7 +131,7 @@ type MetricsTracer interface {
 	FailedDialing(ma.Multiaddr, error, error)
 	DialCompleted(success bool, totalDials int)
 	DialRankingDelay(d time.Duration)
-	UpdatedBlackHoleSuccessCounter(name string, state blackHoleState, nextProbeAfter int, successFraction float64)
+	UpdatedBlackHoleSuccessCounter(name string, state BlackHoleState, nextProbeAfter int, successFraction float64)
 }
 
 type metricsTracer struct{}
@@ -274,7 +274,7 @@ func (m *metricsTracer) DialRankingDelay(d time.Duration) {
 	dialRankingDelay.Observe(d.Seconds())
 }
 
-func (m *metricsTracer) UpdatedBlackHoleSuccessCounter(name string, state blackHoleState,
+func (m *metricsTracer) UpdatedBlackHoleSuccessCounter(name string, state BlackHoleState,
 	nextProbeAfter int, successFraction float64) {
 	tags := metricshelper.GetStringSlice()
 	defer metricshelper.PutStringSlice(tags)

--- a/p2p/net/swarm/swarm_metrics_test.go
+++ b/p2p/net/swarm/swarm_metrics_test.go
@@ -79,7 +79,7 @@ func TestMetricsNoAllocNoCover(t *testing.T) {
 	}
 
 	bhfNames := []string{"udp", "ipv6", "tcp", "icmp"}
-	bhfState := []blackHoleState{blackHoleStateAllowed, blackHoleStateBlocked}
+	bhfState := []BlackHoleState{blackHoleStateAllowed, blackHoleStateBlocked}
 
 	tests := map[string]func(){
 		"OpenedConnection": func() {


### PR DESCRIPTION
This commit changes the `blackHoleState` type from private to public by renaming it to `BlackHoleState`. This modification allows other packages to access and use this type, which is essential for monitoring and debugging purposes within the libp2p system.

Related issue: #2890 