### PR TITLE
fix: enable dctur when interface address is public 

### DIFF
--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/libp2p/go-msgio/pbio"
 
 	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
 )
 
 // Protocol is the libp2p protocol for Hole Punching.
@@ -106,13 +107,9 @@ func (s *Service) watchForPublicAddr() {
 	t := time.NewTimer(duration)
 	defer t.Stop()
 	for {
-		interfaceListenAddrs, err := s.host.Network().InterfaceListenAddresses()
 
-		if err != nil {
-			log.Debugf("failed to get to get InterfaceListenAddresses: %s", err)
-		}
 		// Use both host and observed to enable hole punching for undialable public ips that might not be observed
-		if containsPublicAddr(s.ids.OwnObservedAddrs()) || containsPublicAddr(interfaceListenAddrs) {
+		if len(s.getPublicAddrs()) > 0 {
 			log.Debug("Host now has a public address. Starting holepunch protocol.")
 			s.host.SetStreamHandler(Protocol, s.handleNewStream)
 			break
@@ -177,13 +174,8 @@ func (s *Service) incomingHolePunch(str network.Stream) (rtt time.Duration, remo
 	if !isRelayAddress(str.Conn().RemoteMultiaddr()) {
 		return 0, nil, nil, fmt.Errorf("received hole punch stream: %s", str.Conn().RemoteMultiaddr())
 	}
-	ownAddrs = removeRelayAddrs(s.ids.OwnObservedAddrs())
-	interfaceListenAddrs, err := s.host.Network().InterfaceListenAddresses()
 
-	if err != nil {
-		log.Debugf("failed to get to get InterfaceListenAddresses: %s", err)
-	}
-	ownAddrs = ma.Unique(append(ownAddrs, interfaceListenAddrs...))
+	ownAddrs = s.getPublicAddrs()
 
 	if s.filter != nil {
 		ownAddrs = s.filter.FilterLocal(str.Conn().RemotePeer(), ownAddrs)
@@ -285,6 +277,29 @@ func (s *Service) handleNewStream(str network.Stream) {
 	dt := time.Since(start)
 	s.tracer.EndHolePunch(rp, dt, err)
 	s.tracer.HolePunchFinished("receiver", 1, addrs, ownAddrs, getDirectConnection(s.host, rp))
+}
+
+// getPublicAddrs returns public observed and interface addresses
+func (s *Service) getPublicAddrs() []ma.Multiaddr {
+	addrs := removeRelayAddrs(s.ids.OwnObservedAddrs())
+
+	interfaceListenAddrs, err := s.host.Network().InterfaceListenAddresses()
+	if err != nil {
+		log.Debugf("failed to get to get InterfaceListenAddresses: %s", err)
+	} else {
+		addrs = append(addrs, interfaceListenAddrs...)
+	}
+
+	addrs = ma.Unique(addrs)
+
+	publicAddrs := make([]ma.Multiaddr, 0, len(addrs))
+
+	for _, addr := range addrs {
+		if manet.IsPublicAddr(addr) {
+			publicAddrs = append(publicAddrs, addr)
+		}
+	}
+	return publicAddrs
 }
 
 // DirectConnect is only exposed for testing purposes.

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -107,8 +107,6 @@ func (s *Service) watchForPublicAddr() {
 	t := time.NewTimer(duration)
 	defer t.Stop()
 	for {
-
-		// Use both host and observed to enable hole punching for undialable public ips that might not be observed
 		if len(s.getPublicAddrs()) > 0 {
 			log.Debug("Host now has a public address. Starting holepunch protocol.")
 			s.host.SetStreamHandler(Protocol, s.handleNewStream)
@@ -174,9 +172,7 @@ func (s *Service) incomingHolePunch(str network.Stream) (rtt time.Duration, remo
 	if !isRelayAddress(str.Conn().RemoteMultiaddr()) {
 		return 0, nil, nil, fmt.Errorf("received hole punch stream: %s", str.Conn().RemoteMultiaddr())
 	}
-
 	ownAddrs = s.getPublicAddrs()
-
 	if s.filter != nil {
 		ownAddrs = s.filter.FilterLocal(str.Conn().RemotePeer(), ownAddrs)
 	}

--- a/p2p/protocol/holepunch/util.go
+++ b/p2p/protocol/holepunch/util.go
@@ -8,18 +8,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr/net"
 )
-
-func containsPublicAddr(addrs []ma.Multiaddr) bool {
-	for _, addr := range addrs {
-		if isRelayAddress(addr) || !manet.IsPublicAddr(addr) {
-			continue
-		}
-		return true
-	}
-	return false
-}
 
 func removeRelayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
 	result := make([]ma.Multiaddr, 0, len(addrs))


### PR DESCRIPTION
## What's in this PR

This change attempts to fix #2913.

In essence, it enables the `dctur` protocol, when a peer has a public IP (if it's bound to an interface with a public IP) without having to wait for an identify response (which would then make the public address visible via `OwnObservedAddrs()`).


## Open questions

- The `OwnObservedAddrs()` function in the identify service (which we rely on in the holepunch service) seems to **not** return observed addresses if they aren't dialable. Why is that? 
  - Should be fixed by https://github.com/libp2p/go-libp2p/pull/2936
