### PR TITLE
chore: add a funding JSON file to apply for Optimism rPGF round 5

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+    "opRetro": {
+      "projectId": "0xc71faa1bcb4ceb785816c3f22823377e9e5e7c48649badd9f0a0ce491f20d4b3"
+    }
+  }


### PR DESCRIPTION
This funding.json file is added here in order to apply for Optimism's rPGF round 5: https://retrofunding.optimism.io/application/5

The application process requires this file to exist in public github repositories that are linked to applications.
The go-libp2p repo will be listed in IP Shipyard's application for round 5.

The contents of this file were autogenerated:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/1476a915-332a-4a2a-b257-a3bf1218cdd6">
