### PR TITLE
chore: parameterise s3 build cache setup

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           test-filter: go-libp2p-head
           extra-versions: ${{ github.workspace }}/test-plans/ping-version.json
-          s3-cache-bucket: libp2p-by-tf-aws-bootstrap
-          s3-access-key-id: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}
+          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
As we're setting up a new cache bucket, we'd like to be able to control its' configuration via GitHub vars/secrets fully. 