### PR TITLE
chore: remove Roadmap file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 
 # Table of Contents <!-- omit in toc -->
 - [Background](#background)
-- [Roadmap](#roadmap)
 - [Usage](#usage)
   - [Examples](#examples)
   - [Dashboards](#dashboards)
@@ -35,11 +34,6 @@ To learn more, check out the following resources:
 - [**The libp2p Specification**](https://github.com/libp2p/specs)
 - [**js-libp2p implementation**](https://github.com/libp2p/js-libp2p)
 - [**rust-libp2p implementation**](https://github.com/libp2p/rust-libp2p)
-
-# Roadmap
-
-Our roadmap for go-libp2p can be found here: https://github.com/libp2p/go-libp2p/blob/master/ROADMAP.md
-This document represents current projects the go-libp2p team is focused on and provides an estimation of completion targets. It is a complementary roadmap to the overarching libp2p project roadmap: https://github.com/libp2p/specs/blob/master/ROADMAP.md
 
 # Usage
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,0 @@
-# go-libp2p roadmap Q4’22/Q1’23
-
-Please see our roadmap in [Starmap](https://starmap.site/roadmap/github.com/libp2p/go-libp2p/issues/1806#simple)
-
-Please add any feedback or questions in: https://github.com/libp2p/go-libp2p/issues/1806


### PR DESCRIPTION
Users and contributors can view roadmap in Github issues.