### PR TITLE
fix: use quic.Version instead of the deprecated quic.VersionNumber

### DIFF
--- a/p2p/transport/quic/listener.go
+++ b/p2p/transport/quic/listener.go
@@ -23,11 +23,11 @@ type listener struct {
 	rcmgr           network.ResourceManager
 	privKey         ic.PrivKey
 	localPeer       peer.ID
-	localMultiaddrs map[quic.VersionNumber]ma.Multiaddr
+	localMultiaddrs map[quic.Version]ma.Multiaddr
 }
 
 func newListener(ln quicreuse.Listener, t *transport, localPeer peer.ID, key ic.PrivKey, rcmgr network.ResourceManager) (listener, error) {
-	localMultiaddrs := make(map[quic.VersionNumber]ma.Multiaddr)
+	localMultiaddrs := make(map[quic.Version]ma.Multiaddr)
 	for _, addr := range ln.Multiaddrs() {
 		if _, err := addr.ValueForProtocol(ma.P_QUIC_V1); err == nil {
 			localMultiaddrs[quic.Version1] = addr

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -327,7 +327,7 @@ func (t *transport) Listen(addr ma.Multiaddr) (tpt.Listener, error) {
 
 		acceptRunner = &acceptLoopRunner{
 			acceptSem: make(chan struct{}, 1),
-			muxer:     make(map[quic.VersionNumber]chan acceptVal),
+			muxer:     make(map[quic.Version]chan acceptVal),
 		}
 	}
 

--- a/p2p/transport/quicreuse/config.go
+++ b/p2p/transport/quicreuse/config.go
@@ -12,7 +12,7 @@ var quicConfig = &quic.Config{
 	MaxStreamReceiveWindow:     10 * (1 << 20), // 10 MB
 	MaxConnectionReceiveWindow: 15 * (1 << 20), // 15 MB
 	KeepAlivePeriod:            15 * time.Second,
-	Versions:                   []quic.VersionNumber{quic.Version1},
+	Versions:                   []quic.Version{quic.Version1},
 	// We don't use datagrams (yet), but this is necessary for WebTransport
 	EnableDatagrams: true,
 }

--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -232,7 +232,7 @@ func (c *ConnManager) DialQUIC(ctx context.Context, raddr ma.Multiaddr, tlsConf 
 
 	if v == quic.Version1 {
 		// The endpoint has explicit support for QUIC v1, so we'll only use that version.
-		quicConf.Versions = []quic.VersionNumber{quic.Version1}
+		quicConf.Versions = []quic.Version{quic.Version1}
 	} else {
 		return nil, errors.New("unknown QUIC version")
 	}

--- a/p2p/transport/quicreuse/quic_multiaddr.go
+++ b/p2p/transport/quicreuse/quic_multiaddr.go
@@ -13,7 +13,7 @@ var (
 	quicV1MA = ma.StringCast("/quic-v1")
 )
 
-func ToQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, error) {
+func ToQuicMultiaddr(na net.Addr, version quic.Version) (ma.Multiaddr, error) {
 	udpMA, err := manet.FromNetAddr(na)
 	if err != nil {
 		return nil, err
@@ -26,8 +26,8 @@ func ToQuicMultiaddr(na net.Addr, version quic.VersionNumber) (ma.Multiaddr, err
 	}
 }
 
-func FromQuicMultiaddr(addr ma.Multiaddr) (*net.UDPAddr, quic.VersionNumber, error) {
-	var version quic.VersionNumber
+func FromQuicMultiaddr(addr ma.Multiaddr) (*net.UDPAddr, quic.Version, error) {
+	var version quic.Version
 	var partsBeforeQUIC []ma.Multiaddr
 	ma.ForEach(addr, func(c ma.Component) bool {
 		switch c.Protocol().Code {


### PR DESCRIPTION
start from quic-go@0.47.0, quic.VersionNumber has been officially removed, commit can be seen at https://github.com/quic-go/quic-go/pull/4627