### PR TITLE
fix: Better GC in membacked peerstore

### DIFF
--- a/core/peerstore/peerstore.go
+++ b/core/peerstore/peerstore.go
@@ -175,7 +175,7 @@ func GetCertifiedAddrBook(ab AddrBook) (cab CertifiedAddrBook, ok bool) {
 
 // KeyBook tracks the keys of Peers.
 type KeyBook interface {
-	// PubKey stores the public key of a peer.
+	// PubKey returns the public key of a peer.
 	PubKey(peer.ID) ic.PubKey
 
 	// AddPubKey stores the public key of a peer.

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -495,9 +495,12 @@ func (h *BasicHost) SignalAddressChange() {
 	}
 }
 
-func makeUpdatedAddrEvent(prev, current []ma.Multiaddr) *event.EvtLocalAddressesUpdated {
+func (h *BasicHost) makeUpdatedAddrEvent(prev, current []ma.Multiaddr) *event.EvtLocalAddressesUpdated {
+	if prev == nil && current == nil {
+		return nil
+	}
 	prevmap := make(map[string]ma.Multiaddr, len(prev))
-	evt := event.EvtLocalAddressesUpdated{Diffs: true}
+	evt := &event.EvtLocalAddressesUpdated{Diffs: true}
 	addrsAdded := false
 
 	for _, addr := range prev {
@@ -524,7 +527,19 @@ func makeUpdatedAddrEvent(prev, current []ma.Multiaddr) *event.EvtLocalAddresses
 		return nil
 	}
 
-	return &evt
+	// Our addresses have changed. Make a new signed peer record.
+	if !h.disableSignedPeerRecord {
+		// add signed peer record to the event
+		sr, err := h.makeSignedPeerRecord(current)
+		if err != nil {
+			log.Errorf("error creating a signed peer record from the set of current addresses, err=%s", err)
+			// drop this change
+			return nil
+		}
+		evt.SignedPeerRecord = sr
+	}
+
+	return evt
 }
 
 func (h *BasicHost) makeSignedPeerRecord(addrs []ma.Multiaddr) (*record.Envelope, error) {
@@ -548,34 +563,27 @@ func (h *BasicHost) background() {
 	var lastAddrs []ma.Multiaddr
 
 	emitAddrChange := func(currentAddrs []ma.Multiaddr, lastAddrs []ma.Multiaddr) {
-		// nothing to do if both are nil..defensive check
-		if currentAddrs == nil && lastAddrs == nil {
-			return
-		}
-
-		changeEvt := makeUpdatedAddrEvent(lastAddrs, currentAddrs)
-
+		changeEvt := h.makeUpdatedAddrEvent(lastAddrs, currentAddrs)
 		if changeEvt == nil {
 			return
 		}
-
+		// Our addresses have changed.
+		// store the signed peer record in the peer store.
 		if !h.disableSignedPeerRecord {
-			// add signed peer record to the event
-			sr, err := h.makeSignedPeerRecord(currentAddrs)
-			if err != nil {
-				log.Errorf("error creating a signed peer record from the set of current addresses, err=%s", err)
-				return
-			}
-			changeEvt.SignedPeerRecord = sr
-
-			// persist the signed record to the peerstore
-			if _, err := h.caBook.ConsumePeerRecord(sr, peerstore.PermanentAddrTTL); err != nil {
+			if _, err := h.caBook.ConsumePeerRecord(changeEvt.SignedPeerRecord, peerstore.PermanentAddrTTL); err != nil {
 				log.Errorf("failed to persist signed peer record in peer store, err=%s", err)
 				return
 			}
 		}
+		// update host addresses in the peer store
+		removedAddrs := make([]ma.Multiaddr, 0, len(changeEvt.Removed))
+		for _, ua := range changeEvt.Removed {
+			removedAddrs = append(removedAddrs, ua.Address)
+		}
+		h.Peerstore().SetAddrs(h.ID(), currentAddrs, peerstore.PermanentAddrTTL)
+		h.Peerstore().SetAddrs(h.ID(), removedAddrs, 0)
 
-		// emit addr change event on the bus
+		// emit addr change event
 		if err := h.emitters.evtLocalAddrsUpdated.Emit(*changeEvt); err != nil {
 			log.Warnf("error emitting event for updated addrs: %s", err)
 		}
@@ -587,11 +595,10 @@ func (h *BasicHost) background() {
 	defer ticker.Stop()
 
 	for {
+		// Update our local IP addresses before checking our current addresses.
 		if len(h.network.ListenAddresses()) > 0 {
 			h.updateLocalIpAddr()
 		}
-		// Request addresses anyways because, technically, address filters still apply.
-		// The underlying AllAddrs call is effectively a no-op.
 		curr := h.Addrs()
 		emitAddrChange(curr, lastAddrs)
 		lastAddrs = curr

--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -163,7 +163,7 @@ func WithClock(clock clock) AddrBookOption {
 // background periodically schedules a gc
 func (mab *memoryAddrBook) background(ctx context.Context) {
 	defer mab.refCount.Done()
-	ticker := time.NewTicker(1 * time.Hour)
+	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
 	for {

--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -46,8 +46,8 @@ type peerAddrs struct {
 	expiringHeap []*expiringAddr
 }
 
-func newPeerAddrs() *peerAddrs {
-	return &peerAddrs{
+func newPeerAddrs() peerAddrs {
+	return peerAddrs{
 		addrs: make(map[peer.ID]map[string]*expiringAddr),
 	}
 }
@@ -137,7 +137,7 @@ func (rc realclock) Now() time.Time {
 type memoryAddrBook struct {
 	mu sync.RWMutex
 	// TODO bound the number of not connected addresses we store.
-	addrs             *peerAddrs
+	addrs             peerAddrs
 	signedPeerRecords map[peer.ID]*peerRecordState
 
 	refCount sync.WaitGroup
@@ -299,7 +299,7 @@ func (mab *memoryAddrBook) addAddrsUnlocked(p peer.ID, addrs []ma.Multiaddr, ttl
 		if !found {
 			// not found, announce it.
 			entry := &expiringAddr{Addr: addr, Expires: exp, TTL: ttl, Peer: p}
-			heap.Push(mab.addrs, entry)
+			heap.Push(&mab.addrs, entry)
 			mab.subManager.BroadcastAddr(p, addr)
 		} else {
 			// update ttl & exp to whichever is greater between new and existing entry
@@ -355,7 +355,7 @@ func (mab *memoryAddrBook) SetAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Du
 			}
 		} else {
 			if ttl > 0 {
-				heap.Push(mab.addrs, &expiringAddr{Addr: addr, Expires: exp, TTL: ttl, Peer: p})
+				heap.Push(&mab.addrs, &expiringAddr{Addr: addr, Expires: exp, TTL: ttl, Peer: p})
 				mab.subManager.BroadcastAddr(p, addr)
 			}
 		}

--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -16,8 +16,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-var SignedPeerRecordBound = 100_000
-
 var log = logging.Logger("peerstore")
 
 type expiringAddr struct {
@@ -231,8 +229,6 @@ func (mab *memoryAddrBook) AddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Du
 	mab.addAddrs(p, addrs, ttl)
 }
 
-var ErrTooManyRecords = fmt.Errorf("too many signed peer records. Dropping this one")
-
 // ConsumePeerRecord adds addresses from a signed peer.PeerRecord, which will expire after the given TTL.
 // See https://godoc.org/github.com/libp2p/go-libp2p/core/peerstore#CertifiedAddrBook for more details.
 func (mab *memoryAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, ttl time.Duration) (bool, error) {
@@ -250,9 +246,6 @@ func (mab *memoryAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, tt
 
 	mab.mu.Lock()
 	defer mab.mu.Unlock()
-	if (len(mab.signedPeerRecords)) >= SignedPeerRecordBound {
-		return false, ErrTooManyRecords
-	}
 
 	// ensure seq is greater than or equal to the last received
 	lastState, found := mab.signedPeerRecords[rec.PeerID]

--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -110,12 +110,15 @@ func (pa *peerAddrs) FindAddr(p peer.ID, addrBytes ma.Multiaddr) (*expiringAddr,
 	return nil, false
 }
 
-func (pa *peerAddrs) Peek() *expiringAddr {
-	return pa.expiringHeap[len(pa.expiringHeap)-1]
+func (pa *peerAddrs) NextExpiry() time.Time {
+	if len(pa.expiringHeap) == 0 {
+		return time.Time{}
+	}
+	return pa.expiringHeap[len(pa.expiringHeap)-1].Expires
 }
 
 func (pa *peerAddrs) gc(now time.Time) {
-	for len(pa.expiringHeap) > 0 && pa.Peek().ExpiredBy(now) {
+	for len(pa.expiringHeap) > 0 && now.After(pa.NextExpiry()) {
 		heap.Pop(pa)
 	}
 }

--- a/p2p/host/peerstore/pstoremem/addr_book_test.go
+++ b/p2p/host/peerstore/pstoremem/addr_book_test.go
@@ -1,0 +1,133 @@
+package pstoremem
+
+import (
+	"container/heap"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerAddrsNextExpiry(t *testing.T) {
+	paa := newPeerAddrs()
+	pa := &paa
+	a1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
+	a2 := ma.StringCast("/ip4/1.2.3.4/udp/2/quic-v1")
+
+	// t1 is before t2
+	t1 := time.Time{}.Add(1 * time.Second)
+	t2 := time.Time{}.Add(2 * time.Second)
+	heap.Push(pa, &expiringAddr{Addr: a1, Expires: t1, TTL: 10 * time.Second, Peer: "p1"})
+	heap.Push(pa, &expiringAddr{Addr: a2, Expires: t2, TTL: 10 * time.Second, Peer: "p2"})
+
+	if pa.NextExpiry() != t1 {
+		t.Fatal("expiry should be set to t1, got", pa.NextExpiry())
+	}
+}
+
+func TestPeerAddrsHeapProperty(t *testing.T) {
+	paa := newPeerAddrs()
+	pa := &paa
+	addrs := []ma.Multiaddr{}
+	expiries := []time.Time{}
+
+	const N = 10000
+	for i := 0; i < N; i++ {
+		addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/1.2.3.4/udp/%d/quic-v1", i)))
+		expiries = append(expiries, time.Time{}.Add(time.Duration(10000-i)*time.Second)) // expiries are in reverse order
+		pid := peer.ID(fmt.Sprintf("p%d", i))
+		heap.Push(pa, &expiringAddr{Addr: addrs[i], Expires: expiries[i], TTL: 10 * time.Second, Peer: pid})
+	}
+
+	for i := N - 1; i >= 0; i-- {
+		ea, ok := pa.PopIfExpired(expiries[i])
+		require.True(t, ok)
+		require.Equal(t, ea.Addr, addrs[i])
+
+		ea, ok = pa.PopIfExpired(expiries[i])
+		require.False(t, ok)
+		require.Nil(t, ea)
+	}
+}
+
+func TestPeerAddrsHeapPropertyDeletions(t *testing.T) {
+	paa := newPeerAddrs()
+	pa := &paa
+	expiringAddrs := []*expiringAddr{}
+
+	const N = 10000
+	for i := 0; i < N; i++ {
+		a := ma.StringCast(fmt.Sprintf("/ip4/1.2.3.4/udp/%d/quic-v1", i))
+		e := time.Time{}.Add(time.Duration(10000-i) * time.Second) // expiries are in reverse order
+		p := peer.ID(fmt.Sprintf("p%d", i))
+		expiringAddrs = append(expiringAddrs, &expiringAddr{Addr: a, Expires: e, TTL: 10 * time.Second, Peer: p})
+		heap.Push(pa, expiringAddrs[i])
+	}
+
+	// delete every 3rd element
+	for i := 0; i < N; i += 3 {
+		paa.Delete(expiringAddrs[i])
+	}
+
+	for i := N - 1; i >= 0; i-- {
+		ea, ok := pa.PopIfExpired(expiringAddrs[i].Expires)
+		if i%3 == 0 {
+			require.False(t, ok)
+			require.Nil(t, ea)
+		} else {
+			require.True(t, ok)
+			require.Equal(t, ea.Addr, expiringAddrs[i].Addr)
+		}
+
+		ea, ok = pa.PopIfExpired(expiringAddrs[i].Expires)
+		require.False(t, ok)
+		require.Nil(t, ea)
+	}
+}
+
+func TestPeerAddrsHeapPropertyUpdates(t *testing.T) {
+	paa := newPeerAddrs()
+	pa := &paa
+	expiringAddrs := []*expiringAddr{}
+
+	const N = 10000
+	for i := 0; i < N; i++ {
+		a := ma.StringCast(fmt.Sprintf("/ip4/1.2.3.4/udp/%d/quic-v1", i))
+		e := time.Time{}.Add(time.Duration(N-i) * time.Second) // expiries are in reverse order
+		p := peer.ID(fmt.Sprintf("p%d", i))
+		expiringAddrs = append(expiringAddrs, &expiringAddr{Addr: a, Expires: e, TTL: 10 * time.Second, Peer: p})
+		heap.Push(pa, expiringAddrs[i])
+	}
+
+	// update every 3rd element to expire at the end
+	var endElements []ma.Multiaddr
+	for i := 0; i < N; i += 3 {
+		expiringAddrs[i].Expires = time.Time{}.Add(1000_000 * time.Second)
+		pa.Fix(expiringAddrs[i])
+		endElements = append(endElements, expiringAddrs[i].Addr)
+	}
+
+	for i := N - 1; i >= 0; i-- {
+		if i%3 == 0 {
+			continue // skip the elements at the end
+		}
+		ea, ok := pa.PopIfExpired(expiringAddrs[i].Expires)
+		require.True(t, ok, "pos: %d", i)
+		require.Equal(t, ea.Addr, expiringAddrs[i].Addr)
+
+		ea, ok = pa.PopIfExpired(expiringAddrs[i].Expires)
+		require.False(t, ok)
+		require.Nil(t, ea)
+	}
+
+	for len(endElements) > 0 {
+		ea, ok := pa.PopIfExpired(time.Time{}.Add(1000_000 * time.Second))
+		require.True(t, ok)
+		require.Contains(t, endElements, ea.Addr)
+		endElements = slices.DeleteFunc(endElements, func(a ma.Multiaddr) bool { return ea.Addr.Equal(a) })
+	}
+}

--- a/p2p/host/peerstore/pstoremem/inmem_test.go
+++ b/p2p/host/peerstore/pstoremem/inmem_test.go
@@ -93,20 +93,22 @@ func BenchmarkGC(b *testing.B) {
 	require.NoError(b, err)
 	defer ps.Close()
 
-	peerCount := 10_000
+	peerCount := 100_000
 	addrsPerPeer := 32
-
-	for i := 0; i < peerCount; i++ {
-		id := peer.ID(strconv.Itoa(i))
-		addrs := make([]multiaddr.Multiaddr, addrsPerPeer)
-		for j := 0; j < addrsPerPeer; j++ {
-			addrs[j] = multiaddr.StringCast("/ip4/1.2.3.4/tcp/" + strconv.Itoa(j))
-		}
-		ps.AddAddrs(id, addrs, 24*time.Hour)
-	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		for i := 0; i < peerCount; i++ {
+			id := peer.ID(strconv.Itoa(i))
+			addrs := make([]multiaddr.Multiaddr, addrsPerPeer)
+			for j := 0; j < addrsPerPeer; j++ {
+				addrs[j] = multiaddr.StringCast("/ip4/1.2.3.4/tcp/" + strconv.Itoa(j))
+			}
+			ps.AddAddrs(id, addrs, 24*time.Hour)
+		}
+		clock.Add(25 * time.Hour)
+		b.StartTimer()
 		ps.gc()
 	}
 }

--- a/p2p/host/peerstore/pstoremem/inmem_test.go
+++ b/p2p/host/peerstore/pstoremem/inmem_test.go
@@ -1,10 +1,14 @@
 package pstoremem
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
 	pt "github.com/libp2p/go-libp2p/p2p/host/peerstore/test"
+	"github.com/multiformats/go-multiaddr"
 
 	mockClock "github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
@@ -81,4 +85,28 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/ipfs/go-log/v2/writer.(*MirrorWriter).logRoutine"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 	)
+}
+
+func BenchmarkGC(b *testing.B) {
+	clock := mockClock.NewMock()
+	ps, err := NewPeerstore(WithClock(clock))
+	require.NoError(b, err)
+	defer ps.Close()
+
+	peerCount := 10_000
+	addrsPerPeer := 32
+
+	for i := 0; i < peerCount; i++ {
+		id := peer.ID(strconv.Itoa(i))
+		addrs := make([]multiaddr.Multiaddr, addrsPerPeer)
+		for j := 0; j < addrsPerPeer; j++ {
+			addrs[j] = multiaddr.StringCast("/ip4/1.2.3.4/tcp/" + strconv.Itoa(j))
+		}
+		ps.AddAddrs(id, addrs, 24*time.Hour)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ps.gc()
+	}
 }


### PR DESCRIPTION
Closes #1698 

Makes GC ~60x faster (on my synthetic benchmark) under certain circumstances. So by that logic, it should be fine to run this more often.

Adds a min heap list to track the next address to expire. This lets us short circuit gc if we see the next address to expire isn't expired yet.

Also bumps the gc interval from 60 minutes to 1 minute. This should be fine since we don't traverse every address anymore.

This relies on existing tests to assert nothing has broken.

Of course there are many more improvements that could be made. See the linked issue for inspiration. The next lowest hanging fruit is to do something similar to this across peers.