### PR TITLE
connmgr: reduce log level for untagging untracked peers

### DIFF
--- a/p2p/net/connmgr/connmgr.go
+++ b/p2p/net/connmgr/connmgr.go
@@ -592,7 +592,7 @@ func (cm *BasicConnMgr) UntagPeer(p peer.ID, tag string) {
 
 	pi, ok := s.peers[p]
 	if !ok {
-		log.Info("tried to remove tag from untracked peer: ", p)
+		log.Debug("tried to remove tag from untracked peer: ", p, tag)
 		return
 	}
 


### PR DESCRIPTION
Method UntagPeer() logs an "info" log message whenever it's called for a peer that is untracked. It generates a lot of noise in the logs for something that is basically harmless.

This commit reduces the log level to "debug" for this message.