### PR TITLE
Feat: Expose Fx options directly

### DIFF
--- a/fx/options.go
+++ b/fx/options.go
@@ -1,0 +1,362 @@
+package libp2pfx
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+	"slices"
+
+	"github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/pnet"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/sec"
+	"github.com/libp2p/go-libp2p/core/transport"
+	blankhost "github.com/libp2p/go-libp2p/p2p/host/blank"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
+	connmgrImpl "github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/libp2p/go-libp2p/p2p/net/swarm"
+	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
+	"github.com/libp2p/go-libp2p/p2p/security/noise"
+	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
+	libp2pquic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	"github.com/multiformats/go-multiaddr"
+	mstream "github.com/multiformats/go-multistream"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/quic-go/quic-go"
+	"go.uber.org/fx"
+	"golang.org/x/crypto/hkdf"
+)
+
+type blankHostParams struct {
+	fx.In
+	Network   network.Network
+	Mux       *mstream.MultistreamMuxer[protocol.ID]
+	ConnMgr   connmgr.ConnManager
+	EventBus  event.Bus
+	Lifecycle fx.Lifecycle
+}
+
+func BlankHost() fx.Option {
+	return fx.Provide(func(params blankHostParams) host.Host {
+		h := blankhost.BlankHost{
+			N:       params.Network,
+			M:       params.Mux,
+			ConnMgr: params.ConnMgr,
+			E:       params.EventBus,
+			// Users can do this manually, but can't opt out of it otherwise.
+			SkipInitSignedRecord: true,
+		}
+		params.Lifecycle.Append(fx.Hook{
+			OnStart: func(context.Context) error {
+				return h.Start()
+			},
+			OnStop: func(context.Context) error {
+				return h.Close()
+			},
+		})
+		return &h
+	})
+}
+
+type swarmParams struct {
+	fx.In
+	fx.Lifecycle
+	Local       peer.ID
+	Peerstore   peerstore.Peerstore
+	EventBus    event.Bus
+	ListenAddrs []ListenAddr `group:"listenAddr"`
+}
+
+func SwarmNetwork(opts ...swarm.Option) fx.Option {
+	return fx.Module("swarm",
+		fx.Provide(fx.Annotate(func(params swarmParams) (*swarm.Swarm, error) {
+			s, err := swarm.NewSwarm(
+				params.Local,
+				params.Peerstore,
+				params.EventBus,
+				opts...,
+			)
+			if err != nil {
+				return nil, err
+			}
+			params.Lifecycle.Append(fx.StartStopHook(
+				func() error {
+					addrs := make([]multiaddr.Multiaddr, len(params.ListenAddrs))
+					for i, a := range params.ListenAddrs {
+						addrs[i] = multiaddr.Multiaddr(a)
+					}
+					return s.Listen(addrs...)
+				},
+				s.Close,
+			))
+			return s, nil
+		}, fx.As(new(network.Network)), fx.As(fx.Self()))),
+		fx.Invoke(
+			fx.Annotate(
+				func(swrm *swarm.Swarm, tpts []transport.Transport) error {
+					for _, t := range tpts {
+						if err := swrm.AddTransport(t); err != nil {
+							return err
+						}
+					}
+					return nil
+				},
+				fx.ParamTags("", `group:"transport"`),
+			)),
+	)
+}
+
+type peerIDRes struct {
+	fx.Out
+	Peer peer.ID
+	Key  crypto.PrivKey
+}
+
+func RandomPeerID() fx.Option {
+	return fx.Provide(func() (peerIDRes, error) {
+		priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+		if err != nil {
+			return peerIDRes{}, err
+		}
+		pid, err := peer.IDFromPrivateKey(priv)
+		if err != nil {
+			return peerIDRes{}, err
+		}
+		return peerIDRes{Peer: pid, Key: priv}, nil
+	})
+}
+
+var QUICTransport = fx.Provide(
+	fx.Annotate(
+		func(params struct {
+			fx.In
+			PrivKey     crypto.PrivKey
+			QUICConnMgr *quicreuse.ConnManager
+			ConnGater   connmgr.ConnectionGater
+			Rcmgr       network.ResourceManager
+		}) (transport.Transport, error) {
+			return libp2pquic.NewTransport(
+				params.PrivKey,
+				params.QUICConnMgr,
+				nil,
+				params.ConnGater,
+				params.Rcmgr,
+			)
+		},
+		fx.ResultTags(`group:"transport"`),
+	),
+)
+
+func TCPTransport(opts ...tcp.Option) fx.Option {
+	return fx.Provide(
+		fx.Annotate(
+			func(p struct {
+				fx.In
+				Upgrader transport.Upgrader
+				Rcmgr    network.ResourceManager
+			}) (transport.Transport, error) {
+				return tcp.NewTCPTransport(p.Upgrader, p.Rcmgr, opts...)
+			},
+			fx.As(new(transport.Transport)),
+			fx.ResultTags(`group:"transport"`),
+		),
+	)
+}
+
+func Upgrader(opts ...tptu.Option) fx.Option {
+	return fx.Provide(
+		func(p struct {
+			fx.In
+			Security  []sec.SecureTransport
+			Muxers    []tptu.StreamMuxer
+			Rcmgr     network.ResourceManager
+			ConnGater connmgr.ConnectionGater
+		}) (transport.Upgrader, error) {
+			// Not supporting PSK here since it doesn't work on all transports,
+			// and there are better ways of authenticating peers.  If you need
+			// PSK, provide the upgrader manually.
+			var psk pnet.PSK = nil
+			return tptu.New(p.Security, p.Muxers, psk, p.Rcmgr, p.ConnGater, opts...)
+		},
+	)
+}
+
+// Security is a helper to provide a list of security transports in a specific order.
+func Security(ss ...func() (protocol.ID, fx.Option)) fx.Option {
+	order := make(map[protocol.ID]int)
+	var opts []fx.Option
+	for i, s := range ss {
+		id, opt := s()
+		order[id] = i
+		opts = append(opts, opt)
+	}
+	opts = append(opts,
+		fx.Provide(fx.Annotate(func(unorderedSecurity []sec.SecureTransport) []sec.SecureTransport {
+			slices.SortFunc(unorderedSecurity, func(a, b sec.SecureTransport) int {
+				return order[a.ID()] - order[b.ID()]
+			})
+			return unorderedSecurity
+		}, fx.ParamTags(`group:"unorderedSecurity"`))),
+	)
+	return fx.Options(opts...)
+}
+
+var Noise = func() (protocol.ID, fx.Option) {
+	return noise.ID, fx.Provide(
+		fx.Annotate(
+			func(
+				p struct {
+					fx.In
+					Privkey crypto.PrivKey
+					Muxers  []tptu.StreamMuxer
+				}) (sec.SecureTransport, error) {
+				return noise.New(noise.ID, p.Privkey, p.Muxers)
+			},
+			fx.ResultTags(`group:"unorderedSecurity"`),
+		),
+	)
+}
+
+var TLS = func() (protocol.ID, fx.Option) {
+	return tls.ID, fx.Provide(
+		fx.Annotate(
+			func(
+				p struct {
+					fx.In
+					Privkey crypto.PrivKey
+					Muxers  []tptu.StreamMuxer
+				}) (sec.SecureTransport, error) {
+				return tls.New(tls.ID, p.Privkey, p.Muxers)
+			},
+			fx.ResultTags(`group:"unorderedSecurity"`),
+		),
+	)
+}
+
+var Yamux = fx.Supply(
+	[]tptu.StreamMuxer{{
+		ID:    yamux.ID,
+		Muxer: yamux.DefaultTransport,
+	}},
+)
+
+type MetricsConfig struct {
+	Disable            bool
+	PrometheusRegister prometheus.Registerer
+}
+
+var DisableMetrics = fx.Decorate(func(params struct {
+	fx.In
+	cfg *MetricsConfig `optional:"true"`
+}) *MetricsConfig {
+	if params.cfg == nil {
+		params.cfg = new(MetricsConfig)
+	}
+	params.cfg.Disable = true
+	return params.cfg
+})
+
+var QUICReuseConnManager = fx.Provide(
+	func(metricsCfg MetricsConfig, key quic.StatelessResetKey, tokenGenerator quic.TokenGeneratorKey, lifecycle fx.Lifecycle) (*quicreuse.ConnManager, error) {
+		var opts []quicreuse.Option
+		if !metricsCfg.Disable {
+			opts = append(opts, quicreuse.EnableMetrics(metricsCfg.PrometheusRegister))
+		}
+		cm, err := quicreuse.NewConnManager(key, tokenGenerator, opts...)
+		if err != nil {
+			return nil, err
+		}
+		lifecycle.Append(fx.StopHook(cm.Close))
+		return cm, nil
+	},
+	func(key crypto.PrivKey) (quic.StatelessResetKey, error) {
+		var statelessResetKey quic.StatelessResetKey
+		keyBytes, err := key.Raw()
+		if err != nil {
+			return statelessResetKey, err
+		}
+
+		const statelessResetKeyInfo = "libp2p quic stateless reset key"
+		keyReader := hkdf.New(sha256.New, keyBytes, nil, []byte(statelessResetKeyInfo))
+		if _, err := io.ReadFull(keyReader, statelessResetKey[:]); err != nil {
+			return statelessResetKey, err
+		}
+		return statelessResetKey, nil
+	},
+	func(key crypto.PrivKey) (quic.TokenGeneratorKey, error) {
+		var tokenKey quic.TokenGeneratorKey
+		keyBytes, err := key.Raw()
+		if err != nil {
+			return tokenKey, err
+		}
+
+		const tokenGeneratorKeyInfo = "libp2p quic token generator key"
+		keyReader := hkdf.New(sha256.New, keyBytes, nil, []byte(tokenGeneratorKeyInfo))
+		if _, err := io.ReadFull(keyReader, tokenKey[:]); err != nil {
+			return tokenKey, err
+		}
+		return tokenKey, nil
+	},
+)
+
+func EventBus(opts ...eventbus.Option) fx.Option {
+	return fx.Supply(fx.Annotate(eventbus.NewBus(opts...), fx.As(new(event.Bus))))
+}
+
+func InMemoryPeerstore() fx.Option {
+	return fx.Provide(func() (peerstore.Peerstore, error) {
+		return pstoremem.NewPeerstore()
+	})
+}
+
+func ConnManager(low, hi int) fx.Option {
+	return fx.Provide(func() (connmgr.ConnManager, error) {
+		return connmgrImpl.NewConnManager(low, hi)
+	})
+}
+
+var DefaultConnManager = ConnManager(160, 192)
+
+var NullConnManager = fx.Provide(func() connmgr.ConnManager {
+	return connmgr.NullConnMgr{}
+})
+
+var NullResourceManager = fx.Provide(func() network.ResourceManager {
+	return &network.NullResourceManager{}
+})
+
+var NullConnectionGater = fx.Provide(func() connmgr.ConnectionGater {
+	return nil
+})
+
+var MultistreamMuxer = fx.Provide(func() *mstream.MultistreamMuxer[protocol.ID] {
+	return mstream.NewMultistreamMuxer[protocol.ID]()
+})
+
+// New type to specify that these are used for listening.
+type ListenAddr multiaddr.Multiaddr
+
+func ListenAddrs(addrs ...multiaddr.Multiaddr) fx.Option {
+	return fx.Provide(
+		fx.Annotate(
+			func() []ListenAddr {
+				out := make([]ListenAddr, len(addrs))
+				for i, a := range addrs {
+					out[i] = ListenAddr(a)
+				}
+				return out
+			},
+			fx.ResultTags(`group:"listenAddr,flatten"`),
+		))
+}

--- a/fx/options_test.go
+++ b/fx/options_test.go
@@ -1,0 +1,235 @@
+package libp2pfx
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/sec"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestConstructHost(t *testing.T) {
+	app := fx.New(
+		BlankHost(),
+		SwarmNetwork(),
+		RandomPeerID(),
+		EventBus(),
+		InMemoryPeerstore(),
+		NullConnManager,
+		MultistreamMuxer,
+		fx.Invoke(func(h host.Host) {
+			require.NotNil(t, h)
+		}),
+	)
+	require.NoError(t, app.Start(context.Background()))
+	defer assert.NoError(t, app.Stop(context.Background()))
+}
+
+func echoTest(t *testing.T, h1, h2 host.Host) {
+	require.NoError(t,
+		h1.Connect(context.Background(), peer.AddrInfo{
+			ID:    h2.ID(),
+			Addrs: h2.Addrs(),
+		}))
+	require.NoError(t,
+		h2.Connect(context.Background(), peer.AddrInfo{
+			ID:    h1.ID(),
+			Addrs: h1.Addrs(),
+		}))
+
+	h2.SetStreamHandler("/test", func(s network.Stream) {
+		defer s.Close()
+		io.Copy(s, s)
+	})
+
+	s, err := h1.NewStream(context.Background(), h2.ID(), "/test")
+	require.NoError(t, err)
+
+	_, err = s.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, s.CloseWrite())
+
+	b, err := io.ReadAll(s)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(b))
+}
+
+func TestQUICTransport(t *testing.T) {
+	newHost := func() host.Host {
+		var h host.Host
+		app := fx.New(
+			fx.NopLogger,
+			BlankHost(),
+			SwarmNetwork(),
+			RandomPeerID(),
+			EventBus(),
+			InMemoryPeerstore(),
+			MultistreamMuxer,
+			QUICTransport,
+			QUICReuseConnManager,
+			NullConnectionGater,
+			NullResourceManager,
+			NullConnManager,
+			fx.Supply(MetricsConfig{Disable: true}),
+			fx.Populate(&h),
+			ListenAddrs(multiaddr.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")),
+		)
+
+		require.NoError(t, app.Start(context.Background()))
+		t.Cleanup(func() { app.Stop(context.Background()) })
+		return h
+	}
+
+	h1 := newHost()
+	h2 := newHost()
+
+	echoTest(t, h1, h2)
+}
+
+func TestTCPTransport(t *testing.T) {
+	newHost := func() host.Host {
+		var h host.Host
+		app := fx.New(
+			fx.NopLogger,
+			BlankHost(),
+			SwarmNetwork(),
+			RandomPeerID(),
+			EventBus(),
+			InMemoryPeerstore(),
+			MultistreamMuxer,
+			QUICReuseConnManager,
+			NullConnectionGater,
+			NullResourceManager,
+			NullConnManager,
+			fx.Supply(MetricsConfig{Disable: true}),
+			fx.Populate(&h),
+			Upgrader(),
+			TCPTransport(),
+			Yamux,
+			// TODO how to order?
+			Security(
+				TLS,
+				Noise,
+			),
+			// Assert the security order is correct
+			ListenAddrs(multiaddr.StringCast("/ip4/127.0.0.1/tcp/0")),
+		)
+
+		require.NoError(t, app.Start(context.Background()))
+		t.Cleanup(func() { app.Stop(context.Background()) })
+		return h
+	}
+
+	h1 := newHost()
+	h2 := newHost()
+	t.Log(h1.Addrs(), h2.Addrs())
+
+	echoTest(t, h1, h2)
+}
+
+func TestSecurityOrder(t *testing.T) {
+	app := fx.New(
+		RandomPeerID(),
+		Yamux,
+		Security(
+			TLS,
+			Noise,
+		),
+		// Assert the security order is correct
+		fx.Invoke(func(security []sec.SecureTransport) {
+			ids := make([]string, len(security))
+			for i, s := range security {
+				ids[i] = string(s.ID())
+			}
+			assert.Equal(t, []string{"/tls/1.0.0", "/noise"}, ids)
+		}),
+	)
+	require.NoError(t, app.Start(context.Background()))
+	require.NoError(t, app.Stop(context.Background()))
+}
+
+func quicOptions() fx.Option {
+	return fx.Options(
+		fx.NopLogger,
+		BlankHost(),
+		SwarmNetwork(),
+		RandomPeerID(),
+		EventBus(),
+		InMemoryPeerstore(),
+		MultistreamMuxer,
+		QUICTransport,
+		QUICReuseConnManager,
+		NullConnectionGater,
+		NullResourceManager,
+		NullConnManager,
+		fx.Supply(MetricsConfig{Disable: true}),
+		ListenAddrs(multiaddr.StringCast("/ip4/127.0.0.1/udp/0/quic-v1")),
+	)
+}
+
+func TestPing(t *testing.T) {
+	newHost := func() (host.Host, *ping.PingService) {
+		var h host.Host
+		var s *ping.PingService
+		opts := quicOptions()
+		app := fx.New(
+			opts,
+			PingService,
+			fx.Populate(&h),
+			fx.Populate(&s),
+		)
+		require.NoError(t, app.Start(context.Background()))
+		t.Cleanup(func() { assert.NoError(t, app.Stop(context.Background())) })
+		return h, s
+	}
+
+	h1, s := newHost()
+	h2, _ := newHost()
+	require.NoError(t, h1.Connect(context.Background(), peer.AddrInfo{h2.ID(), h2.Addrs()}))
+	res := <-s.Ping(context.Background(), h2.ID())
+	require.NoError(t, res.Error)
+	t.Log(res.RTT)
+}
+
+func TestIdentify(t *testing.T) {
+	newHost := func() (host.Host, identify.IDService, event.Bus) {
+		var h host.Host
+		var s identify.IDService
+		var eb event.Bus
+		opts := quicOptions()
+		app := fx.New(
+			opts,
+			IdentifyService(),
+			fx.Populate(&h, &s, &eb),
+		)
+		require.NoError(t, app.Start(context.Background()))
+		t.Cleanup(func() { assert.NoError(t, app.Stop(context.Background())) })
+		return h, s, eb
+	}
+
+	h1, s, eb1 := newHost()
+	h2, _, eb2 := newHost()
+	sub1, err := eb1.Subscribe(new(event.EvtPeerIdentificationCompleted))
+	require.NoError(t, err)
+
+	sub2, err := eb2.Subscribe(new(event.EvtPeerIdentificationCompleted))
+	require.NoError(t, err)
+
+	require.NoError(t, h1.Connect(context.Background(), peer.AddrInfo{h2.ID(), h2.Addrs()}))
+	c := h1.Network().Conns()[0]
+	<-s.IdentifyWait(c)
+	res := (<-sub1.Out()).(event.EvtPeerIdentificationCompleted)
+	t.Log(res)
+	res = (<-sub2.Out()).(event.EvtPeerIdentificationCompleted)
+	t.Log(res)
+}

--- a/fx/services.go
+++ b/fx/services.go
@@ -1,0 +1,25 @@
+package libp2pfx
+
+import (
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	"go.uber.org/fx"
+)
+
+func IdentifyService(opts ...identify.Option) fx.Option {
+	return fx.Provide(func(l fx.Lifecycle, h host.Host) (identify.IDService, error) {
+		s, err := identify.NewIDService(h, opts...)
+		if err != nil {
+			return nil, err
+		}
+		l.Append(fx.StartStopHook(s.Start, s.Close))
+		return s, nil
+	})
+}
+
+var PingService = fx.Provide(func(l fx.Lifecycle, h host.Host) *ping.PingService {
+	s := &ping.PingService{Host: h}
+	l.Append(fx.StartStopHook(s.Start, s.Stop))
+	return s
+})

--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -39,6 +39,14 @@ func NewPingService(h host.Host) *PingService {
 	return ps
 }
 
+func (p *PingService) Start() {
+	p.Host.SetStreamHandler(ID, p.PingHandler)
+}
+
+func (p *PingService) Stop() {
+	p.Host.RemoveStreamHandler(ID)
+}
+
 func (p *PingService) PingHandler(s network.Stream) {
 	if err := s.Scope().SetService(ServiceName); err != nil {
 		log.Debugf("error attaching stream to ping service: %s", err)


### PR DESCRIPTION
This allows many things:

- Easily build libp2p in a modular way, relying on Fx to fill in the dependency graph.
- Allow user services to get access to shared resources like the Peerstore, or other services like Idenetify without having to expose a method in the Host interface for all these things. Or without having the user have to cast the `host.Host` into a basic host.
- Allow users who don't need resources like a Peerstore to avoid allocating one.
- In the case that the user is already using Fx, it plugs neatly into their constructor. In case it isn't, it should still be just as easy to construct the libp2p host as it is today.
- Better support for "setup packs". Preconfigured options for certain use-cases (e.g. everything please; I'm a public server; absolute bare minimum)

In draft until we get close to feature parity with the existing constructor. Please let me know if you'd be interested in trying this when we release it. (In particular I think this would significantly clean up Kubo's libp2p constructor). 