### PR TITLE
RoutedHost: Embed the underlying host instead of hiding it

### DIFF
--- a/p2p/host/routed/routed_test.go
+++ b/p2p/host/routed/routed_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
 	basic "github.com/libp2p/go-libp2p/p2p/host/basic"
 	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
 
@@ -12,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ Routing = (*mockRouting)(nil)
+var _ routing.PeerRouting = (*mockRouting)(nil)
 
 type mockRouting struct {
 	callCount  int


### PR DESCRIPTION
When using a libp2p host with routing, the underlying concrete type is RoutedHost. This type wraps the original Host type and hides it into a private field, which makes it hard to make interface type assertions on the host.

E.g. sometimes it's useful to have access to the underlying instance of the IDService, which is exposed by BasicHost as a method `IDService() identityIDService`, but is inaccessible for type assertions because RoutedHost hides the BasicHost in its private field.

This commit uses type embedding, instead of a private field, to fix it.