### PR TITLE
feat(tcpreuse): add options for sharing TCP listeners amongst TCP, WS and WSS transports

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -59,7 +59,7 @@ func TestTransportConstructor(t *testing.T) {
 		_ connmgr.ConnectionGater,
 		upgrader transport.Upgrader,
 	) transport.Transport {
-		tpt, err := tcp.NewTCPTransport(upgrader, nil)
+		tpt, err := tcp.NewTCPTransport(upgrader, nil, nil)
 		require.NoError(t, err)
 		return tpt
 	}
@@ -750,4 +750,17 @@ func getTLSConf(t *testing.T, ip net.IP, start, end time.Time) *tls.Config {
 			Leaf:        cert,
 		}},
 	}
+}
+
+func TestSharedTCPAddr(t *testing.T) {
+	h, err := New(
+		ShareTCPListener(),
+		Transport(tcp.NewTCPTransport),
+		Transport(websocket.New),
+		ListenAddrStrings("/ip4/0.0.0.0/tcp/8888"),
+		ListenAddrStrings("/ip4/0.0.0.0/tcp/8888/ws"),
+	)
+	require.NoError(t, err)
+	fmt.Println(h.Addrs())
+	h.Close()
 }

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -761,6 +761,17 @@ func TestSharedTCPAddr(t *testing.T) {
 		ListenAddrStrings("/ip4/0.0.0.0/tcp/8888/ws"),
 	)
 	require.NoError(t, err)
-	fmt.Println(h.Addrs())
+	sawTCP := false
+	sawWS := false
+	for _, addr := range h.Addrs() {
+		if strings.HasSuffix(addr.String(), "/tcp/8888") {
+			sawTCP = true
+		}
+		if strings.HasSuffix(addr.String(), "/tcp/8888/ws") {
+			sawWS = true
+		}
+	}
+	require.True(t, sawTCP)
+	require.True(t, sawWS)
 	h.Close()
 }

--- a/options.go
+++ b/options.go
@@ -644,6 +644,7 @@ func WithFxOption(opts ...fx.Option) Option {
 	}
 }
 
+// ShareTCPListener shares the same listen address between TCP and Websocket transports.
 func ShareTCPListener() Option {
 	return func(cfg *Config) error {
 		cfg.ShareTCPListener = true

--- a/options.go
+++ b/options.go
@@ -644,7 +644,11 @@ func WithFxOption(opts ...fx.Option) Option {
 	}
 }
 
-// ShareTCPListener shares the same listen address between TCP and Websocket transports.
+// ShareTCPListener shares the same listen address between TCP and Websocket
+// transports. This lets both transports use the same TCP port.
+//
+// Currently this behavior is Opt-in. In a future release this will be the
+// default, and this option will be removed.
 func ShareTCPListener() Option {
 	return func(cfg *Config) error {
 		cfg.ShareTCPListener = true

--- a/options.go
+++ b/options.go
@@ -643,3 +643,10 @@ func WithFxOption(opts ...fx.Option) Option {
 		return nil
 	}
 }
+
+func ShareTCPListener() Option {
+	return func(cfg *Config) error {
+		cfg.ShareTCPListener = true
+		return nil
+	}
+}

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -84,7 +84,7 @@ func makeSwarmWithNoListenAddrs(t *testing.T, opts ...Option) *Swarm {
 	upgrader := makeUpgrader(t, s)
 	var tcpOpts []tcp.Option
 	tcpOpts = append(tcpOpts, tcp.DisableReuseport())
-	tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, tcpOpts...)
+	tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, nil, tcpOpts...)
 	require.NoError(t, err)
 	if err := s.AddTransport(tcpTransport); err != nil {
 		t.Fatal(err)

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -79,7 +79,7 @@ func TestDialAddressSelection(t *testing.T) {
 	s, err := swarm.NewSwarm("local", nil, eventbus.NewBus())
 	require.NoError(t, err)
 
-	tcpTr, err := tcp.NewTCPTransport(nil, nil)
+	tcpTr, err := tcp.NewTCPTransport(nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, s.AddTransport(tcpTr))
 	reuse, err := quicreuse.NewConnManager(quic.StatelessResetKey{}, quic.TokenGeneratorKey{})

--- a/p2p/net/swarm/swarm_dial_test.go
+++ b/p2p/net/swarm/swarm_dial_test.go
@@ -53,7 +53,7 @@ func TestAddrsForDial(t *testing.T) {
 	ps.AddPrivKey(id, priv)
 	t.Cleanup(func() { ps.Close() })
 
-	tpt, err := websocket.New(nil, &network.NullResourceManager{})
+	tpt, err := websocket.New(nil, &network.NullResourceManager{}, nil)
 	require.NoError(t, err)
 	s, err := NewSwarm(id, ps, eventbus.NewBus(), WithMultiaddrResolver(ResolverFromMaDNS{resolver}))
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestDedupAddrsForDial(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	tpt, err := tcp.NewTCPTransport(nil, &network.NullResourceManager{})
+	tpt, err := tcp.NewTCPTransport(nil, &network.NullResourceManager{}, nil)
 	require.NoError(t, err)
 	err = s.AddTransport(tpt)
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func newTestSwarmWithResolver(t *testing.T, resolver *madns.Resolver) *Swarm {
 	})
 
 	// Add a tcp transport so that we know we can dial a tcp multiaddr and we don't filter it out.
-	tpt, err := tcp.NewTCPTransport(nil, &network.NullResourceManager{})
+	tpt, err := tcp.NewTCPTransport(nil, &network.NullResourceManager{}, nil)
 	require.NoError(t, err)
 	err = s.AddTransport(tpt)
 	require.NoError(t, err)
@@ -151,7 +151,7 @@ func newTestSwarmWithResolver(t *testing.T, resolver *madns.Resolver) *Swarm {
 	err = s.AddTransport(wtTpt)
 	require.NoError(t, err)
 
-	wsTpt, err := websocket.New(nil, &network.NullResourceManager{})
+	wsTpt, err := websocket.New(nil, &network.NullResourceManager{}, nil)
 	require.NoError(t, err)
 	err = s.AddTransport(wsTpt)
 	require.NoError(t, err)

--- a/p2p/net/swarm/testing/testing.go
+++ b/p2p/net/swarm/testing/testing.go
@@ -164,7 +164,7 @@ func GenSwarm(t testing.TB, opts ...Option) *swarm.Swarm {
 		if cfg.disableReuseport {
 			tcpOpts = append(tcpOpts, tcp.DisableReuseport())
 		}
-		tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, tcpOpts...)
+		tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, nil, tcpOpts...)
 		require.NoError(t, err)
 		if err := s.AddTransport(tcpTransport); err != nil {
 			t.Fatal(err)

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -84,13 +84,13 @@ func (l *listener) handleIncoming() {
 		}
 		catcher.Reset()
 
+		// Check if we already have a connection scope. See the comment in tcpreuse/listener.go for an explanation.
 		var connScope network.ConnManagementScope
 		if sc, ok := maconn.(interface {
 			Scope() network.ConnManagementScope
 		}); ok {
 			connScope = sc.Scope()
 		}
-
 		if connScope == nil {
 			// gate the connection if applicable
 			if l.upgrader.connGater != nil && !l.upgrader.connGater.InterceptAccept(maconn) {

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -91,7 +91,7 @@ func (l *listener) handleIncoming() {
 			connScope = sc.Scope()
 		}
 
-		if connScope != nil {
+		if connScope == nil {
 			// gate the connection if applicable
 			if l.upgrader.connGater != nil && !l.upgrader.connGater.InterceptAccept(maconn) {
 				log.Debugf("gater blocked incoming connection on local addr %s from %s",

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -84,23 +84,33 @@ func (l *listener) handleIncoming() {
 		}
 		catcher.Reset()
 
-		// gate the connection if applicable
-		if l.upgrader.connGater != nil && !l.upgrader.connGater.InterceptAccept(maconn) {
-			log.Debugf("gater blocked incoming connection on local addr %s from %s",
-				maconn.LocalMultiaddr(), maconn.RemoteMultiaddr())
-			if err := maconn.Close(); err != nil {
-				log.Warnf("failed to close incoming connection rejected by gater: %s", err)
-			}
-			continue
+		var connScope network.ConnManagementScope
+		if sc, ok := maconn.(interface {
+			Scope() network.ConnManagementScope
+		}); ok {
+			connScope = sc.Scope()
 		}
 
-		connScope, err := l.rcmgr.OpenConnection(network.DirInbound, true, maconn.RemoteMultiaddr())
-		if err != nil {
-			log.Debugw("resource manager blocked accept of new connection", "error", err)
-			if err := maconn.Close(); err != nil {
-				log.Warnf("failed to incoming connection rejected by resource manager: %s", err)
+		if connScope != nil {
+			// gate the connection if applicable
+			if l.upgrader.connGater != nil && !l.upgrader.connGater.InterceptAccept(maconn) {
+				log.Debugf("gater blocked incoming connection on local addr %s from %s",
+					maconn.LocalMultiaddr(), maconn.RemoteMultiaddr())
+				if err := maconn.Close(); err != nil {
+					log.Warnf("failed to close incoming connection rejected by gater: %s", err)
+				}
+				continue
 			}
-			continue
+
+			var err error
+			connScope, err = l.rcmgr.OpenConnection(network.DirInbound, true, maconn.RemoteMultiaddr())
+			if err != nil {
+				log.Debugw("resource manager blocked accept of new connection", "error", err)
+				if err := maconn.Close(); err != nil {
+					log.Warnf("failed to incoming connection rejected by resource manager: %s", err)
+				}
+				continue
+			}
 		}
 
 		// The go routine below calls Release when the context is

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -107,7 +107,7 @@ func (l *listener) handleIncoming() {
 			if err != nil {
 				log.Debugw("resource manager blocked accept of new connection", "error", err)
 				if err := maconn.Close(); err != nil {
-					log.Warnf("failed to incoming connection rejected by resource manager: %s", err)
+					log.Warnf("failed to open incoming connection. rejected by resource manager: %s", err)
 				}
 				continue
 			}

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -107,7 +107,7 @@ func (l *listener) handleIncoming() {
 			if err != nil {
 				log.Debugw("resource manager blocked accept of new connection", "error", err)
 				if err := maconn.Close(); err != nil {
-					log.Warnf("failed to open incoming connection. rejected by resource manager: %s", err)
+					log.Warnf("failed to open incoming connection. Rejected by resource manager: %s", err)
 				}
 				continue
 			}

--- a/p2p/protocol/circuitv2/relay/relay_test.go
+++ b/p2p/protocol/circuitv2/relay/relay_test.go
@@ -60,7 +60,7 @@ func getNetHosts(t *testing.T, ctx context.Context, n int) (hosts []host.Host, u
 		upgrader := swarmt.GenUpgrader(t, netw, nil)
 		upgraders = append(upgraders, upgrader)
 
-		tpt, err := tcp.NewTCPTransport(upgrader, nil)
+		tpt, err := tcp.NewTCPTransport(upgrader, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -100,6 +100,38 @@ var transportsToTest = []TransportTestCase{
 		},
 	},
 	{
+		Name: "TCP-Shared / TLS / Yamux",
+		HostGenerator: func(t *testing.T, opts TransportTestCaseOpts) host.Host {
+			libp2pOpts := transformOpts(opts)
+			libp2pOpts = append(libp2pOpts, libp2p.ShareTCPListener())
+			libp2pOpts = append(libp2pOpts, libp2p.Security(tls.ID, tls.New))
+			libp2pOpts = append(libp2pOpts, libp2p.Muxer(yamux.ID, yamux.DefaultTransport))
+			if opts.NoListen {
+				libp2pOpts = append(libp2pOpts, libp2p.NoListenAddrs)
+			} else {
+				libp2pOpts = append(libp2pOpts, libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+			}
+			h, err := libp2p.New(libp2pOpts...)
+			require.NoError(t, err)
+			return h
+		},
+	},
+	{
+		Name: "WebSocket-Shared",
+		HostGenerator: func(t *testing.T, opts TransportTestCaseOpts) host.Host {
+			libp2pOpts := transformOpts(opts)
+			libp2pOpts = append(libp2pOpts, libp2p.ShareTCPListener())
+			if opts.NoListen {
+				libp2pOpts = append(libp2pOpts, libp2p.NoListenAddrs)
+			} else {
+				libp2pOpts = append(libp2pOpts, libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0/ws"))
+			}
+			h, err := libp2p.New(libp2pOpts...)
+			require.NoError(t, err)
+			return h
+		},
+	},
+	{
 		Name: "WebSocket",
 		HostGenerator: func(t *testing.T, opts TransportTestCaseOpts) host.Host {
 			libp2pOpts := transformOpts(opts)

--- a/p2p/transport/tcp/metrics.go
+++ b/p2p/transport/tcp/metrics.go
@@ -24,7 +24,7 @@ var (
 
 const collectFrequency = 10 * time.Second
 
-var collector *aggregatingCollector
+var defaultCollector *aggregatingCollector
 
 var initMetricsOnce sync.Once
 
@@ -34,8 +34,8 @@ func initMetrics() {
 	bytesSentDesc = prometheus.NewDesc("tcp_sent_bytes", "TCP bytes sent", nil, nil)
 	bytesRcvdDesc = prometheus.NewDesc("tcp_rcvd_bytes", "TCP bytes received", nil, nil)
 
-	collector = newAggregatingCollector()
-	prometheus.MustRegister(collector)
+	defaultCollector = newAggregatingCollector()
+	prometheus.MustRegister(defaultCollector)
 
 	const direction = "direction"
 
@@ -196,13 +196,15 @@ func (c *aggregatingCollector) Collect(metrics chan<- prometheus.Metric) {
 
 func (c *aggregatingCollector) ClosedConn(conn *tracingConn, direction string) {
 	c.mutex.Lock()
-	collector.removeConn(conn.id)
+	c.removeConn(conn.id)
 	c.mutex.Unlock()
 	closedConns.WithLabelValues(direction).Inc()
 }
 
 type tracingConn struct {
 	id uint64
+
+	collector *aggregatingCollector
 
 	startTime time.Time
 	isClient  bool
@@ -213,7 +215,8 @@ type tracingConn struct {
 	closeErr  error
 }
 
-func newTracingConn(c manet.Conn, isClient bool) (*tracingConn, error) {
+// newTracingConn wraps a manet.Conn with a tracingConn. A nil collector will use the default collector.
+func newTracingConn(c manet.Conn, collector *aggregatingCollector, isClient bool) (*tracingConn, error) {
 	initMetricsOnce.Do(func() { initMetrics() })
 	conn, err := tcp.NewConn(c)
 	if err != nil {
@@ -224,8 +227,12 @@ func newTracingConn(c manet.Conn, isClient bool) (*tracingConn, error) {
 		isClient:  isClient,
 		Conn:      c,
 		tcpConn:   conn,
+		collector: collector,
 	}
-	tc.id = collector.AddConn(tc)
+	if tc.collector == nil {
+		tc.collector = defaultCollector
+	}
+	tc.id = tc.collector.AddConn(tc)
 	newConns.WithLabelValues(tc.getDirection()).Inc()
 	return tc, nil
 }
@@ -239,7 +246,7 @@ func (c *tracingConn) getDirection() string {
 
 func (c *tracingConn) Close() error {
 	c.closeOnce.Do(func() {
-		collector.ClosedConn(c, c.getDirection())
+		c.collector.ClosedConn(c, c.getDirection())
 		c.closeErr = c.Conn.Close()
 	})
 	return c.closeErr
@@ -258,10 +265,12 @@ func (c *tracingConn) getTCPInfo() (*tcpinfo.Info, error) {
 
 type tracingListener struct {
 	manet.Listener
+	collector *aggregatingCollector
 }
 
-func newTracingListener(l manet.Listener) *tracingListener {
-	return &tracingListener{Listener: l}
+// newTracingListener wraps a manet.Listener with a tracingListener. A nil collector will use the default collector.
+func newTracingListener(l manet.Listener, collector *aggregatingCollector) *tracingListener {
+	return &tracingListener{Listener: l, collector: collector}
 }
 
 func (l *tracingListener) Accept() (manet.Conn, error) {
@@ -269,5 +278,5 @@ func (l *tracingListener) Accept() (manet.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newTracingConn(conn, false)
+	return newTracingConn(conn, l.collector, false)
 }

--- a/p2p/transport/tcp/metrics_none.go
+++ b/p2p/transport/tcp/metrics_none.go
@@ -6,5 +6,9 @@ package tcp
 
 import manet "github.com/multiformats/go-multiaddr/net"
 
-func newTracingConn(c manet.Conn, _ bool) (manet.Conn, error) { return c, nil }
-func newTracingListener(l manet.Listener) manet.Listener      { return l }
+type aggregatingCollector struct{}
+
+func newTracingConn(c manet.Conn, collector *aggregatingCollector, isClient bool) (manet.Conn, error) {
+	return c, nil
+}
+func newTracingListener(l manet.Listener, collector *aggregatingCollector) manet.Listener { return l }

--- a/p2p/transport/tcp/metrics_none.go
+++ b/p2p/transport/tcp/metrics_none.go
@@ -6,9 +6,5 @@ package tcp
 
 import manet "github.com/multiformats/go-multiaddr/net"
 
-type aggregatingCollector struct{}
-
-func newTracingConn(c manet.Conn, collector *aggregatingCollector, isClient bool) (manet.Conn, error) {
-	return c, nil
-}
-func newTracingListener(l manet.Listener, collector *aggregatingCollector) manet.Listener { return l }
+func newTracingConn(c manet.Conn, _ bool) (manet.Conn, error) { return c, nil }
+func newTracingListener(l manet.Listener) manet.Listener      { return l }

--- a/p2p/transport/tcp/metrics_unix_test.go
+++ b/p2p/transport/tcp/metrics_unix_test.go
@@ -1,0 +1,33 @@
+// go:build: unix
+
+package tcp
+
+import (
+	"testing"
+
+	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse"
+	ttransport "github.com/libp2p/go-libp2p/p2p/transport/testsuite"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTcpTransportCollectsMetricsWithSharedTcpSocket(t *testing.T) {
+	peerA, ia := makeInsecureMuxer(t)
+	_, ib := makeInsecureMuxer(t)
+
+	sharedTCPSocketA := tcpreuse.NewConnMgr(false, nil, nil)
+	sharedTCPSocketB := tcpreuse.NewConnMgr(false, nil, nil)
+
+	ua, err := tptu.New(ia, muxers, nil, nil, nil)
+	require.NoError(t, err)
+	ta, err := NewTCPTransport(ua, nil, sharedTCPSocketA, WithMetrics())
+	require.NoError(t, err)
+	ub, err := tptu.New(ib, muxers, nil, nil, nil)
+	require.NoError(t, err)
+	tb, err := NewTCPTransport(ub, nil, sharedTCPSocketB, WithMetrics())
+	require.NoError(t, err)
+
+	zero := "/ip4/127.0.0.1/tcp/0"
+	ttransport.SubtestTransport(t, ta, tb, zero, peerA)
+}

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -142,8 +142,6 @@ type TcpTransport struct {
 	rcmgr network.ResourceManager
 
 	reuse reuseport.Transport
-
-	metricsCollector *aggregatingCollector
 }
 
 var _ transport.Transport = &TcpTransport{}
@@ -233,7 +231,7 @@ func (t *TcpTransport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p 
 	c := conn
 	if t.enableMetrics {
 		var err error
-		c, err = newTracingConn(conn, t.metricsCollector, true)
+		c, err = newTracingConn(conn, true)
 		if err != nil {
 			return nil, err
 		}
@@ -279,7 +277,7 @@ func (t *TcpTransport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
 	}
 
 	if t.enableMetrics {
-		list = newTracingListener(&tcpListener{list, 0}, t.metricsCollector)
+		list = newTracingListener(&tcpListener{list, 0})
 	}
 	return t.upgrader.UpgradeListener(t, list), nil
 }

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -148,7 +148,7 @@ var _ transport.Transport = &TcpTransport{}
 var _ transport.DialUpdater = &TcpTransport{}
 
 // NewTCPTransport creates a tcp transport object that tracks dialers and listeners
-// created. It represents an entire TCP stack (though it might not necessarily be).
+// created.
 func NewTCPTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*TcpTransport, error) {
 	if rcmgr == nil {
 		rcmgr = &network.NullResourceManager{}
@@ -269,7 +269,7 @@ func (t *TcpTransport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
 	if t.sharedTcp == nil {
 		list, err = t.unsharedMAListen(laddr)
 	} else {
-		list, err = t.sharedTcp.DemultiplexedListen(laddr, tcpreuse.MultistreamSelect)
+		list, err = t.sharedTcp.DemultiplexedListen(laddr, tcpreuse.DemultiplexedConnType_MultistreamSelect)
 	}
 	if err != nil {
 		return nil, err

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -117,13 +117,6 @@ func WithMetrics() Option {
 	}
 }
 
-func WithSharedTCP(mgr *tcpreuse.ConnMgr) Option {
-	return func(tr *TcpTransport) error {
-		tr.sharedTcp = mgr
-		return nil
-	}
-}
-
 // TcpTransport is the TCP transport.
 type TcpTransport struct {
 	// Connection upgrader for upgrading insecure stream connections to

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -149,7 +149,7 @@ var _ transport.DialUpdater = &TcpTransport{}
 
 // NewTCPTransport creates a tcp transport object that tracks dialers and listeners
 // created.
-func NewTCPTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*TcpTransport, error) {
+func NewTCPTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager, sharedTCP *tcpreuse.ConnMgr, opts ...Option) (*TcpTransport, error) {
 	if rcmgr == nil {
 		rcmgr = &network.NullResourceManager{}
 	}
@@ -157,6 +157,7 @@ func NewTCPTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager,
 		upgrader:       upgrader,
 		connectTimeout: defaultConnectTimeout, // can be set by using the WithConnectionTimeout option
 		rcmgr:          rcmgr,
+		sharedTcp:      sharedTCP,
 	}
 	for _, o := range opts {
 		if err := o(tr); err != nil {

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/net/reuseport"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse"
 
 	logging "github.com/ipfs/go-log/v2"
 	ma "github.com/multiformats/go-multiaddr"
@@ -32,6 +33,9 @@ type canKeepAlive interface {
 }
 
 var _ canKeepAlive = &net.TCPConn{}
+
+// Deprecated: Use tcpreuse.ReuseportIsAvailable
+var ReuseportIsAvailable = tcpreuse.ReuseportIsAvailable
 
 func tryKeepAlive(conn net.Conn, keepAlive bool) {
 	keepAliveConn, ok := conn.(canKeepAlive)
@@ -113,6 +117,13 @@ func WithMetrics() Option {
 	}
 }
 
+func WithSharedTCP(mgr *tcpreuse.ConnMgr) Option {
+	return func(tr *TcpTransport) error {
+		tr.sharedTcp = mgr
+		return nil
+	}
+}
+
 // TcpTransport is the TCP transport.
 type TcpTransport struct {
 	// Connection upgrader for upgrading insecure stream connections to
@@ -121,6 +132,9 @@ type TcpTransport struct {
 
 	disableReuseport bool // Explicitly disable reuseport.
 	enableMetrics    bool
+
+	// share and demultiplex TCP listeners across multiple transports
+	sharedTcp *tcpreuse.ConnMgr
 
 	// TCP connect timeout
 	connectTimeout time.Duration
@@ -166,6 +180,10 @@ func (t *TcpTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (manet.Co
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, t.connectTimeout)
 		defer cancel()
+	}
+
+	if t.sharedTcp != nil {
+		return t.sharedTcp.DialContext(ctx, raddr)
 	}
 
 	if t.UseReuseport() {
@@ -233,10 +251,10 @@ func (t *TcpTransport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p 
 
 // UseReuseport returns true if reuseport is enabled and available.
 func (t *TcpTransport) UseReuseport() bool {
-	return !t.disableReuseport && ReuseportIsAvailable()
+	return !t.disableReuseport && tcpreuse.ReuseportIsAvailable()
 }
 
-func (t *TcpTransport) maListen(laddr ma.Multiaddr) (manet.Listener, error) {
+func (t *TcpTransport) unsharedMAListen(laddr ma.Multiaddr) (manet.Listener, error) {
 	if t.UseReuseport() {
 		return t.reuse.Listen(laddr)
 	}
@@ -245,10 +263,18 @@ func (t *TcpTransport) maListen(laddr ma.Multiaddr) (manet.Listener, error) {
 
 // Listen listens on the given multiaddr.
 func (t *TcpTransport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
-	list, err := t.maListen(laddr)
+	var list manet.Listener
+	var err error
+
+	if t.sharedTcp == nil {
+		list, err = t.unsharedMAListen(laddr)
+	} else {
+		list, err = t.sharedTcp.DemultiplexedListen(laddr, tcpreuse.MultistreamSelect)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	if t.enableMetrics {
 		list = newTracingListener(&tcpListener{list, 0})
 	}

--- a/p2p/transport/tcp/tcp.go
+++ b/p2p/transport/tcp/tcp.go
@@ -142,6 +142,8 @@ type TcpTransport struct {
 	rcmgr network.ResourceManager
 
 	reuse reuseport.Transport
+
+	metricsCollector *aggregatingCollector
 }
 
 var _ transport.Transport = &TcpTransport{}
@@ -231,7 +233,7 @@ func (t *TcpTransport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p 
 	c := conn
 	if t.enableMetrics {
 		var err error
-		c, err = newTracingConn(conn, true)
+		c, err = newTracingConn(conn, t.metricsCollector, true)
 		if err != nil {
 			return nil, err
 		}
@@ -277,7 +279,7 @@ func (t *TcpTransport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
 	}
 
 	if t.enableMetrics {
-		list = newTracingListener(&tcpListener{list, 0})
+		list = newTracingListener(&tcpListener{list, 0}, t.metricsCollector)
 	}
 	return t.upgrader.UpgradeListener(t, list), nil
 }

--- a/p2p/transport/tcp/tcp_test.go
+++ b/p2p/transport/tcp/tcp_test.go
@@ -32,11 +32,11 @@ func TestTcpTransport(t *testing.T) {
 
 		ua, err := tptu.New(ia, muxers, nil, nil, nil)
 		require.NoError(t, err)
-		ta, err := NewTCPTransport(ua, nil)
+		ta, err := NewTCPTransport(ua, nil, nil)
 		require.NoError(t, err)
 		ub, err := tptu.New(ib, muxers, nil, nil, nil)
 		require.NoError(t, err)
-		tb, err := NewTCPTransport(ub, nil)
+		tb, err := NewTCPTransport(ub, nil, nil)
 		require.NoError(t, err)
 
 		zero := "/ip4/127.0.0.1/tcp/0"
@@ -53,11 +53,11 @@ func TestTcpTransportWithMetrics(t *testing.T) {
 
 	ua, err := tptu.New(ia, muxers, nil, nil, nil)
 	require.NoError(t, err)
-	ta, err := NewTCPTransport(ua, nil, WithMetrics())
+	ta, err := NewTCPTransport(ua, nil, nil, WithMetrics())
 	require.NoError(t, err)
 	ub, err := tptu.New(ib, muxers, nil, nil, nil)
 	require.NoError(t, err)
-	tb, err := NewTCPTransport(ub, nil, WithMetrics())
+	tb, err := NewTCPTransport(ub, nil, nil, WithMetrics())
 	require.NoError(t, err)
 
 	zero := "/ip4/127.0.0.1/tcp/0"
@@ -73,7 +73,7 @@ func TestResourceManager(t *testing.T) {
 
 	ua, err := tptu.New(ia, muxers, nil, nil, nil)
 	require.NoError(t, err)
-	ta, err := NewTCPTransport(ua, nil)
+	ta, err := NewTCPTransport(ua, nil, nil)
 	require.NoError(t, err)
 	ln, err := ta.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestResourceManager(t *testing.T) {
 	ub, err := tptu.New(ib, muxers, nil, nil, nil)
 	require.NoError(t, err)
 	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
-	tb, err := NewTCPTransport(ub, rcmgr)
+	tb, err := NewTCPTransport(ub, rcmgr, nil)
 	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestTcpTransportCantDialDNS(t *testing.T) {
 		require.NoError(t, err)
 
 		var u transport.Upgrader
-		tpt, err := NewTCPTransport(u, nil)
+		tpt, err := NewTCPTransport(u, nil, nil)
 		require.NoError(t, err)
 
 		if tpt.CanDial(dnsa) {
@@ -138,7 +138,7 @@ func TestTcpTransportCantListenUtp(t *testing.T) {
 		require.NoError(t, err)
 
 		var u transport.Upgrader
-		tpt, err := NewTCPTransport(u, nil)
+		tpt, err := NewTCPTransport(u, nil, nil)
 		require.NoError(t, err)
 
 		_, err = tpt.Listen(utpa)
@@ -155,7 +155,7 @@ func TestDialWithUpdates(t *testing.T) {
 
 	ua, err := tptu.New(ia, muxers, nil, nil, nil)
 	require.NoError(t, err)
-	ta, err := NewTCPTransport(ua, nil)
+	ta, err := NewTCPTransport(ua, nil, nil)
 	require.NoError(t, err)
 	ln, err := ta.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestDialWithUpdates(t *testing.T) {
 
 	ub, err := tptu.New(ib, muxers, nil, nil, nil)
 	require.NoError(t, err)
-	tb, err := NewTCPTransport(ub, nil)
+	tb, err := NewTCPTransport(ub, nil, nil)
 	require.NoError(t, err)
 
 	updCh := make(chan transport.DialUpdate, 1)

--- a/p2p/transport/tcp/tcp_test.go
+++ b/p2p/transport/tcp/tcp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse"
 	ttransport "github.com/libp2p/go-libp2p/p2p/transport/testsuite"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -41,9 +42,9 @@ func TestTcpTransport(t *testing.T) {
 		zero := "/ip4/127.0.0.1/tcp/0"
 		ttransport.SubtestTransport(t, ta, tb, zero, peerA)
 
-		envReuseportVal = false
+		tcpreuse.EnvReuseportVal = false
 	}
-	envReuseportVal = true
+	tcpreuse.EnvReuseportVal = true
 }
 
 func TestTcpTransportWithMetrics(t *testing.T) {
@@ -126,9 +127,9 @@ func TestTcpTransportCantDialDNS(t *testing.T) {
 			t.Fatal("shouldn't be able to dial dns")
 		}
 
-		envReuseportVal = false
+		tcpreuse.EnvReuseportVal = false
 	}
-	envReuseportVal = true
+	tcpreuse.EnvReuseportVal = true
 }
 
 func TestTcpTransportCantListenUtp(t *testing.T) {
@@ -143,9 +144,9 @@ func TestTcpTransportCantListenUtp(t *testing.T) {
 		_, err = tpt.Listen(utpa)
 		require.Error(t, err, "shouldn't be able to listen on utp addr with tcp transport")
 
-		envReuseportVal = false
+		tcpreuse.EnvReuseportVal = false
 	}
-	envReuseportVal = true
+	tcpreuse.EnvReuseportVal = true
 }
 
 func TestDialWithUpdates(t *testing.T) {

--- a/p2p/transport/tcpreuse/connwithscope.go
+++ b/p2p/transport/tcpreuse/connwithscope.go
@@ -1,0 +1,26 @@
+package tcpreuse
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse/internal/sampledconn"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+type connWithScope struct {
+	sampledconn.ManetTCPConnInterface
+	scope network.ConnManagementScope
+}
+
+func (c connWithScope) Scope() network.ConnManagementScope {
+	return c.scope
+}
+
+func manetConnWithScope(c manet.Conn, scope network.ConnManagementScope) (manet.Conn, error) {
+	if tcpconn, ok := c.(sampledconn.ManetTCPConnInterface); ok {
+		return &connWithScope{tcpconn, scope}, nil
+	}
+
+	return nil, fmt.Errorf("manet.Conn is not a TCP Conn")
+}

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -1,7 +1,6 @@
 package tcpreuse
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"time"
@@ -9,16 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse/internal/sampledconn"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
-
-type peekAble interface {
-	// Peek returns the next n bytes without advancing the reader. The bytes stop
-	// being valid at the next read call. If Peek returns fewer than n bytes, it
-	// also returns an error explaining why the read is short. The error is
-	// [ErrBufferFull] if n is larger than b's buffer size.
-	Peek(n int) ([]byte, error)
-}
-
-var _ peekAble = (*bufio.Reader)(nil)
 
 // TODO: We can unexport this type and rely completely on the multiaddr passed in to
 // DemultiplexedListen.

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -1,0 +1,240 @@
+package tcpreuse
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"time"
+
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+type peekAble interface {
+	// Peek returns the next n bytes without advancing the reader. The bytes stop
+	// being valid at the next read call. If Peek returns fewer than n bytes, it
+	// also returns an error explaining why the read is short. The error is
+	// [ErrBufferFull] if n is larger than b's buffer size.
+	Peek(n int) ([]byte, error)
+}
+
+var _ peekAble = (*bufio.Reader)(nil)
+
+type DemultiplexedConnType int
+
+const (
+	Unknown DemultiplexedConnType = iota
+	MultistreamSelect
+	HTTP
+	TLS
+)
+
+func (t DemultiplexedConnType) String() string {
+	switch t {
+	case MultistreamSelect:
+		return "MultistreamSelect"
+	case HTTP:
+		return "HTTP"
+	case TLS:
+		return "TLS"
+	default:
+		return fmt.Sprintf("Unknown(%d)", int(t))
+	}
+}
+
+func (t DemultiplexedConnType) IsKnown() bool {
+	return t >= 1 || t <= 3
+}
+
+func ConnTypeFromConn(c net.Conn) (DemultiplexedConnType, manet.Conn, error) {
+	if err := c.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+		closeErr := c.Close()
+		return 0, nil, errors.Join(err, closeErr)
+	}
+
+	s, sc, err := ReadSampleFromConn(c)
+	if err != nil {
+		closeErr := c.Close()
+		return 0, nil, errors.Join(err, closeErr)
+	}
+
+	if err := c.SetReadDeadline(time.Time{}); err != nil {
+		closeErr := c.Close()
+		return 0, nil, errors.Join(err, closeErr)
+	}
+
+	if IsMultistreamSelect(s) {
+		return MultistreamSelect, sc, nil
+	}
+	if IsTLS(s) {
+		return TLS, sc, nil
+	}
+	if IsHTTP(s) {
+		return HTTP, sc, nil
+	}
+	return Unknown, sc, nil
+}
+
+// ReadSampleFromConn read the sample and returns a reader which still include the sample, so it can be kept undamaged.
+// If an error occurs it only return the error.
+func ReadSampleFromConn(c net.Conn) (Sample, manet.Conn, error) {
+	if peekAble, ok := c.(peekAble); ok {
+		b, err := peekAble.Peek(len(Sample{}))
+		switch {
+		case err == nil:
+			mac, err := manet.WrapNetConn(c)
+			if err != nil {
+				return Sample{}, nil, err
+			}
+
+			return Sample(b), mac, nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			// fallback to sampledConn
+		default:
+			return Sample{}, nil, err
+		}
+	}
+
+	tcpConnLike, ok := c.(tcpConnInterface)
+	if !ok {
+		return Sample{}, nil, fmt.Errorf("expected tcp-like connection")
+	}
+
+	laddr, err := manet.FromNetAddr(c.LocalAddr())
+	if err != nil {
+		return Sample{}, nil, fmt.Errorf("failed to convert nconn.LocalAddr: %s", err)
+	}
+
+	raddr, err := manet.FromNetAddr(c.RemoteAddr())
+	if err != nil {
+		return Sample{}, nil, fmt.Errorf("failed to convert nconn.RemoteAddr: %s", err)
+	}
+
+	sc := &sampledConn{tcpConnInterface: tcpConnLike, maEndpoints: maEndpoints{laddr: laddr, raddr: raddr}}
+	_, err = io.ReadFull(c, sc.s[:])
+	if err != nil {
+		return Sample{}, nil, err
+	}
+
+	return sc.s, sc, nil
+}
+
+// Try out best to mimic a TCPConn's functions
+// Note: Skipping `SyscallConn() (syscall.RawConn, error)` since it can be misused given we've read a few bytes from the connection
+// If this is an issue here we can revisit the options.
+type tcpConnInterface interface {
+	net.Conn
+
+	CloseRead() error
+	CloseWrite() error
+
+	SetLinger(sec int) error
+	SetKeepAlive(keepalive bool) error
+	SetKeepAlivePeriod(d time.Duration) error
+	SetNoDelay(noDelay bool) error
+	MultipathTCP() (bool, error)
+
+	io.ReaderFrom
+	io.WriterTo
+}
+
+type maEndpoints struct {
+	laddr ma.Multiaddr
+	raddr ma.Multiaddr
+}
+
+// LocalMultiaddr returns the local address associated with
+// this connection
+func (c *maEndpoints) LocalMultiaddr() ma.Multiaddr {
+	return c.laddr
+}
+
+// RemoteMultiaddr returns the remote address associated with
+// this connection
+func (c *maEndpoints) RemoteMultiaddr() ma.Multiaddr {
+	return c.raddr
+}
+
+type sampledConn struct {
+	tcpConnInterface
+	maEndpoints
+
+	s              Sample
+	readFromSample uint8
+}
+
+var _ = [math.MaxUint8]struct{}{}[len(Sample{})] // compiletime assert sampledConn.readFromSample wont overflow
+var _ io.ReaderFrom = (*sampledConn)(nil)
+var _ io.WriterTo = (*sampledConn)(nil)
+
+func (sc *sampledConn) Read(b []byte) (int, error) {
+	if int(sc.readFromSample) != len(sc.s) {
+		red := copy(b, sc.s[sc.readFromSample:])
+		sc.readFromSample += uint8(red)
+		return red, nil
+	}
+
+	return sc.tcpConnInterface.Read(b)
+}
+
+// forward optimizations
+func (sc *sampledConn) ReadFrom(r io.Reader) (int64, error) {
+	return io.Copy(sc.tcpConnInterface, r)
+}
+
+// forward optimizations
+func (sc *sampledConn) WriteTo(w io.Writer) (total int64, err error) {
+	if int(sc.readFromSample) != len(sc.s) {
+		b := sc.s[sc.readFromSample:]
+		written, err := w.Write(b)
+		if written < 0 || len(b) < written {
+			// buggy writer, harden against this
+			sc.readFromSample = uint8(len(sc.s))
+			total = int64(len(sc.s))
+		} else {
+			sc.readFromSample += uint8(written)
+			total += int64(written)
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+
+	written, err := io.Copy(w, sc.tcpConnInterface)
+	total += written
+	return total, err
+}
+
+type Matcher interface {
+	Match(s Sample) bool
+}
+
+// Sample might evolve over time.
+type Sample [3]byte
+
+// Matchers are implemented here instead of in the transports so we can easily fuzz them together.
+
+func IsMultistreamSelect(s Sample) bool {
+	return string(s[:]) == "\x13/m"
+}
+
+func IsHTTP(s Sample) bool {
+	switch string(s[:]) {
+	case "GET", "HEA", "POS", "PUT", "DEL", "CON", "OPT", "TRA", "PAT":
+		return true
+	default:
+		return false
+	}
+}
+
+func IsTLS(s Sample) bool {
+	switch string(s[:]) {
+	case "\x16\x03\x01", "\x16\x03\x02", "\x16\x03\x03", "\x16\x03\x04":
+		return true
+	default:
+		return false
+	}
+}

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -4,13 +4,9 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io"
-	"math"
-	"net"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/network"
-	ma "github.com/multiformats/go-multiaddr"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse/internal/sampledconn"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
@@ -52,13 +48,17 @@ func (t DemultiplexedConnType) IsKnown() bool {
 	return t >= 1 || t <= 3
 }
 
-func getDemultiplexedConn(c net.Conn, scope network.ConnManagementScope) (DemultiplexedConnType, manet.Conn, error) {
+// identifyConnType attempts to identify the connection type by peeking at the
+// first few bytes.
+// It Callers must not use the passed in Conn after this
+// function returns. if an error is returned, the connection will be closed.
+func identifyConnType(c manet.Conn) (DemultiplexedConnType, manet.Conn, error) {
 	if err := c.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
 		closeErr := c.Close()
 		return 0, nil, errors.Join(err, closeErr)
 	}
 
-	s, sc, err := readSampleFromConn(c, scope)
+	s, c, err := sampledconn.PeekBytes(c)
 	if err != nil {
 		closeErr := c.Close()
 		return 0, nil, errors.Join(err, closeErr)
@@ -70,174 +70,25 @@ func getDemultiplexedConn(c net.Conn, scope network.ConnManagementScope) (Demult
 	}
 
 	if IsMultistreamSelect(s) {
-		return DemultiplexedConnType_MultistreamSelect, sc, nil
+		return DemultiplexedConnType_MultistreamSelect, c, nil
 	}
 	if IsTLS(s) {
-		return DemultiplexedConnType_TLS, sc, nil
+		return DemultiplexedConnType_TLS, c, nil
 	}
 	if IsHTTP(s) {
-		return DemultiplexedConnType_HTTP, sc, nil
+		return DemultiplexedConnType_HTTP, c, nil
 	}
-	return DemultiplexedConnType_Unknown, sc, nil
+	return DemultiplexedConnType_Unknown, c, nil
 }
-
-// readSampleFromConn reads a sample and returns a reader which still includes the sample, so it can be kept undamaged.
-// If an error occurs it only returns the error.
-func readSampleFromConn(c net.Conn, scope network.ConnManagementScope) (Sample, manet.Conn, error) {
-	// TODO: Should we remove this? This is only implemented by bufio.Reader.
-	// This made sense for magiselect: https://github.com/libp2p/go-libp2p/pull/2737 as it deals with a wrapped
-	// ReadWriteCloser from multistream which does use a buffered reader underneath.
-	// For our present purpose, we have a net.Conn and no net.Conn implementation offers peeking.
-	if peekAble, ok := c.(peekAble); ok {
-		b, err := peekAble.Peek(len(Sample{}))
-		switch {
-		case err == nil:
-			mac, err := manet.WrapNetConn(c)
-			if err != nil {
-				return Sample{}, nil, err
-			}
-
-			return Sample(b), mac, nil
-		case errors.Is(err, bufio.ErrBufferFull):
-			// We can only peek < len(Sample{}) data.
-			// fallback to sampledConn
-		default:
-			return Sample{}, nil, err
-		}
-	}
-
-	tcpConnLike, ok := c.(tcpConnInterface)
-	if !ok {
-		return Sample{}, nil, fmt.Errorf("expected tcp-like connection")
-	}
-
-	laddr, err := manet.FromNetAddr(c.LocalAddr())
-	if err != nil {
-		return Sample{}, nil, fmt.Errorf("failed to convert nconn.LocalAddr: %s", err)
-	}
-
-	raddr, err := manet.FromNetAddr(c.RemoteAddr())
-	if err != nil {
-		return Sample{}, nil, fmt.Errorf("failed to convert nconn.RemoteAddr: %s", err)
-	}
-
-	sc := &sampledConn{
-		tcpConnInterface: tcpConnLike,
-		maEndpoints:      maEndpoints{laddr: laddr, raddr: raddr},
-		scope:            scope,
-	}
-	_, err = io.ReadFull(c, sc.s[:])
-	if err != nil {
-		return Sample{}, nil, err
-	}
-	return sc.s, sc, nil
-}
-
-// tcpConnInterface is the interface for TCPConn's functions
-// Note: Skipping `SyscallConn() (syscall.RawConn, error)` since it can be misused given we've read a few bytes from the connection.
-// TODO: allow SyscallConn? Disallowing it breaks metrics tracking in TCP Transport.
-type tcpConnInterface interface {
-	net.Conn
-
-	CloseRead() error
-	CloseWrite() error
-
-	SetLinger(sec int) error
-	SetKeepAlive(keepalive bool) error
-	SetKeepAlivePeriod(d time.Duration) error
-	SetNoDelay(noDelay bool) error
-	MultipathTCP() (bool, error)
-
-	io.ReaderFrom
-	io.WriterTo
-}
-
-type maEndpoints struct {
-	laddr ma.Multiaddr
-	raddr ma.Multiaddr
-}
-
-// LocalMultiaddr returns the local address associated with
-// this connection
-func (c *maEndpoints) LocalMultiaddr() ma.Multiaddr {
-	return c.laddr
-}
-
-// RemoteMultiaddr returns the remote address associated with
-// this connection
-func (c *maEndpoints) RemoteMultiaddr() ma.Multiaddr {
-	return c.raddr
-}
-
-type sampledConn struct {
-	tcpConnInterface
-	maEndpoints
-	scope          network.ConnManagementScope
-	s              Sample
-	readFromSample uint8
-}
-
-var _ = [math.MaxUint8]struct{}{}[len(Sample{})] // compiletime assert sampledConn.readFromSample wont overflow
-var _ io.ReaderFrom = (*sampledConn)(nil)
-var _ io.WriterTo = (*sampledConn)(nil)
-
-func (sc *sampledConn) Read(b []byte) (int, error) {
-	if int(sc.readFromSample) != len(sc.s) {
-		red := copy(b, sc.s[sc.readFromSample:])
-		sc.readFromSample += uint8(red)
-		return red, nil
-	}
-
-	return sc.tcpConnInterface.Read(b)
-}
-
-// TODO: Do we need these?
-
-func (sc *sampledConn) ReadFrom(r io.Reader) (int64, error) {
-	return io.Copy(sc.tcpConnInterface, r)
-}
-
-func (sc *sampledConn) WriteTo(w io.Writer) (total int64, err error) {
-	if int(sc.readFromSample) != len(sc.s) {
-		b := sc.s[sc.readFromSample:]
-		written, err := w.Write(b)
-		if written < 0 || len(b) < written {
-			// buggy writer, harden against this
-			sc.readFromSample = uint8(len(sc.s))
-			total = int64(len(sc.s))
-		} else {
-			sc.readFromSample += uint8(written)
-			total += int64(written)
-		}
-		if err != nil {
-			return total, err
-		}
-	}
-
-	written, err := io.Copy(w, sc.tcpConnInterface)
-	total += written
-	return total, err
-}
-
-func (sc *sampledConn) Scope() network.ConnManagementScope {
-	return sc.scope
-}
-
-func (sc *sampledConn) Close() error {
-	sc.scope.Done()
-	return sc.tcpConnInterface.Close()
-}
-
-// Sample is the byte sequence we use to demultiplex.
-type Sample [3]byte
 
 // Matchers are implemented here instead of in the transports so we can easily fuzz them together.
+type Prefix = [3]byte
 
-func IsMultistreamSelect(s Sample) bool {
+func IsMultistreamSelect(s Prefix) bool {
 	return string(s[:]) == "\x13/m"
 }
 
-func IsHTTP(s Sample) bool {
+func IsHTTP(s Prefix) bool {
 	switch string(s[:]) {
 	case "GET", "HEA", "POS", "PUT", "DEL", "CON", "OPT", "TRA", "PAT":
 		return true
@@ -246,7 +97,7 @@ func IsHTTP(s Sample) bool {
 	}
 }
 
-func IsTLS(s Sample) bool {
+func IsTLS(s Prefix) bool {
 	switch string(s[:]) {
 	case "\x16\x03\x01", "\x16\x03\x02", "\x16\x03\x03", "\x16\x03\x04":
 		return true

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -9,6 +9,9 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
+// This is readiung the first 3 bytes of the packet. It should be instant.
+const identifyConnTimeout = 1 * time.Second
+
 type DemultiplexedConnType int
 
 const (
@@ -40,7 +43,7 @@ func (t DemultiplexedConnType) IsKnown() bool {
 // It Callers must not use the passed in Conn after this
 // function returns. if an error is returned, the connection will be closed.
 func identifyConnType(c manet.Conn) (DemultiplexedConnType, manet.Conn, error) {
-	if err := c.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+	if err := c.SetReadDeadline(time.Now().Add(identifyConnTimeout)); err != nil {
 		closeErr := c.Close()
 		return 0, nil, errors.Join(err, closeErr)
 	}

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -9,8 +9,6 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-// TODO: We can unexport this type and rely completely on the multiaddr passed in to
-// DemultiplexedListen.
 type DemultiplexedConnType int
 
 const (

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -89,7 +89,7 @@ func IsHTTP(s Prefix) bool {
 
 func IsTLS(s Prefix) bool {
 	switch string(s[:]) {
-	case "\x16\x03\x01", "\x16\x03\x02", "\x16\x03\x03", "\x16\x03\x04":
+	case "\x16\x03\x01", "\x16\x03\x02", "\x16\x03\x03":
 		return true
 	default:
 		return false

--- a/p2p/transport/tcpreuse/demultiplex_test.go
+++ b/p2p/transport/tcpreuse/demultiplex_test.go
@@ -25,7 +25,7 @@ func FuzzClash(f *testing.F) {
 	add('\x16', '\x03', '\x04')
 
 	f.Fuzz(func(t *testing.T, a, b, c byte) {
-		s := Sample{a, b, c}
+		s := Prefix{a, b, c}
 		var total uint
 
 		ms := IsMultistreamSelect(s)

--- a/p2p/transport/tcpreuse/demultiplex_test.go
+++ b/p2p/transport/tcpreuse/demultiplex_test.go
@@ -1,0 +1,50 @@
+package tcpreuse
+
+import "testing"
+
+func FuzzClash(f *testing.F) {
+	// make untyped literals type correctly
+	add := func(a, b, c byte) { f.Add(a, b, c) }
+
+	// multistream-select
+	add('\x13', '/', 'm')
+	// http
+	add('G', 'E', 'T')
+	add('H', 'E', 'A')
+	add('P', 'O', 'S')
+	add('P', 'U', 'T')
+	add('D', 'E', 'L')
+	add('C', 'O', 'N')
+	add('O', 'P', 'T')
+	add('T', 'R', 'A')
+	add('P', 'A', 'T')
+	// tls
+	add('\x16', '\x03', '\x01')
+	add('\x16', '\x03', '\x02')
+	add('\x16', '\x03', '\x03')
+	add('\x16', '\x03', '\x04')
+
+	f.Fuzz(func(t *testing.T, a, b, c byte) {
+		s := Sample{a, b, c}
+		var total uint
+
+		ms := IsMultistreamSelect(s)
+		if ms {
+			total++
+		}
+
+		http := IsHTTP(s)
+		if http {
+			total++
+		}
+
+		tls := IsTLS(s)
+		if tls {
+			total++
+		}
+
+		if total > 1 {
+			t.Errorf("clash on: %q; ms: %v; http: %v; tls: %v", s, ms, http, tls)
+		}
+	})
+}

--- a/p2p/transport/tcpreuse/dialer.go
+++ b/p2p/transport/tcpreuse/dialer.go
@@ -1,0 +1,16 @@
+package tcpreuse
+
+import (
+	"context"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+// DialContext is like Dial but takes a context.
+func (t *ConnMgr) DialContext(ctx context.Context, raddr ma.Multiaddr) (manet.Conn, error) {
+	if t.useReuseport() {
+		return t.reuse.DialContext(ctx, raddr)
+	}
+	var d manet.Dialer
+	return d.DialContext(ctx, raddr)
+}

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_common.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_common.go
@@ -1,0 +1,53 @@
+package sampledconn
+
+import (
+	"io"
+	"net"
+	"time"
+)
+
+const sampleSize = 3
+
+type fallbackSampledConn struct {
+	tcpConnInterface
+	Sample         [sampleSize]byte
+	readFromSample uint8
+}
+
+// tcpConnInterface is the interface for TCPConn's functions
+// NOTE: Skipping `SyscallConn() (syscall.RawConn, error)` since it can be
+// misused given we've read a few bytes from the connection.
+type tcpConnInterface interface {
+	net.Conn
+
+	CloseRead() error
+	CloseWrite() error
+
+	SetLinger(sec int) error
+	SetKeepAlive(keepalive bool) error
+	SetKeepAlivePeriod(d time.Duration) error
+	SetNoDelay(noDelay bool) error
+	MultipathTCP() (bool, error)
+
+	io.ReaderFrom
+	io.WriterTo
+}
+
+func newFallbackSampledConn(conn tcpConnInterface) (*fallbackSampledConn, error) {
+	s := &fallbackSampledConn{tcpConnInterface: conn}
+	_, err := io.ReadFull(conn, s.Sample[:])
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (sc *fallbackSampledConn) Read(b []byte) (int, error) {
+	if int(sc.readFromSample) != len(sc.Sample) {
+		red := copy(b, sc.Sample[sc.readFromSample:])
+		sc.readFromSample += uint8(red)
+		return red, nil
+	}
+
+	return sc.tcpConnInterface.Read(b)
+}

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_other.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_other.go
@@ -1,4 +1,4 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package sampledconn
 

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_other.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package sampledconn
+
+type SampledConn = *fallbackSampledConn
+
+func NewSampledConn(conn tcpConnInterface) (SampledConn, error) {
+	return newFallbackSampledConn(conn)
+}

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_other.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_other.go
@@ -2,8 +2,10 @@
 
 package sampledconn
 
-type SampledConn = *fallbackSampledConn
+import (
+	"syscall"
+)
 
-func NewSampledConn(conn tcpConnInterface) (SampledConn, error) {
-	return newFallbackSampledConn(conn)
+func OSPeekConn(conn syscall.Conn) (PeekedBytes, error) {
+	return PeekedBytes{}, errNotSupported
 }

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_test.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_test.go
@@ -1,0 +1,70 @@
+package sampledconn
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSampledConn(t *testing.T) {
+	testCases := []string{
+		"platform",
+		// "fallback",
+	}
+
+	// Start a TCP server
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	serverAddr := listener.Addr().String()
+
+	// Server goroutine
+	go func() {
+		conn, err := listener.Accept()
+		assert.NoError(t, err)
+		defer conn.Close()
+
+		// Write some data to the connection
+		_, err = conn.Write([]byte("hello"))
+		assert.NoError(t, err)
+	}()
+
+	// Give the server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			// Create a TCP client
+			clientConn, err := net.Dial("tcp", serverAddr)
+			assert.NoError(t, err)
+			defer clientConn.Close()
+
+			if tc == "platform" {
+				// Wrap the client connection in SampledConn
+				sampledConn, err := NewSampledConn(clientConn.(*net.TCPConn))
+				assert.NoError(t, err)
+				assert.Equal(t, "hel", string(sampledConn.Sample[:]))
+
+				buf := make([]byte, 5)
+				_, err = sampledConn.Read(buf)
+				assert.NoError(t, err)
+				assert.Equal(t, "hello", string(buf))
+			} else {
+				// Wrap the client connection in SampledConn
+				sampledConn, err := newFallbackSampledConn(clientConn.(tcpConnInterface))
+				assert.NoError(t, err)
+				assert.Equal(t, "hel", string(sampledConn.Sample[:]))
+
+				buf := make([]byte, 5)
+				_, err = io.ReadFull(sampledConn, buf)
+				assert.NoError(t, err)
+				assert.Equal(t, "hello", string(buf))
+
+			}
+		})
+	}
+}

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_test.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_test.go
@@ -15,7 +15,7 @@ import (
 func TestSampledConn(t *testing.T) {
 	testCases := []string{
 		"platform",
-		// "fallback",
+		"fallback",
 	}
 
 	// Start a TCP server
@@ -27,13 +27,15 @@ func TestSampledConn(t *testing.T) {
 
 	// Server goroutine
 	go func() {
-		conn, err := listener.Accept()
-		assert.NoError(t, err)
-		defer conn.Close()
+		for i := 0; i < len(testCases); i++ {
+			conn, err := listener.Accept()
+			assert.NoError(t, err)
+			defer conn.Close()
 
-		// Write some data to the connection
-		_, err = conn.Write([]byte("hello"))
-		assert.NoError(t, err)
+			// Write some data to the connection
+			_, err = conn.Write([]byte("hello"))
+			assert.NoError(t, err)
+		}
 	}()
 
 	// Give the server a moment to start

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_test.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_test.go
@@ -45,19 +45,19 @@ func TestSampledConn(t *testing.T) {
 
 			if tc == "platform" {
 				// Wrap the client connection in SampledConn
-				sampledConn, err := NewSampledConn(clientConn.(*net.TCPConn))
+				peeked, clientConn, err := PeekBytes(clientConn.(*net.TCPConn))
 				assert.NoError(t, err)
-				assert.Equal(t, "hel", string(sampledConn.Sample[:]))
+				assert.Equal(t, "hel", string(peeked[:]))
 
 				buf := make([]byte, 5)
-				_, err = sampledConn.Read(buf)
+				_, err = clientConn.Read(buf)
 				assert.NoError(t, err)
 				assert.Equal(t, "hello", string(buf))
 			} else {
 				// Wrap the client connection in SampledConn
-				sampledConn, err := newFallbackSampledConn(clientConn.(tcpConnInterface))
+				sample, sampledConn, err := newFallbackSampledConn(clientConn.(tcpConnInterface))
 				assert.NoError(t, err)
-				assert.Equal(t, "hel", string(sampledConn.Sample[:]))
+				assert.Equal(t, "hel", string(sample[:]))
 
 				buf := make([]byte, 5)
 				_, err = io.ReadFull(sampledConn, buf)

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_unix.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_unix.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package sampledconn
+
+import (
+	"errors"
+	"net"
+	"syscall"
+)
+
+type SampledConn struct {
+	*net.TCPConn
+	Sample [sampleSize]byte
+}
+
+func NewSampledConn(conn *net.TCPConn) (SampledConn, error) {
+	s := SampledConn{
+		TCPConn: conn,
+	}
+
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return s, err
+	}
+
+	readBytes := 0
+	var readErr error
+	err = rawConn.Read(func(fd uintptr) bool {
+		for readBytes < sampleSize {
+			var n int
+			n, _, readErr = syscall.Recvfrom(int(fd), s.Sample[readBytes:], syscall.MSG_PEEK)
+			if errors.Is(readErr, syscall.EAGAIN) {
+				return false
+			}
+			if readErr != nil {
+				return true
+			}
+			readBytes += n
+		}
+		return true
+	})
+	if readErr != nil {
+		return s, readErr
+	}
+	if err != nil {
+		return s, err
+	}
+
+	return s, nil
+}

--- a/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_windows.go
+++ b/p2p/transport/tcpreuse/internal/sampledconn/sampledconn_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package sampledconn
+
+import (
+	"errors"
+	"golang.org/x/sys/windows"
+	"syscall"
+)
+
+func OSPeekConn(conn syscall.Conn) (PeekedBytes, error) {
+	s := PeekedBytes{}
+
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return s, err
+	}
+
+	readBytes := 0
+	var readErr error
+	err = rawConn.Read(func(fd uintptr) bool {
+		for readBytes < peekSize {
+			var n uint32
+			flags := uint32(windows.MSG_PEEK)
+			wsabuf := windows.WSABuf{
+				Len: uint32(len(s) - readBytes),
+				Buf: &s[readBytes],
+			}
+
+			readErr = windows.WSARecv(windows.Handle(fd), &wsabuf, 1, &n, &flags, nil, nil)
+			if errors.Is(readErr, windows.WSAEWOULDBLOCK) {
+				return false
+			}
+			if readErr != nil {
+				return true
+			}
+			readBytes += int(n)
+		}
+		return true
+	})
+	if readErr != nil {
+		return s, readErr
+	}
+	if err != nil {
+		return s, err
+	}
+
+	return s, nil
+}

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -22,25 +22,25 @@ var log = logging.Logger("tcp-demultiplex")
 
 // ConnMgr enables you to share the same listen address between TCP and WebSocket transports.
 type ConnMgr struct {
-	disableReuseport bool
-	reuse            reuseport.Transport
-	connGater        connmgr.ConnectionGater
-	rcmgr            network.ResourceManager
+	enableReuseport bool
+	reuse           reuseport.Transport
+	connGater       connmgr.ConnectionGater
+	rcmgr           network.ResourceManager
 
 	mx        sync.Mutex
 	listeners map[string]*multiplexedListener
 }
 
-func NewConnMgr(disableReuseport bool, gater connmgr.ConnectionGater, rcmgr network.ResourceManager) *ConnMgr {
+func NewConnMgr(enableReuseport bool, gater connmgr.ConnectionGater, rcmgr network.ResourceManager) *ConnMgr {
 	if rcmgr == nil {
 		rcmgr = &network.NullResourceManager{}
 	}
 	return &ConnMgr{
-		disableReuseport: disableReuseport,
-		reuse:            reuseport.Transport{},
-		connGater:        gater,
-		rcmgr:            rcmgr,
-		listeners:        make(map[string]*multiplexedListener),
+		enableReuseport: enableReuseport,
+		reuse:           reuseport.Transport{},
+		connGater:       gater,
+		rcmgr:           rcmgr,
+		listeners:       make(map[string]*multiplexedListener),
 	}
 }
 
@@ -53,7 +53,7 @@ func (t *ConnMgr) maListen(listenAddr ma.Multiaddr) (manet.Listener, error) {
 }
 
 func (t *ConnMgr) useReuseport() bool {
-	return !t.disableReuseport && ReuseportIsAvailable()
+	return t.enableReuseport && ReuseportIsAvailable()
 }
 
 func getTCPAddr(listenAddr ma.Multiaddr) (ma.Multiaddr, error) {

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -191,7 +191,6 @@ func (m *multiplexedListener) run() error {
 			}
 			continue
 		}
-
 		connScope, err := m.rcmgr.OpenConnection(network.DirInbound, true, c.RemoteMultiaddr())
 		if err != nil {
 			log.Debugw("resource manager blocked accept of new connection", "error", err)

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -111,6 +111,7 @@ func (t *ConnMgr) DemultiplexedListen(laddr ma.Multiaddr, connType Demultiplexed
 		t.mx.Lock()
 		defer t.mx.Unlock()
 		delete(t.listeners, laddr.String())
+		delete(t.listeners, l.Multiaddr().String())
 		return l.Close()
 	}
 	ml = &multiplexedListener{
@@ -121,14 +122,14 @@ func (t *ConnMgr) DemultiplexedListen(laddr ma.Multiaddr, connType Demultiplexed
 		connGater: t.connGater,
 		rcmgr:     t.rcmgr,
 	}
+	t.listeners[laddr.String()] = ml
+	t.listeners[l.Multiaddr().String()] = ml
 
 	dl, err := ml.DemultiplexedListen(connType)
 	if err != nil {
 		cerr := ml.Close()
 		return nil, errors.Join(err, cerr)
 	}
-
-	t.listeners[laddr.String()] = ml
 
 	ml.wg.Add(1)
 	go ml.run()

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -204,7 +204,7 @@ func (m *multiplexedListener) run() error {
 		if err != nil {
 			log.Debugw("resource manager blocked accept of new connection", "error", err)
 			if err := c.Close(); err != nil {
-				log.Warnf("failed to incoming connection rejected by resource manager: %s", err)
+				log.Warnf("failed to open incoming connection. Rejected by resource manager: %s", err)
 			}
 			continue
 		}

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -210,7 +210,7 @@ func (m *multiplexedListener) run() error {
 
 		select {
 		case acceptQueue <- struct{}{}:
-		// TODO: We can drop the connection, but this is similar to the behaviour in the upgrader.
+		// NOTE: We can drop the connection, but this is similar to the behaviour in the upgrader.
 		case <-m.ctx.Done():
 			c.Close()
 			log.Debugf("accept queue full, dropping connection: %s", c.RemoteMultiaddr())
@@ -229,8 +229,6 @@ func (m *multiplexedListener) run() error {
 				return
 			}
 
-			// TODO: Add a test that makes sure we can get the SyscallConn in Unix platforms.
-			// Wrap the scope into the conn.
 			connWithScope, err := manetConnWithScope(c, connScope)
 			if err != nil {
 				connScope.Done()

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -1,0 +1,250 @@
+package tcpreuse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/transport"
+	"github.com/libp2p/go-libp2p/p2p/net/reuseport"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+var log = logging.Logger("tcp-demultiplex")
+
+type ConnMgr struct {
+	disableReuseport bool
+	reuse            reuseport.Transport
+	listeners        map[string]*multiplexedListener
+	mx               sync.Mutex
+}
+
+func NewConnMgr(disableReuseport bool) *ConnMgr {
+	return &ConnMgr{
+		disableReuseport: disableReuseport,
+		reuse:            reuseport.Transport{},
+		listeners:        make(map[string]*multiplexedListener),
+	}
+}
+
+func (t *ConnMgr) maListen(laddr ma.Multiaddr) (manet.Listener, error) {
+	if t.useReuseport() {
+		return t.reuse.Listen(laddr)
+	} else {
+		return manet.Listen(laddr)
+	}
+}
+
+func (t *ConnMgr) useReuseport() bool {
+	return !t.disableReuseport && ReuseportIsAvailable()
+}
+
+func (t *ConnMgr) DemultiplexedListen(laddr ma.Multiaddr, connType DemultiplexedConnType) (manet.Listener, error) {
+	if !connType.IsKnown() {
+		return nil, fmt.Errorf("unknown connection type: %s", connType)
+	}
+
+	t.mx.Lock()
+	defer t.mx.Unlock()
+	ml, ok := t.listeners[laddr.String()]
+	if ok {
+		dl, err := ml.DemultiplexedListen(connType)
+		if err != nil {
+			return nil, err
+		}
+		return dl, nil
+	}
+
+	l, err := t.maListen(laddr)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelFunc := func() error {
+		cancel()
+		t.mx.Lock()
+		defer t.mx.Unlock()
+		delete(t.listeners, laddr.String())
+		return l.Close()
+	}
+	ml = &multiplexedListener{
+		Listener:  l,
+		listeners: make(map[DemultiplexedConnType]*demultiplexedListener),
+		buffer:    make(chan manet.Conn, 16), // TODO: how big should this buffer be?
+		ctx:       ctx,
+		closeFn:   cancelFunc,
+	}
+
+	dl, err := ml.DemultiplexedListen(connType)
+	if err != nil {
+		cerr := ml.Close()
+		return nil, errors.Join(err, cerr)
+	}
+
+	go func() {
+		err = ml.Run()
+		if err != nil {
+			log.Debugf("Error running multiplexed listener: %s", err.Error())
+		}
+	}()
+
+	t.listeners[laddr.String()] = ml
+
+	return dl, nil
+}
+
+var _ manet.Listener = &demultiplexedListener{}
+
+type multiplexedListener struct {
+	manet.Listener
+	listeners       map[DemultiplexedConnType]*demultiplexedListener
+	mx              sync.Mutex
+	listenerCounter int
+	buffer          chan manet.Conn
+
+	ctx     context.Context
+	closeFn func() error
+}
+
+func (m *multiplexedListener) DemultiplexedListen(connType DemultiplexedConnType) (manet.Listener, error) {
+	if !connType.IsKnown() {
+		return nil, fmt.Errorf("unknown connection type: %s", connType)
+	}
+
+	m.mx.Lock()
+	defer m.mx.Unlock()
+	l, ok := m.listeners[connType]
+	if ok {
+		return l, nil
+	}
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	closeFn := func() error {
+		cancel()
+		m.mx.Lock()
+		defer m.mx.Unlock()
+		m.listenerCounter--
+		if m.listenerCounter == 0 {
+			return m.Close()
+		}
+		return nil
+	}
+
+	l = &demultiplexedListener{
+		buffer:  make(chan manet.Conn, 16), // TODO: how big should this buffer be?
+		inner:   m.Listener,
+		ctx:     ctx,
+		closeFn: closeFn,
+	}
+
+	m.listeners[connType] = l
+	m.listenerCounter++
+
+	return l, nil
+}
+
+func (m *multiplexedListener) Run() error {
+	const numWorkers = 16
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			m.background()
+		}()
+	}
+
+	for {
+		c, err := m.Listener.Accept()
+		if err != nil {
+			return err
+		}
+
+		select {
+		case m.buffer <- c:
+		case <-m.ctx.Done():
+			return transport.ErrListenerClosed
+		}
+	}
+}
+
+func (m *multiplexedListener) background() {
+	// TODO: if/how do we want to handle stalled connections and stop them from clogging up the pipeline?
+	// Drop connection because the buffer is full
+	for {
+		select {
+		case c := <-m.buffer:
+			t, sampleC, err := ConnTypeFromConn(c)
+			if err != nil {
+				closeErr := c.Close()
+				err = errors.Join(err, closeErr)
+				log.Debugf("error demultiplexing connection: %s", err.Error())
+				continue
+			}
+
+			demux, ok := m.listeners[t]
+			if !ok {
+				closeErr := c.Close()
+				if closeErr != nil {
+					log.Debugf("no registered listener for demultiplex connection %s. Error closing the connection %s", t, closeErr.Error())
+				} else {
+					log.Debugf("no registered listener for demultiplex connection %s", t)
+				}
+				continue
+			}
+
+			select {
+			case demux.buffer <- sampleC:
+			case <-m.ctx.Done():
+				return
+			default:
+				closeErr := c.Close()
+				if closeErr != nil {
+					log.Debugf("dropped connection due to full buffer of awaiting connections of type %s. Error closing the connection %s", t, closeErr.Error())
+				} else {
+					log.Debugf("dropped connection due to full buffer of awaiting connections of type %s", t)
+				}
+				continue
+			}
+		case <-m.ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *multiplexedListener) Close() error {
+	cerr := m.closeFn()
+	lerr := m.Listener.Close()
+	return errors.Join(lerr, cerr)
+}
+
+type demultiplexedListener struct {
+	buffer  chan manet.Conn
+	inner   manet.Listener
+	ctx     context.Context
+	closeFn func() error
+}
+
+func (m *demultiplexedListener) Accept() (manet.Conn, error) {
+	select {
+	case c := <-m.buffer:
+		return c, nil
+	case <-m.ctx.Done():
+		return nil, transport.ErrListenerClosed
+	}
+}
+
+func (m *demultiplexedListener) Close() error {
+	return m.closeFn()
+}
+
+func (m *demultiplexedListener) Multiaddr() ma.Multiaddr {
+	// TODO: do we need to add a suffix for the rest of the transport?
+	return m.inner.Multiaddr()
+}
+
+func (m *demultiplexedListener) Addr() net.Addr {
+	return m.inner.Addr()
+}

--- a/p2p/transport/tcpreuse/listener_test.go
+++ b/p2p/transport/tcpreuse/listener_test.go
@@ -64,9 +64,9 @@ func (wh wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func TestListenerSingle(t *testing.T) {
 	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
 	const N = 64
-	for _, disableReuseport := range []bool{true, false} {
-		t.Run(fmt.Sprintf("multistream-reuseport:%v", disableReuseport), func(t *testing.T) {
-			cm := NewConnMgr(disableReuseport, nil, nil)
+	for _, enableReuseport := range []bool{true, false} {
+		t.Run(fmt.Sprintf("multistream-reuseport:%v", enableReuseport), func(t *testing.T) {
+			cm := NewConnMgr(enableReuseport, nil, nil)
 			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 			require.NoError(t, err)
 			go func() {
@@ -116,8 +116,8 @@ func TestListenerSingle(t *testing.T) {
 			wg.Wait()
 		})
 
-		t.Run(fmt.Sprintf("WebSocket-reuseport:%v", disableReuseport), func(t *testing.T) {
-			cm := NewConnMgr(disableReuseport, nil, nil)
+		t.Run(fmt.Sprintf("WebSocket-reuseport:%v", enableReuseport), func(t *testing.T) {
+			cm := NewConnMgr(enableReuseport, nil, nil)
 			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
 			require.NoError(t, err)
 			wh := wsHandler{conns: make(chan *websocket.Conn, acceptQueueSize)}
@@ -168,8 +168,8 @@ func TestListenerSingle(t *testing.T) {
 			wg.Wait()
 		})
 
-		t.Run(fmt.Sprintf("WebSocketTLS-reuseport:%v", disableReuseport), func(t *testing.T) {
-			cm := NewConnMgr(disableReuseport, nil, nil)
+		t.Run(fmt.Sprintf("WebSocketTLS-reuseport:%v", enableReuseport), func(t *testing.T) {
+			cm := NewConnMgr(enableReuseport, nil, nil)
 			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_TLS)
 			require.NoError(t, err)
 			defer l.Close()
@@ -227,8 +227,8 @@ func TestListenerSingle(t *testing.T) {
 func TestListenerMultiplexed(t *testing.T) {
 	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
 	const N = 20
-	for _, disableReuseport := range []bool{true, false} {
-		cm := NewConnMgr(disableReuseport, nil, nil)
+	for _, enableReuseport := range []bool{true, false} {
+		cm := NewConnMgr(enableReuseport, nil, nil)
 		msl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 		require.NoError(t, err)
 		defer msl.Close()
@@ -405,7 +405,7 @@ func TestListenerClose(t *testing.T) {
 
 	testClose := func(listenAddr ma.Multiaddr) {
 		// listen on port 0
-		cm := NewConnMgr(true, nil, nil)
+		cm := NewConnMgr(false, nil, nil)
 		ml, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 		require.NoError(t, err)
 		wl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)

--- a/p2p/transport/tcpreuse/listener_test.go
+++ b/p2p/transport/tcpreuse/listener_test.go
@@ -20,6 +20,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/multiformats/go-multistream"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,7 +63,7 @@ func (wh wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func TestListenerSingle(t *testing.T) {
 	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
-	const N = 128
+	const N = 64
 	for _, disableReuseport := range []bool{true, false} {
 		t.Run(fmt.Sprintf("multistream-reuseport:%v", disableReuseport), func(t *testing.T) {
 			cm := NewConnMgr(disableReuseport, nil, nil)
@@ -101,11 +102,15 @@ func TestListenerSingle(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					cc := multistream.NewMSSelect(c, "a")
+					defer cc.Close()
 					buf := make([]byte, 30)
 					n, err := cc.Read(buf)
-					require.NoError(t, err)
-					require.Equal(t, "hello-multistream", string(buf[:n]))
-					c.Close()
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, "hello-multistream", string(buf[:n])) {
+						return
+					}
 				}()
 			}
 			wg.Wait()
@@ -147,11 +152,17 @@ func TestListenerSingle(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
-					require.NoError(t, err)
-					require.Equal(t, msgType, websocket.TextMessage)
-					require.Equal(t, "hello", string(buf))
-					c.Close()
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, msgType, websocket.TextMessage) {
+						return
+					}
+					if !assert.Equal(t, "hello", string(buf)) {
+						return
+					}
 				}()
 			}
 			wg.Wait()
@@ -195,11 +206,17 @@ func TestListenerSingle(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
-					require.NoError(t, err)
-					require.Equal(t, msgType, websocket.TextMessage)
-					require.Equal(t, "hello", string(buf))
-					c.Close()
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, msgType, websocket.TextMessage) {
+						return
+					}
+					if !assert.Equal(t, "hello", string(buf)) {
+						return
+					}
 				}()
 			}
 			wg.Wait()
@@ -209,7 +226,7 @@ func TestListenerSingle(t *testing.T) {
 
 func TestListenerMultiplexed(t *testing.T) {
 	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
-	const N = 128
+	const N = 20
 	for _, disableReuseport := range []bool{true, false} {
 		cm := NewConnMgr(disableReuseport, nil, nil)
 		msl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
@@ -315,16 +332,22 @@ func TestListenerMultiplexed(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < N; i++ {
 				c, err := msl.Accept()
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					return
+				}
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					cc := multistream.NewMSSelect(c, "a")
+					defer cc.Close()
 					buf := make([]byte, 20)
 					n, err := cc.Read(buf)
-					require.NoError(t, err)
-					require.Equal(t, "multistream", string(buf[:n]))
-					cc.Close()
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, "multistream", string(buf[:n])) {
+						return
+					}
 				}()
 			}
 		}()
@@ -337,11 +360,17 @@ func TestListenerMultiplexed(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
-					require.NoError(t, err)
-					require.Equal(t, msgType, websocket.TextMessage)
-					require.Equal(t, "websocket", string(buf))
-					c.Close()
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, msgType, websocket.TextMessage) {
+						return
+					}
+					if !assert.Equal(t, "websocket", string(buf)) {
+						return
+					}
 				}()
 			}
 		}()
@@ -354,11 +383,17 @@ func TestListenerMultiplexed(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
-					require.NoError(t, err)
-					require.Equal(t, msgType, websocket.TextMessage)
-					require.Equal(t, "websocket-tls", string(buf))
-					c.Close()
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, msgType, websocket.TextMessage) {
+						return
+					}
+					if !assert.Equal(t, "websocket-tls", string(buf)) {
+						return
+					}
 				}()
 			}
 		}()

--- a/p2p/transport/tcpreuse/listener_test.go
+++ b/p2p/transport/tcpreuse/listener_test.go
@@ -402,7 +402,6 @@ func TestListenerMultiplexed(t *testing.T) {
 }
 
 func TestListenerClose(t *testing.T) {
-
 	testClose := func(listenAddr ma.Multiaddr) {
 		// listen on port 0
 		cm := NewConnMgr(false, nil, nil)
@@ -417,24 +416,20 @@ func TestListenerClose(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
 
+		ml.Close()
+
 		mll, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 		require.NoError(t, err)
-		require.Equal(t, mll, ml)
+		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
 
+		mll.Close()
 		wl.Close()
-		ml.Close()
 
 		ml, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 		require.NoError(t, err)
-
-		require.NotEqual(t, ml.Multiaddr(), mll.Multiaddr())
-		require.NotEqual(t, mll, ml)
-		ml.Close()
 
 		// Now listen on the specific port previously used
 		listenAddr = ml.Multiaddr()
-		ml, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
-		require.NoError(t, err)
 		wl, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
 		require.NoError(t, err)
 		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
@@ -444,19 +439,8 @@ func TestListenerClose(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
 
-		mll, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
-		require.NoError(t, err)
-		require.Equal(t, mll, ml)
-
+		ml.Close()
 		wl.Close()
-		ml.Close()
-
-		ml, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
-		require.NoError(t, err)
-
-		require.Equal(t, ml.Multiaddr(), mll.Multiaddr())
-		require.NotEqual(t, mll, ml)
-		ml.Close()
 	}
 	listenAddrs := []ma.Multiaddr{ma.StringCast("/ip4/0.0.0.0/tcp/0"), ma.StringCast("/ip6/::/tcp/0")}
 	for _, listenAddr := range listenAddrs {

--- a/p2p/transport/tcpreuse/listener_test.go
+++ b/p2p/transport/tcpreuse/listener_test.go
@@ -65,7 +65,7 @@ func TestListenerSingle(t *testing.T) {
 	const N = 128
 	for _, disableReuseport := range []bool{true, false} {
 		t.Run(fmt.Sprintf("multistream-reuseport:%v", disableReuseport), func(t *testing.T) {
-			cm := NewConnMgr(disableReuseport)
+			cm := NewConnMgr(disableReuseport, nil, nil)
 			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 			require.NoError(t, err)
 			go func() {
@@ -112,7 +112,7 @@ func TestListenerSingle(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("WebSocket-reuseport:%v", disableReuseport), func(t *testing.T) {
-			cm := NewConnMgr(disableReuseport)
+			cm := NewConnMgr(disableReuseport, nil, nil)
 			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
 			require.NoError(t, err)
 			wh := wsHandler{conns: make(chan *websocket.Conn, acceptQueueSize)}
@@ -158,7 +158,7 @@ func TestListenerSingle(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("WebSocketTLS-reuseport:%v", disableReuseport), func(t *testing.T) {
-			cm := NewConnMgr(disableReuseport)
+			cm := NewConnMgr(disableReuseport, nil, nil)
 			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_TLS)
 			require.NoError(t, err)
 			defer l.Close()
@@ -211,7 +211,7 @@ func TestListenerMultiplexed(t *testing.T) {
 	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
 	const N = 128
 	for _, disableReuseport := range []bool{true, false} {
-		cm := NewConnMgr(disableReuseport)
+		cm := NewConnMgr(disableReuseport, nil, nil)
 		msl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 		require.NoError(t, err)
 		defer msl.Close()
@@ -370,7 +370,7 @@ func TestListenerClose(t *testing.T) {
 
 	testClose := func(listenAddr ma.Multiaddr) {
 		// listen on port 0
-		cm := NewConnMgr(true)
+		cm := NewConnMgr(true, nil, nil)
 		ml, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
 		require.NoError(t, err)
 		wl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)

--- a/p2p/transport/tcpreuse/listener_test.go
+++ b/p2p/transport/tcpreuse/listener_test.go
@@ -1,0 +1,430 @@
+package tcpreuse
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	"github.com/multiformats/go-multistream"
+	"github.com/stretchr/testify/require"
+)
+
+func selfSignedTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	certTemplate := x509.Certificate{
+		SerialNumber: &big.Int{},
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	cert := tls.Certificate{
+		Certificate: [][]byte{derBytes},
+		PrivateKey:  priv,
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	return tlsConfig
+}
+
+type wsHandler struct{ conns chan *websocket.Conn }
+
+func (wh wsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	u := websocket.Upgrader{}
+	c, _ := u.Upgrade(w, r, http.Header{})
+	wh.conns <- c
+}
+
+func TestListenerSingle(t *testing.T) {
+	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
+	const N = 128
+	for _, disableReuseport := range []bool{true, false} {
+		t.Run(fmt.Sprintf("multistream-reuseport:%v", disableReuseport), func(t *testing.T) {
+			cm := NewConnMgr(disableReuseport)
+			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+			require.NoError(t, err)
+			go func() {
+				d := net.Dialer{}
+				for i := 0; i < N; i++ {
+					go func() {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						conn, err := d.DialContext(ctx, l.Addr().Network(), l.Addr().String())
+						if err != nil {
+							t.Error("failed to dial", err, i)
+							return
+						}
+						lconn := multistream.NewMSSelect(conn, "a")
+						buf := make([]byte, 10)
+						_, err = lconn.Write([]byte("hello-multistream"))
+						if err != nil {
+							t.Error(err)
+						}
+						_, err = lconn.Read(buf)
+						if err == nil {
+							t.Error("expected EOF got nil")
+						}
+					}()
+				}
+			}()
+
+			var wg sync.WaitGroup
+			for i := 0; i < N; i++ {
+				c, err := l.Accept()
+				require.NoError(t, err)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					cc := multistream.NewMSSelect(c, "a")
+					buf := make([]byte, 30)
+					n, err := cc.Read(buf)
+					require.NoError(t, err)
+					require.Equal(t, "hello-multistream", string(buf[:n]))
+					c.Close()
+				}()
+			}
+			wg.Wait()
+		})
+
+		t.Run(fmt.Sprintf("WebSocket-reuseport:%v", disableReuseport), func(t *testing.T) {
+			cm := NewConnMgr(disableReuseport)
+			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
+			require.NoError(t, err)
+			wh := wsHandler{conns: make(chan *websocket.Conn, acceptQueueSize)}
+			go func() {
+				http.Serve(manet.NetListener(l), wh)
+			}()
+			go func() {
+				d := websocket.Dialer{}
+				for i := 0; i < N; i++ {
+					go func() {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						conn, _, err := d.DialContext(ctx, fmt.Sprintf("ws://%s", l.Addr().String()), http.Header{})
+						if err != nil {
+							t.Error("failed to dial", err, i)
+							return
+						}
+						err = conn.WriteMessage(websocket.TextMessage, []byte("hello"))
+						if err != nil {
+							t.Error(err)
+						}
+						_, _, err = conn.ReadMessage()
+						if err == nil {
+							t.Error("expected EOF got nil")
+						}
+					}()
+				}
+			}()
+			var wg sync.WaitGroup
+			for i := 0; i < N; i++ {
+				c := <-wh.conns
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					msgType, buf, err := c.ReadMessage()
+					require.NoError(t, err)
+					require.Equal(t, msgType, websocket.TextMessage)
+					require.Equal(t, "hello", string(buf))
+					c.Close()
+				}()
+			}
+			wg.Wait()
+		})
+
+		t.Run(fmt.Sprintf("WebSocketTLS-reuseport:%v", disableReuseport), func(t *testing.T) {
+			cm := NewConnMgr(disableReuseport)
+			l, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_TLS)
+			require.NoError(t, err)
+			defer l.Close()
+			wh := wsHandler{conns: make(chan *websocket.Conn, acceptQueueSize)}
+			go func() {
+				s := http.Server{Handler: wh, TLSConfig: selfSignedTLSConfig(t)}
+				s.ServeTLS(manet.NetListener(l), "", "")
+			}()
+			go func() {
+				d := websocket.Dialer{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+				for i := 0; i < N; i++ {
+					go func() {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						conn, _, err := d.DialContext(ctx, fmt.Sprintf("wss://%s", l.Addr().String()), http.Header{})
+						if err != nil {
+							t.Error("failed to dial", err, i)
+							return
+						}
+						err = conn.WriteMessage(websocket.TextMessage, []byte("hello"))
+						if err != nil {
+							t.Error(err)
+						}
+						_, _, err = conn.ReadMessage()
+						if err == nil {
+							t.Error("expected EOF got nil")
+						}
+					}()
+				}
+			}()
+			var wg sync.WaitGroup
+			for i := 0; i < N; i++ {
+				c := <-wh.conns
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					msgType, buf, err := c.ReadMessage()
+					require.NoError(t, err)
+					require.Equal(t, msgType, websocket.TextMessage)
+					require.Equal(t, "hello", string(buf))
+					c.Close()
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
+
+func TestListenerMultiplexed(t *testing.T) {
+	listenAddr := ma.StringCast("/ip4/0.0.0.0/tcp/0")
+	const N = 128
+	for _, disableReuseport := range []bool{true, false} {
+		cm := NewConnMgr(disableReuseport)
+		msl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+		defer msl.Close()
+
+		wsl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
+		require.NoError(t, err)
+		defer wsl.Close()
+		require.Equal(t, wsl.Multiaddr(), msl.Multiaddr())
+		wh := wsHandler{conns: make(chan *websocket.Conn, acceptQueueSize)}
+		go func() {
+			http.Serve(manet.NetListener(wsl), wh)
+		}()
+
+		wssl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_TLS)
+		require.NoError(t, err)
+		defer wssl.Close()
+		require.Equal(t, wssl.Multiaddr(), wsl.Multiaddr())
+		whs := wsHandler{conns: make(chan *websocket.Conn, acceptQueueSize)}
+		go func() {
+			s := http.Server{Handler: whs, TLSConfig: selfSignedTLSConfig(t)}
+			s.ServeTLS(manet.NetListener(wssl), "", "")
+		}()
+
+		// multistream connections
+		go func() {
+			d := net.Dialer{}
+			for i := 0; i < N; i++ {
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					conn, err := d.DialContext(ctx, msl.Addr().Network(), msl.Addr().String())
+					if err != nil {
+						t.Error("failed to dial", err, i)
+						return
+					}
+					lconn := multistream.NewMSSelect(conn, "a")
+					buf := make([]byte, 10)
+					_, err = lconn.Write([]byte("multistream"))
+					if err != nil {
+						t.Error(err)
+					}
+					_, err = lconn.Read(buf)
+					if err == nil {
+						t.Error("expected EOF got nil")
+					}
+				}()
+			}
+		}()
+
+		// ws connections
+		go func() {
+			d := websocket.Dialer{}
+			for i := 0; i < N; i++ {
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					conn, _, err := d.DialContext(ctx, fmt.Sprintf("ws://%s", msl.Addr().String()), http.Header{})
+					if err != nil {
+						t.Error("failed to dial", err, i)
+						return
+					}
+					err = conn.WriteMessage(websocket.TextMessage, []byte("websocket"))
+					if err != nil {
+						t.Error(err)
+					}
+					_, _, err = conn.ReadMessage()
+					if err == nil {
+						t.Error("expected EOF got nil")
+					}
+				}()
+			}
+		}()
+
+		// wss connections
+		go func() {
+			d := websocket.Dialer{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+			for i := 0; i < N; i++ {
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					conn, _, err := d.DialContext(ctx, fmt.Sprintf("wss://%s", msl.Addr().String()), http.Header{})
+					if err != nil {
+						t.Error("failed to dial", err, i)
+						return
+					}
+					err = conn.WriteMessage(websocket.TextMessage, []byte("websocket-tls"))
+					if err != nil {
+						t.Error(err)
+					}
+					_, _, err = conn.ReadMessage()
+					if err == nil {
+						t.Error("expected EOF got nil")
+					}
+				}()
+			}
+		}()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N; i++ {
+				c, err := msl.Accept()
+				require.NoError(t, err)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					cc := multistream.NewMSSelect(c, "a")
+					buf := make([]byte, 20)
+					n, err := cc.Read(buf)
+					require.NoError(t, err)
+					require.Equal(t, "multistream", string(buf[:n]))
+					cc.Close()
+				}()
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N; i++ {
+				c := <-wh.conns
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					msgType, buf, err := c.ReadMessage()
+					require.NoError(t, err)
+					require.Equal(t, msgType, websocket.TextMessage)
+					require.Equal(t, "websocket", string(buf))
+					c.Close()
+				}()
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N; i++ {
+				c := <-whs.conns
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					msgType, buf, err := c.ReadMessage()
+					require.NoError(t, err)
+					require.Equal(t, msgType, websocket.TextMessage)
+					require.Equal(t, "websocket-tls", string(buf))
+					c.Close()
+				}()
+			}
+		}()
+		wg.Wait()
+	}
+}
+
+func TestListenerClose(t *testing.T) {
+
+	testClose := func(listenAddr ma.Multiaddr) {
+		// listen on port 0
+		cm := NewConnMgr(true)
+		ml, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+		wl, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
+		require.NoError(t, err)
+		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
+		wl.Close()
+
+		wl, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
+		require.NoError(t, err)
+		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
+
+		mll, err := cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+		require.Equal(t, mll, ml)
+
+		wl.Close()
+		ml.Close()
+
+		ml, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+
+		require.NotEqual(t, ml.Multiaddr(), mll.Multiaddr())
+		require.NotEqual(t, mll, ml)
+		ml.Close()
+
+		// Now listen on the specific port previously used
+		listenAddr = ml.Multiaddr()
+		ml, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+		wl, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
+		require.NoError(t, err)
+		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
+		wl.Close()
+
+		wl, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_HTTP)
+		require.NoError(t, err)
+		require.Equal(t, wl.Multiaddr(), ml.Multiaddr())
+
+		mll, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+		require.Equal(t, mll, ml)
+
+		wl.Close()
+		ml.Close()
+
+		ml, err = cm.DemultiplexedListen(listenAddr, DemultiplexedConnType_MultistreamSelect)
+		require.NoError(t, err)
+
+		require.Equal(t, ml.Multiaddr(), mll.Multiaddr())
+		require.NotEqual(t, mll, ml)
+		ml.Close()
+	}
+	listenAddrs := []ma.Multiaddr{ma.StringCast("/ip4/0.0.0.0/tcp/0"), ma.StringCast("/ip6/::/tcp/0")}
+	for _, listenAddr := range listenAddrs {
+		testClose(listenAddr)
+	}
+}

--- a/p2p/transport/tcpreuse/reuseport.go
+++ b/p2p/transport/tcpreuse/reuseport.go
@@ -1,4 +1,4 @@
-package tcp
+package tcpreuse
 
 import (
 	"os"
@@ -11,13 +11,13 @@ import (
 // It default to true.
 const envReuseport = "LIBP2P_TCP_REUSEPORT"
 
-// envReuseportVal stores the value of envReuseport. defaults to true.
-var envReuseportVal = true
+// EnvReuseportVal stores the value of envReuseport. defaults to true.
+var EnvReuseportVal = true
 
 func init() {
 	v := strings.ToLower(os.Getenv(envReuseport))
 	if v == "false" || v == "f" || v == "0" {
-		envReuseportVal = false
+		EnvReuseportVal = false
 		log.Infof("REUSEPORT disabled (LIBP2P_TCP_REUSEPORT=%s)", v)
 	}
 }
@@ -31,5 +31,5 @@ func init() {
 // If this becomes a sought after feature, we could add this to the config.
 // In the end, reuseport is a stop-gap.
 func ReuseportIsAvailable() bool {
-	return envReuseportVal && reuseport.Available()
+	return EnvReuseportVal && reuseport.Available()
 }

--- a/p2p/transport/testsuite/utils_suite.go
+++ b/p2p/transport/testsuite/utils_suite.go
@@ -11,7 +11,9 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-var Subtests = []func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID){
+type TransportSubTestFn func(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr, peerA peer.ID)
+
+var Subtests = []TransportSubTestFn{
 	SubtestProtocols,
 	SubtestBasic,
 	SubtestCancel,
@@ -33,12 +35,17 @@ func getFunctionName(i interface{}) string {
 }
 
 func SubtestTransport(t *testing.T, ta, tb transport.Transport, addr string, peerA peer.ID) {
+	t.Helper()
+	SubtestTransportWithFs(t, ta, tb, addr, peerA, Subtests)
+}
+
+func SubtestTransportWithFs(t *testing.T, ta, tb transport.Transport, addr string, peerA peer.ID, tests []TransportSubTestFn) {
 	maddr, err := ma.NewMultiaddr(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, f := range Subtests {
+	for _, f := range tests {
 		t.Run(getFunctionName(f), func(t *testing.T) {
 			f(t, ta, tb, maddr, peerA)
 		})

--- a/p2p/transport/websocket/addrs_test.go
+++ b/p2p/transport/websocket/addrs_test.go
@@ -69,7 +69,7 @@ func TestConvertWebsocketMultiaddrToNetAddr(t *testing.T) {
 }
 
 func TestListeningOnDNSAddr(t *testing.T) {
-	ln, err := newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil)
+	ln, err := newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil, nil)
 	require.NoError(t, err)
 	addr := ln.Multiaddr()
 	first, rest := ma.SplitFirst(addr)

--- a/p2p/transport/websocket/conn.go
+++ b/p2p/transport/websocket/conn.go
@@ -99,9 +99,20 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 	return len(b), nil
 }
 
+func (c *Conn) Scope() network.ConnManagementScope {
+	nc := c.NetConn()
+	if sc, ok := nc.(interface {
+		Scope() network.ConnManagementScope
+	}); ok {
+		return sc.Scope()
+	}
+	return nil
+}
+
 // Close closes the connection. Only the first call to Close will receive the
 // close error, subsequent and concurrent calls will return nil.
 // This method is thread-safe.
+// TODO: Fix this ^
 func (c *Conn) Close() error {
 	var err error
 	c.closeOnce.Do(func() {

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -75,9 +75,9 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 	} else {
 		var connType tcpreuse.DemultiplexedConnType
 		if parsed.isWSS {
-			connType = tcpreuse.TLS
+			connType = tcpreuse.DemultiplexedConnType_TLS
 		} else {
-			connType = tcpreuse.HTTP
+			connType = tcpreuse.DemultiplexedConnType_HTTP
 		}
 		mal, err := sharedTcp.DemultiplexedListen(parsed.restMultiaddr, connType)
 		if err != nil {

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/transport"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse"
 
 	ma "github.com/multiformats/go-multiaddr"
 	mafmt "github.com/multiformats/go-multiaddr-fmt"
@@ -80,6 +81,13 @@ func WithTLSConfig(conf *tls.Config) Option {
 	}
 }
 
+func WithSharedTCP(mgr *tcpreuse.ConnMgr) Option {
+	return func(t *WebsocketTransport) error {
+		t.sharedTcp = mgr
+		return nil
+	}
+}
+
 // WebsocketTransport is the actual go-libp2p transport
 type WebsocketTransport struct {
 	upgrader transport.Upgrader
@@ -87,6 +95,8 @@ type WebsocketTransport struct {
 
 	tlsClientConf *tls.Config
 	tlsConf       *tls.Config
+
+	sharedTcp *tcpreuse.ConnMgr
 }
 
 var _ transport.Transport = (*WebsocketTransport)(nil)
@@ -233,7 +243,7 @@ func (t *WebsocketTransport) maListen(a ma.Multiaddr) (manet.Listener, error) {
 	if t.tlsConf != nil {
 		tlsConf = t.tlsConf.Clone()
 	}
-	l, err := newListener(a, tlsConf)
+	l, err := newListener(a, tlsConf, t.sharedTcp)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -101,7 +101,7 @@ type WebsocketTransport struct {
 
 var _ transport.Transport = (*WebsocketTransport)(nil)
 
-func New(u transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*WebsocketTransport, error) {
+func New(u transport.Upgrader, rcmgr network.ResourceManager, sharedTCP *tcpreuse.ConnMgr, opts ...Option) (*WebsocketTransport, error) {
 	if rcmgr == nil {
 		rcmgr = &network.NullResourceManager{}
 	}
@@ -109,6 +109,7 @@ func New(u transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*
 		upgrader:      u,
 		rcmgr:         rcmgr,
 		tlsClientConf: &tls.Config{},
+		sharedTcp:     sharedTCP,
 	}
 	for _, opt := range opts {
 		if err := opt(t); err != nil {

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -81,13 +81,6 @@ func WithTLSConfig(conf *tls.Config) Option {
 	}
 }
 
-func WithSharedTCP(mgr *tcpreuse.ConnMgr) Option {
-	return func(t *WebsocketTransport) error {
-		t.sharedTcp = mgr
-		return nil
-	}
-}
-
 // WebsocketTransport is the actual go-libp2p transport
 type WebsocketTransport struct {
 	upgrader transport.Upgrader


### PR DESCRIPTION
closes #2684 

@MarcoPolo @sukunrt I took a stab at this as a result of looking at https://github.com/ipfs/kubo/pull/10521. I also pulled from @Jorropo's work on #2737.

Initial testing seems to indicate things work ok, but this definitely needs more tests, API cleanup + eyes before merging.

Side note: Given that we're sharing the underlying TCP listener now I wonder if we basically have to tackle #1435 as well.