### PR TITLE
feat(websocket): switch the underlying http server logger to use ipfs/go-log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	go.uber.org/fx v1.22.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.4.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.25.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sync v0.7.0
@@ -123,7 +124,6 @@ require (
 	github.com/wlynxg/anet v0.0.3 // indirect
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -4,15 +4,21 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"go.uber.org/zap"
 	"net"
 	"net/http"
 	"sync"
+
+	logging "github.com/ipfs/go-log/v2"
 
 	"github.com/libp2p/go-libp2p/core/transport"
 
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
+
+var log = logging.Logger("websocket-transport")
+var stdLog = zap.NewStdLog(log.Desugar())
 
 type listener struct {
 	nl     net.Listener
@@ -82,7 +88,7 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config) (*listener, error) {
 		incoming: make(chan *Conn),
 		closed:   make(chan struct{}),
 	}
-	ln.server = http.Server{Handler: ln}
+	ln.server = http.Server{Handler: ln, ErrorLog: stdLog}
 	if parsed.isWSS {
 		ln.isWss = true
 		ln.server.TLSConfig = tlsConf


### PR DESCRIPTION
Does what it says on the box 😅.

The motivation behind this change is that while implementing https://github.com/ipfs/kubo/pull/10521 I noticed a large number of logs of the form `"http: TLS handshake error from ip:port: EOF"` and I couldn't control them in the same way I can logs for any other transport.

This error in particular is one I don't expect many folks have run into since my understanding is that the WSS listener within go-libp2p is not highly utilized with many applications dependent on WSS choosing to use WS + do TLS termination in front of the libp2p node instead. However, in the linked issue the idea is to do the TLS termination within go-libp2p and so the issue becomes apparent.