### PR TITLE
Connection multiaddress should match the address actually dialed (WSS, WebTransport, WebRTC)

### DIFF
--- a/p2p/test/transport/gating_test.go
+++ b/p2p/test/transport/gating_test.go
@@ -101,7 +101,7 @@ func TestInterceptSecuredOutgoing(t *testing.T) {
 				connGater.EXPECT().InterceptAddrDial(h2.ID(), gomock.Any()).Return(true),
 				connGater.EXPECT().InterceptSecured(network.DirOutbound, h2.ID(), gomock.Any()).Do(func(_ network.Direction, _ peer.ID, addrs network.ConnMultiaddrs) {
 					// remove the certhash component from WebTransport and WebRTC addresses
-					require.Equal(t, stripCertHash(h2.Addrs()[0]).String(), addrs.RemoteMultiaddr().String())
+					require.Equal(t, h2.Addrs()[0].String(), addrs.RemoteMultiaddr().String())
 				}),
 			)
 			err := h1.Connect(ctx, peer.AddrInfo{ID: h2.ID(), Addrs: h2.Addrs()})
@@ -135,8 +135,7 @@ func TestInterceptUpgradedOutgoing(t *testing.T) {
 				connGater.EXPECT().InterceptAddrDial(h2.ID(), gomock.Any()).Return(true),
 				connGater.EXPECT().InterceptSecured(network.DirOutbound, h2.ID(), gomock.Any()).Return(true),
 				connGater.EXPECT().InterceptUpgraded(gomock.Any()).Do(func(c network.Conn) {
-					// remove the certhash component from WebTransport addresses
-					require.Equal(t, stripCertHash(h2.Addrs()[0]), c.RemoteMultiaddr())
+					require.Equal(t, h2.Addrs()[0], c.RemoteMultiaddr())
 					require.Equal(t, h1.ID(), c.LocalPeer())
 					require.Equal(t, h2.ID(), c.RemotePeer())
 				}))
@@ -170,12 +169,12 @@ func TestInterceptAccept(t *testing.T) {
 				// In WebRTC, retransmissions of the STUN packet might cause us to create multiple connections,
 				// if the first connection attempt is rejected.
 				connGater.EXPECT().InterceptAccept(gomock.Any()).Do(func(addrs network.ConnMultiaddrs) {
-					// remove the certhash component from WebTransport addresses
+					// remove the certhash component from WebRTC and WebTransport addresses
 					require.Equal(t, stripCertHash(h2.Addrs()[0]), addrs.LocalMultiaddr())
 				}).AnyTimes()
 			} else {
 				connGater.EXPECT().InterceptAccept(gomock.Any()).Do(func(addrs network.ConnMultiaddrs) {
-					// remove the certhash component from WebTransport addresses
+					// remove the certhash component from WebRTC and WebTransport addresses
 					require.Equal(t, stripCertHash(h2.Addrs()[0]), addrs.LocalMultiaddr())
 				})
 			}
@@ -213,8 +212,7 @@ func TestInterceptSecuredIncoming(t *testing.T) {
 			gomock.InOrder(
 				connGater.EXPECT().InterceptAccept(gomock.Any()).Return(true),
 				connGater.EXPECT().InterceptSecured(network.DirInbound, h1.ID(), gomock.Any()).Do(func(_ network.Direction, _ peer.ID, addrs network.ConnMultiaddrs) {
-					// remove the certhash component from WebTransport addresses
-					require.Equal(t, stripCertHash(h2.Addrs()[0]), addrs.LocalMultiaddr())
+					require.Equal(t, h2.Addrs()[0], addrs.LocalMultiaddr())
 				}),
 			)
 			h1.Peerstore().AddAddrs(h2.ID(), h2.Addrs(), time.Hour)
@@ -248,7 +246,7 @@ func TestInterceptUpgradedIncoming(t *testing.T) {
 				connGater.EXPECT().InterceptSecured(network.DirInbound, h1.ID(), gomock.Any()).Return(true),
 				connGater.EXPECT().InterceptUpgraded(gomock.Any()).Do(func(c network.Conn) {
 					// remove the certhash component from WebTransport addresses
-					require.Equal(t, stripCertHash(h2.Addrs()[0]), c.LocalMultiaddr())
+					require.Equal(t, h2.Addrs()[0], c.LocalMultiaddr())
 					require.Equal(t, h1.ID(), c.RemotePeer())
 					require.Equal(t, h2.ID(), c.LocalPeer())
 				}),

--- a/p2p/transport/webrtc/listener.go
+++ b/p2p/transport/webrtc/listener.go
@@ -264,14 +264,13 @@ func (l *listener) setupConnection(
 		return nil, err
 	}
 
-	localMultiaddrWithoutCerthash, _ := ma.SplitFunc(l.localMultiaddr, func(c ma.Component) bool { return c.Protocol().Code == ma.P_CERTHASH })
 	conn, err := newConnection(
 		network.DirInbound,
 		w.PeerConnection,
 		l.transport,
 		scope,
 		l.transport.localPeerId,
-		localMultiaddrWithoutCerthash,
+		l.localMultiaddr,
 		remotePeer,
 		remotePubKey,
 		remoteMultiaddr,

--- a/p2p/transport/webrtc/transport.go
+++ b/p2p/transport/webrtc/transport.go
@@ -387,7 +387,6 @@ func (t *WebRTCTransport) dial(ctx context.Context, scope network.ConnManagement
 	if err != nil {
 		return nil, err
 	}
-	remoteMultiaddrWithoutCerthash, _ := ma.SplitFunc(remoteMultiaddr, func(c ma.Component) bool { return c.Protocol().Code == ma.P_CERTHASH })
 
 	conn, err := newConnection(
 		network.DirOutbound,
@@ -398,7 +397,7 @@ func (t *WebRTCTransport) dial(ctx context.Context, scope network.ConnManagement
 		localAddr,
 		p,
 		remotePubKey,
-		remoteMultiaddrWithoutCerthash,
+		remoteMultiaddr,
 		w.IncomingDataChannels,
 		w.PeerConnectionClosedCh,
 	)

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -188,8 +188,8 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 	}
 	isWss := wsurl.Scheme == "wss"
 	dialer := ws.Dialer{HandshakeTimeout: 30 * time.Second}
+	var sni string
 	if isWss {
-		sni := ""
 		sni, err = raddr.ValueForProtocol(ma.P_SNI)
 		if err != nil {
 			sni = ""
@@ -220,7 +220,7 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 		return nil, err
 	}
 
-	mnc, err := manet.WrapNetConn(NewConn(wscon, isWss))
+	mnc, err := NewOutboundConn(wscon, isWss, sni)
 	if err != nil {
 		wscon.Close()
 		return nil, err

--- a/p2p/transport/webtransport/listener.go
+++ b/p2p/transport/webtransport/listener.go
@@ -234,10 +234,7 @@ func (l *listener) Accept() (tpt.CapableConn, error) {
 }
 
 func (l *listener) handshake(ctx context.Context, sess *webtransport.Session) (*connSecurityMultiaddrs, error) {
-	local, err := toWebtransportMultiaddr(sess.LocalAddr())
-	if err != nil {
-		return nil, fmt.Errorf("error determiniting local addr: %w", err)
-	}
+	local := l.Multiaddr()
 	remote, err := toWebtransportMultiaddr(sess.RemoteAddr())
 	if err != nil {
 		return nil, fmt.Errorf("error determiniting remote addr: %w", err)

--- a/p2p/transport/webtransport/transport.go
+++ b/p2p/transport/webtransport/transport.go
@@ -172,7 +172,7 @@ func (t *transport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p pee
 	if err != nil {
 		return nil, err
 	}
-	sconn, err := t.upgrade(ctx, sess, p, certHashes)
+	sconn, err := t.upgrade(ctx, sess, p, certHashes, raddr)
 	if err != nil {
 		sess.CloseWithError(1, "")
 		return nil, err
@@ -230,14 +230,10 @@ func (t *transport) dial(ctx context.Context, addr ma.Multiaddr, url, sni string
 	return sess, conn, err
 }
 
-func (t *transport) upgrade(ctx context.Context, sess *webtransport.Session, p peer.ID, certHashes []multihash.DecodedMultihash) (*connSecurityMultiaddrs, error) {
+func (t *transport) upgrade(ctx context.Context, sess *webtransport.Session, p peer.ID, certHashes []multihash.DecodedMultihash, remote ma.Multiaddr) (*connSecurityMultiaddrs, error) {
 	local, err := toWebtransportMultiaddr(sess.LocalAddr())
 	if err != nil {
 		return nil, fmt.Errorf("error determining local addr: %w", err)
-	}
-	remote, err := toWebtransportMultiaddr(sess.RemoteAddr())
-	if err != nil {
-		return nil, fmt.Errorf("error determining remote addr: %w", err)
 	}
 
 	str, err := sess.OpenStreamSync(ctx)


### PR DESCRIPTION
It seems like a bug that `wssConn.RemoteMultiaddr()` doesn't contain the TLS or SNI components (and may also have an over-resolved domain name, but haven't tested that yet) and shows a much simpler multiaddr.

Context: I noticed the domain names of wss addresses were not showing up in the https://check.ipfs.network tool due to https://github.com/ipfs/ipfs-check/blob/b35461c0ac6dda2f32efceec52f2559f4c105bc4/daemon.go#L256

If this is buggy behavior it seems like this can be fixed in the websocket conn type, should a generic test for this be added to the transport suite?