### PR TITLE
feat: core/transport: Add SkipResolver interface

### DIFF
--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -85,6 +85,16 @@ type Resolver interface {
 	Resolve(ctx context.Context, maddr ma.Multiaddr) ([]ma.Multiaddr, error)
 }
 
+// SkipResolver can be optionally implemented by transports that don't want to
+// resolve or transform the multiaddr. Useful for transports that wrap other
+// transports. This lets the inner transport specify how a multiaddr is
+// resolved later.
+// Also useful in cases where the transport doesn't need a resolved address to
+// dial.
+type SkipResolver interface {
+	SkipResolve(ctx context.Context, maddr ma.Multiaddr) bool
+}
+
 // Listener is an interface closely resembling the net.Listener interface. The
 // only real difference is that Accept() returns Conn's of the type in this
 // package, and also exposes a Multiaddr method as opposed to a regular Addr

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -50,6 +50,10 @@ type CapableConn interface {
 // shutdown. NOTE: `Dial` and `Listen` may be called after or concurrently with
 // `Close`.
 //
+// In addition to the Transport interface, transports may implement
+// Resolver or SkipResolver interface. When wrapping/embedding a transport, you should
+// ensure that the Resolver/SkipResolver interface is handled correctly.
+//
 // For a conceptual overview, see https://docs.libp2p.io/concepts/transport/
 type Transport interface {
 	// Dial dials a remote peer. It should try to reuse local listener
@@ -86,11 +90,9 @@ type Resolver interface {
 }
 
 // SkipResolver can be optionally implemented by transports that don't want to
-// resolve or transform the multiaddr. Useful for transports that wrap other
-// transports. This lets the inner transport specify how a multiaddr is
-// resolved later.
-// Also useful in cases where the transport doesn't need a resolved address to
-// dial.
+// resolve or transform the multiaddr. Useful for transports that indirectly
+// wrap other transports (e.g. p2p-circuit). This lets the inner transport
+// specify how a multiaddr is resolved later.
 type SkipResolver interface {
 	SkipResolve(ctx context.Context, maddr ma.Multiaddr) bool
 }

--- a/p2p/protocol/circuitv2/client/transport.go
+++ b/p2p/protocol/circuitv2/client/transport.go
@@ -46,6 +46,10 @@ func AddTransport(h host.Host, upgrader transport.Upgrader) error {
 
 // Transport interface
 var _ transport.Transport = (*Client)(nil)
+
+// p2p-circuit implements the SkipResolver interface so that the underlying
+// transport can do the address resolution later. If you wrap this transport,
+// make sure you also implement SkipResolver as well.
 var _ transport.SkipResolver = (*Client)(nil)
 var _ io.Closer = (*Client)(nil)
 

--- a/p2p/protocol/circuitv2/client/transport.go
+++ b/p2p/protocol/circuitv2/client/transport.go
@@ -46,7 +46,15 @@ func AddTransport(h host.Host, upgrader transport.Upgrader) error {
 
 // Transport interface
 var _ transport.Transport = (*Client)(nil)
+var _ transport.SkipResolver = (*Client)(nil)
 var _ io.Closer = (*Client)(nil)
+
+// SkipResolve returns true since we always defer to the inner transport for
+// the actual connection. By skipping resolution here, we let the inner
+// transport decide how to resolve the multiaddr
+func (c *Client) SkipResolve(ctx context.Context, maddr ma.Multiaddr) bool {
+	return true
+}
 
 func (c *Client) Dial(ctx context.Context, a ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
 	connScope, err := c.host.Network().ResourceManager().OpenConnection(network.DirOutbound, false, a)

--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -224,7 +225,13 @@ func (r *Relay) handleReserve(s network.Stream) pbv2.Status {
 	// Delivery of the reservation might fail for a number of reasons.
 	// For example, the stream might be reset or the connection might be closed before the reservation is received.
 	// In that case, the reservation will just be garbage collected later.
-	if err := r.writeResponse(s, pbv2.Status_OK, r.makeReservationMsg(p, expire), r.makeLimitMsg(p)); err != nil {
+	rsvp := makeReservationMsg(
+		r.host.Peerstore().PrivKey(r.host.ID()),
+		r.host.ID(),
+		r.host.Addrs(),
+		p,
+		expire)
+	if err := r.writeResponse(s, pbv2.Status_OK, rsvp, r.makeLimitMsg(p)); err != nil {
 		log.Debugf("error writing reservation response; retracting reservation for %s", p)
 		s.Reset()
 		return pbv2.Status_CONNECTION_FAILED
@@ -567,31 +574,54 @@ func (r *Relay) writeResponse(s network.Stream, status pbv2.Status, rsvp *pbv2.R
 	return wr.WriteMsg(&msg)
 }
 
-func (r *Relay) makeReservationMsg(p peer.ID, expire time.Time) *pbv2.Reservation {
+func makeReservationMsg(
+	signingKey crypto.PrivKey,
+	selfID peer.ID,
+	selfAddrs []ma.Multiaddr,
+	p peer.ID,
+	expire time.Time,
+) *pbv2.Reservation {
 	expireUnix := uint64(expire.Unix())
 
+	rsvp := &pbv2.Reservation{Expire: &expireUnix}
+
+	selfP2PAddr, err := ma.NewComponent("p2p", selfID.String())
+	if err != nil {
+		log.Errorf("error creating p2p component: %s", err)
+		return rsvp
+	}
+
 	var addrBytes [][]byte
-	for _, addr := range r.host.Addrs() {
+	for _, addr := range selfAddrs {
 		if !manet.IsPublicAddr(addr) {
 			continue
 		}
 
-		addr = addr.Encapsulate(r.selfAddr)
+		id, _ := peer.IDFromP2PAddr(addr)
+		switch {
+		case id == "":
+			// No ID, we'll add one to the address
+			addr = addr.Encapsulate(selfP2PAddr)
+		case id == selfID:
+		// This address already has our ID in it.
+		// Do nothing
+		case id != selfID:
+			// This address has a different ID in it. Skip it.
+			log.Warnf("skipping address %s: contains an unexpected ID", addr)
+			continue
+		}
 		addrBytes = append(addrBytes, addr.Bytes())
 	}
 
-	rsvp := &pbv2.Reservation{
-		Expire: &expireUnix,
-		Addrs:  addrBytes,
-	}
+	rsvp.Addrs = addrBytes
 
 	voucher := &proto.ReservationVoucher{
-		Relay:      r.host.ID(),
+		Relay:      selfID,
 		Peer:       p,
 		Expiration: expire,
 	}
 
-	envelope, err := record.Seal(voucher, r.host.Peerstore().PrivKey(r.host.ID()))
+	envelope, err := record.Seal(voucher, signingKey)
 	if err != nil {
 		log.Errorf("error sealing voucher for %s: %s", p, err)
 		return rsvp

--- a/p2p/protocol/circuitv2/relay/relay_priv_test.go
+++ b/p2p/protocol/circuitv2/relay/relay_priv_test.go
@@ -1,0 +1,53 @@
+package relay
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func genKeyAndID(t *testing.T) (crypto.PrivKey, peer.ID) {
+	t.Helper()
+	key, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	id, err := peer.IDFromPrivateKey(key)
+	require.NoError(t, err)
+	return key, id
+}
+
+// TestMakeReservationWithP2PAddrs ensures that our reservation message builder
+// sanitizes the input addresses
+func TestMakeReservationWithP2PAddrs(t *testing.T) {
+	selfKey, selfID := genKeyAndID(t)
+	_, otherID := genKeyAndID(t)
+	_, reserverID := genKeyAndID(t)
+
+	addrs := []ma.Multiaddr{
+		ma.StringCast("/ip4/1.2.3.4/tcp/1234"),                         // No p2p part
+		ma.StringCast("/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String()),  // Already has p2p part
+		ma.StringCast("/ip4/1.2.3.4/tcp/1236/p2p/" + otherID.String()), // Some other peer (?? Not expected, but we could get anything in this func)
+	}
+
+	rsvp := makeReservationMsg(selfKey, selfID, addrs, reserverID, time.Now().Add(time.Minute))
+	require.NotNil(t, rsvp)
+
+	expectedAddrs := []string{
+		"/ip4/1.2.3.4/tcp/1234/p2p/" + selfID.String(),
+		"/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String(),
+	}
+
+	var addrsFromRsvp []string
+	for _, addr := range rsvp.GetAddrs() {
+		a, err := ma.NewMultiaddrBytes(addr)
+		require.NoError(t, err)
+		addrsFromRsvp = append(addrsFromRsvp, a.String())
+	}
+
+	require.Equal(t, expectedAddrs, addrsFromRsvp)
+}


### PR DESCRIPTION
Fixes an issue where the implied SNI is dropped when connecting over a p2p-circuit address. For example if you connected to a peer over `/dns/example.com/wss/p2p/qmFoo/p2p-circuit/p2p/qmTarget` the swarm would resolve example.com without preserving the SNI information needed for `WSS`. The WebSocket transport would only get the IP address of example.com without knowning the host name it needed to use for the SNI.

We had the same problem previously when dialing a wss address. See https://github.com/libp2p/go-libp2p/issues/1597. This was fixed by letting transports resolve the multiaddr instead of the swarm. This case is similar, except that we want to tell the swarm to just skip resolving altogether since the inner transport will resolve the multiaddr later.