### PR TITLE
chore: Simple modification of hard-to-read logs

### DIFF
--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -131,7 +131,10 @@ func (l *listener) handleIncoming() {
 				return
 			}
 
-			log.Debugf("listener %s accepted connection: %s", l, conn)
+			log.Debugf("listener %s accepted connection: %s <---> %s",
+				l,
+				conn.LocalMultiaddr(),
+				conn.RemoteMultiaddr())
 
 			// This records the fact that the connection has been
 			// setup and is waiting to be accepted. This call


### PR DESCRIPTION
The accepted log of the existing `upgrader` module felt a little messy

```
{"level":"debug","ts":"2024-09-06T02:23:14.218Z","logger":"upgrader","caller":"upgrader/listener.go:134","msg":"listener <stream.Listener[TCP] /ip4/10.10.23.38/tcp/20000> accepted connection: <stream.Conn[TCP] /ip4/10.10.23.38/tcp/20000 (12D3KooW9wSGpoaE6CUNSnBpczCWa4H2up12ZG45soDqYU7MPAsc) <-> /ip4/10.10.22.253/tcp/20000 (12D3KooWBLtMMiRVPvULTeQCbhX8FDAGGPqT2o4T7EZbgaumyXu2)>"}
```

```
{"level":"debug","ts":"2024-10-09T11:56:51.750+0900","logger":"upgrader","caller":"upgrader/listener.go:134","msg":"listener <stream.Listener[TCP] /ip4/0.0.0.0/tcp/35045> accepted connection: /ip4/127.0.0.1/tcp/35045 <---> /ip4/127.0.0.1/tcp/44703"}
```

I modified the log in a form similar to what other `upgrader` modules' logs take.

![image](https://github.com/user-attachments/assets/595036d1-1106-499c-b596-e1a381cc1c38)
- Some look of the results I ran locally. Tidier to look at.