### PR TITLE
reorder fields to reduce size of objects

### DIFF
--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -348,6 +348,12 @@ func (l *ResourceLimits) Build(defaults Limit) BaseLimit {
 }
 
 type PartialLimitConfig struct {
+	Service      map[string]ResourceLimits `json:",omitempty"`
+	ServicePeer  map[string]ResourceLimits `json:",omitempty"`
+	Protocol     map[protocol.ID]ResourceLimits `json:",omitempty"`
+	ProtocolPeer map[protocol.ID]ResourceLimits `json:",omitempty"`
+	Peer         map[peer.ID]ResourceLimits `json:",omitempty"`
+
 	System    ResourceLimits `json:",omitempty"`
 	Transient ResourceLimits `json:",omitempty"`
 
@@ -358,19 +364,14 @@ type PartialLimitConfig struct {
 	AllowlistedTransient ResourceLimits `json:",omitempty"`
 
 	ServiceDefault ResourceLimits            `json:",omitempty"`
-	Service        map[string]ResourceLimits `json:",omitempty"`
 
 	ServicePeerDefault ResourceLimits            `json:",omitempty"`
-	ServicePeer        map[string]ResourceLimits `json:",omitempty"`
 
 	ProtocolDefault ResourceLimits                 `json:",omitempty"`
-	Protocol        map[protocol.ID]ResourceLimits `json:",omitempty"`
 
 	ProtocolPeerDefault ResourceLimits                 `json:",omitempty"`
-	ProtocolPeer        map[protocol.ID]ResourceLimits `json:",omitempty"`
 
 	PeerDefault ResourceLimits             `json:",omitempty"`
-	Peer        map[peer.ID]ResourceLimits `json:",omitempty"`
 
 	Conn   ResourceLimits `json:",omitempty"`
 	Stream ResourceLimits `json:",omitempty"`
@@ -513,6 +514,12 @@ func buildMapWithDefault[K comparable](definedLimits map[K]ResourceLimits, defau
 // There is no unset "default" value. Commonly constructed by calling
 // PartialLimitConfig.Build(rcmgr.DefaultLimits.AutoScale())
 type ConcreteLimitConfig struct {
+	service      map[string]BaseLimit
+	servicePeer  map[string]BaseLimit
+	protocol     map[protocol.ID]BaseLimit
+	protocolPeer map[protocol.ID]BaseLimit
+	peer         map[peer.ID]BaseLimit
+
 	system    BaseLimit
 	transient BaseLimit
 
@@ -523,19 +530,14 @@ type ConcreteLimitConfig struct {
 	allowlistedTransient BaseLimit
 
 	serviceDefault BaseLimit
-	service        map[string]BaseLimit
 
 	servicePeerDefault BaseLimit
-	servicePeer        map[string]BaseLimit
 
 	protocolDefault BaseLimit
-	protocol        map[protocol.ID]BaseLimit
 
 	protocolPeerDefault BaseLimit
-	protocolPeer        map[protocol.ID]BaseLimit
 
 	peerDefault BaseLimit
-	peer        map[peer.ID]BaseLimit
 
 	conn   BaseLimit
 	stream BaseLimit

--- a/p2p/host/resource-manager/limit_defaults.go
+++ b/p2p/host/resource-manager/limit_defaults.go
@@ -22,6 +22,12 @@ type baseLimitConfig struct {
 // {}BaseLimit is the limits that Apply for a minimal node (128 MB of memory for libp2p) and 256 file descriptors.
 // {}LimitIncrease is the additional limit granted for every additional 1 GB of RAM.
 type ScalingLimitConfig struct {
+	ServiceLimits       map[string]baseLimitConfig // use AddServiceLimit to modify
+	ServicePeerLimits   map[string]baseLimitConfig // use AddServicePeerLimit to modify
+	ProtocolLimits      map[protocol.ID]baseLimitConfig // use AddProtocolLimit to modify
+	ProtocolPeerLimits  map[protocol.ID]baseLimitConfig // use AddProtocolPeerLimit to modify
+	PeerLimits          map[peer.ID]baseLimitConfig // use AddPeerLimit to modify
+
 	SystemBaseLimit     BaseLimit
 	SystemLimitIncrease BaseLimitIncrease
 
@@ -36,23 +42,18 @@ type ScalingLimitConfig struct {
 
 	ServiceBaseLimit     BaseLimit
 	ServiceLimitIncrease BaseLimitIncrease
-	ServiceLimits        map[string]baseLimitConfig // use AddServiceLimit to modify
 
 	ServicePeerBaseLimit     BaseLimit
 	ServicePeerLimitIncrease BaseLimitIncrease
-	ServicePeerLimits        map[string]baseLimitConfig // use AddServicePeerLimit to modify
 
 	ProtocolBaseLimit     BaseLimit
 	ProtocolLimitIncrease BaseLimitIncrease
-	ProtocolLimits        map[protocol.ID]baseLimitConfig // use AddProtocolLimit to modify
 
 	ProtocolPeerBaseLimit     BaseLimit
 	ProtocolPeerLimitIncrease BaseLimitIncrease
-	ProtocolPeerLimits        map[protocol.ID]baseLimitConfig // use AddProtocolPeerLimit to modify
 
 	PeerBaseLimit     BaseLimit
 	PeerLimitIncrease BaseLimitIncrease
-	PeerLimits        map[peer.ID]baseLimitConfig // use AddPeerLimit to modify
 
 	ConnBaseLimit     BaseLimit
 	ConnLimitIncrease BaseLimitIncrease

--- a/p2p/http/auth/internal/handshake/server.go
+++ b/p2p/http/auth/internal/handshake/server.go
@@ -84,20 +84,19 @@ func (o *opaqueState) Unmarshal(hmacImpl hash.Hash, d []byte) error {
 }
 
 type PeerIDAuthHandshakeServer struct {
-	buf [1024]byte
 	opaque opaqueState
-
-	Hostname string
 	PrivKey  crypto.PrivKey
-	TokenTTL time.Duration
 	// used to authenticate opaque blobs and tokens
 	Hmac hash.Hash
-
-	ran bool
-
-	state peerIDAuthServerState
+	Hostname string
 	p     params
 	hb    headerBuilder
+
+	TokenTTL time.Duration
+
+	state peerIDAuthServerState
+	buf [1024]byte
+	ran bool
 }
 
 var errInvalidHeader = errors.New("invalid header")

--- a/p2p/http/auth/internal/handshake/server.go
+++ b/p2p/http/auth/internal/handshake/server.go
@@ -84,6 +84,9 @@ func (o *opaqueState) Unmarshal(hmacImpl hash.Hash, d []byte) error {
 }
 
 type PeerIDAuthHandshakeServer struct {
+	buf [1024]byte
+	opaque opaqueState
+
 	Hostname string
 	PrivKey  crypto.PrivKey
 	TokenTTL time.Duration
@@ -91,13 +94,10 @@ type PeerIDAuthHandshakeServer struct {
 	Hmac hash.Hash
 
 	ran bool
-	buf [1024]byte
 
 	state peerIDAuthServerState
 	p     params
 	hb    headerBuilder
-
-	opaque opaqueState
 }
 
 var errInvalidHeader = errors.New("invalid header")


### PR DESCRIPTION
This PR re-orders some fields in structs in order to reduce the size in bytes that the struct takes up in memory. Go is sensitive to the exact ordering of fields. I have not done any extensive profiling to see if this change makes a significant difference of memory usage at runtime, but this change is not harmful (unless you consider the ordering of fields useful for documentation purposes).

https://golangprojectstructure.com/how-to-make-go-structs-more-efficient/
https://go101.org/article/memory-layout.html

A tool exists, as noted in the first blog post link, that can find inefficient orderings of fields and provide the correct order.

https://cs.opensource.google/go/x/tools/+/refs/tags/v0.26.0:go/analysis/passes/fieldalignment/cmd/fieldalignment/main.go

```
$ ~/go/bin/fieldalignment ./...
```

I ran this tool on all the code in go-libp2p and fixed the 4 highest offenders.
Before:
```
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/scope.go:33:20: size is 160 but could be 80 diff=80
/home/ubuntu/kazzmir-go-libp2p/p2p/net/connmgr/connmgr.go:29:19: size is 2240 but could be 2152 diff=88
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/extapi.go:30:26: size is 120 but could be 24 diff=96
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/limit_defaults.go:349:25: size is 616 but could be 40 diff=576
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/limit_defaults.go:514:26: size is 616 but could be 40 diff=576
/home/ubuntu/kazzmir-go-libp2p/p2p/http/auth/internal/handshake/server.go:86:32: size is 1384 but could be 312 diff=1072
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/limit_defaults.go:24:25: size is 1192 but could be 40 diff=1152

```

After:
```
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/scope.go:33:20: size is 160 but could be 80 diff=80
/home/ubuntu/kazzmir-go-libp2p/p2p/net/connmgr/connmgr.go:29:19: size is 2240 but could be 2152 diff=88
/home/ubuntu/kazzmir-go-libp2p/p2p/host/resource-manager/extapi.go:30:26: size is 120 but could be 24 diff=96
```

Note that there are many more structs to fix, but the savings is moderate for them (under 100 bytes of savings for each struct).