### PR TITLE
fix: basichost: Use NegotiationTimeout as fallback timeout for NewStream

### DIFF
--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -965,7 +965,8 @@ func TestHostTimeoutNewStream(t *testing.T) {
 		assert.NoError(t, err)
 
 		msgLen, varintN := binary.Uvarint(buf[:n])
-		proto := buf[varintN : varintN+int(msgLen)]
+		buf = buf[varintN:]
+		proto := buf[:int(msgLen)]
 		if string(proto) == "/ipfs/id/1.0.0\n" {
 			// Signal we don't support identify
 			na := []byte("na\n")
@@ -977,15 +978,16 @@ func TestHostTimeoutNewStream(t *testing.T) {
 		} else {
 			// Stall
 			time.Sleep(5 * time.Second)
-			t.Log("Resetting")
 		}
+		t.Log("Resetting")
 		s.Reset()
 	})
 
-	h1.Connect(context.Background(), peer.AddrInfo{
+	err = h1.Connect(context.Background(), peer.AddrInfo{
 		ID:    h2.LocalPeer(),
 		Addrs: h2.ListenAddresses(),
 	})
+	require.NoError(t, err)
 
 	// No context passed in, fallback to negtimeout
 	h1.negtimeout = time.Second

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -2,6 +2,7 @@ package basichost
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"reflect"
@@ -940,4 +941,55 @@ func TestTrimHostAddrList(t *testing.T) {
 			require.ElementsMatch(t, got, tc.out)
 		})
 	}
+}
+
+func TestHostTimeoutNewStream(t *testing.T) {
+	h1, err := NewHost(swarmt.GenSwarm(t), nil)
+	require.NoError(t, err)
+	h1.Start()
+	defer h1.Close()
+
+	const proto = "/testing"
+	h2 := swarmt.GenSwarm(t)
+
+	h2.SetStreamHandler(func(s network.Stream) {
+		// First message is multistream header. Just echo it
+		msHeader := []byte("\x19/multistream/1.0.0\n")
+		_, err := s.Read(msHeader)
+		assert.NoError(t, err)
+		_, err = s.Write(msHeader)
+		assert.NoError(t, err)
+
+		buf := make([]byte, 1024)
+		n, err := s.Read(buf)
+		assert.NoError(t, err)
+
+		msgLen, varintN := binary.Uvarint(buf[:n])
+		proto := buf[varintN : varintN+int(msgLen)]
+		if string(proto) == "/ipfs/id/1.0.0\n" {
+			// Signal we don't support identify
+			na := []byte("na\n")
+			n := binary.PutUvarint(buf, uint64(len(na)))
+			copy(buf[n:], na)
+
+			_, err = s.Write(buf[:int(n)+len(na)])
+			assert.NoError(t, err)
+		} else {
+			// Stall
+			time.Sleep(5 * time.Second)
+			t.Log("Resetting")
+		}
+		s.Reset()
+	})
+
+	h1.Connect(context.Background(), peer.AddrInfo{
+		ID:    h2.LocalPeer(),
+		Addrs: h2.ListenAddresses(),
+	})
+
+	// No context passed in, fallback to negtimeout
+	h1.negtimeout = time.Second
+	_, err = h1.NewStream(context.Background(), h2.LocalPeer(), proto)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "context deadline exceeded")
 }


### PR DESCRIPTION
in case no timeout was provided via context.

Closes #3019 