### PR TITLE
fix: GenerateSecp256k1Key use src as seed

### DIFF
--- a/core/crypto/secp256k1.go
+++ b/core/crypto/secp256k1.go
@@ -20,7 +20,7 @@ type Secp256k1PublicKey secp256k1.PublicKey
 
 // GenerateSecp256k1Key generates a new Secp256k1 private and public key pair
 func GenerateSecp256k1Key(src io.Reader) (PrivKey, PubKey, error) {
-	privk, err := secp256k1.GeneratePrivateKey()
+	privk, err := secp256k1.GeneratePrivateKeyFromRand(src)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
I think `GeneratePrivateKeyFromRand` was not available before, so it was not passed.