### PR TITLE
fix: identify: Clean up peer metadata

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -1045,7 +1045,7 @@ func (nn *netNotifiee) Disconnected(_ network.Network, c network.Conn) {
 	addrs := ids.Host.Peerstore().Addrs(c.RemotePeer())
 	n := len(addrs)
 	if n > recentlyConnectedPeerMaxAddrs {
-		// We want to always save the address we are connected to
+		// We want to always save the address we were connected to
 		for i, a := range addrs {
 			if a.Equal(c.RemoteMultiaddr()) {
 				addrs[i], addrs[0] = addrs[0], addrs[i]
@@ -1056,6 +1056,9 @@ func (nn *netNotifiee) Disconnected(_ network.Network, c network.Conn) {
 	ids.Host.Peerstore().UpdateAddrs(c.RemotePeer(), peerstore.ConnectedAddrTTL, peerstore.TempAddrTTL)
 	ids.Host.Peerstore().AddAddrs(c.RemotePeer(), addrs[:n], peerstore.RecentlyConnectedAddrTTL)
 	ids.Host.Peerstore().UpdateAddrs(c.RemotePeer(), peerstore.TempAddrTTL, 0)
+
+	// Clear the metadata we stored earlier.
+	ids.Host.Peerstore().RemovePeer(c.RemotePeer())
 }
 
 func (nn *netNotifiee) Listen(n network.Network, a ma.Multiaddr)      {}

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -1056,9 +1056,6 @@ func (nn *netNotifiee) Disconnected(_ network.Network, c network.Conn) {
 	ids.Host.Peerstore().UpdateAddrs(c.RemotePeer(), peerstore.ConnectedAddrTTL, peerstore.TempAddrTTL)
 	ids.Host.Peerstore().AddAddrs(c.RemotePeer(), addrs[:n], peerstore.RecentlyConnectedAddrTTL)
 	ids.Host.Peerstore().UpdateAddrs(c.RemotePeer(), peerstore.TempAddrTTL, 0)
-
-	// Clear the metadata we stored earlier.
-	ids.Host.Peerstore().RemovePeer(c.RemotePeer())
 }
 
 func (nn *netNotifiee) Listen(n network.Network, a ma.Multiaddr)      {}

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -215,6 +215,22 @@ func TestIDService(t *testing.T) {
 			testKnowsAddrs(t, h1, h2p, []ma.Multiaddr{})
 			testKnowsAddrs(t, h2, h1p, []ma.Multiaddr{})
 
+			// Assert that we have cleaned up metadata from the peerstore
+			ps1 := h1.Peerstore()
+			ps2 := h2.Peerstore()
+			type peerstoreAndPeerID struct {
+				peerstore peerstore.Peerstore
+				peerID    peer.ID
+			}
+			for _, psAndID := range []peerstoreAndPeerID{{ps1, h2p}, {ps2, h1p}} {
+				ps := psAndID.peerstore
+				p := psAndID.peerID
+				_, err = ps.Get(p, "AgentVersion")
+				require.ErrorIs(t, err, peerstore.ErrNotFound)
+				_, err = ps.Get(p, "ProtocolVersion")
+				require.ErrorIs(t, err, peerstore.ErrNotFound)
+			}
+
 			// test that we received the "identify completed" event.
 			select {
 			case evtAny := <-sub.Out():


### PR DESCRIPTION
On disconnect, we should clean up the AgentVersion and ProtocolVersion