### PR TITLE
feat: eventbus: log error on slow consumers

### DIFF
--- a/p2p/host/eventbus/basic.go
+++ b/p2p/host/eventbus/basic.go
@@ -383,7 +383,12 @@ func (n *wildcardNode) emit(evt interface{}) {
 		select {
 		case sink.ch <- evt:
 		default:
-			n.slowConsumerTimer = emitAndLogError(n.slowConsumerTimer, wildcardType, evt, sink)
+			slowConsumerTimer := emitAndLogError(n.slowConsumerTimer, wildcardType, evt, sink)
+			defer func() {
+				n.Lock()
+				n.slowConsumerTimer = slowConsumerTimer
+				n.Unlock()
+			}()
 		}
 	}
 	n.RUnlock()

--- a/p2p/host/eventbus/basic.go
+++ b/p2p/host/eventbus/basic.go
@@ -348,6 +348,12 @@ func (n *wildcardNode) addSink(sink *namedSink) {
 }
 
 func (n *wildcardNode) removeSink(ch chan interface{}) {
+	go func() {
+		// drain the event channel, will return when closed and drained.
+		// this is necessary to unblock publishes to this channel.
+		for range ch {
+		}
+	}()
 	n.nSinks.Add(-1) // ok to do outside the lock
 	n.Lock()
 	for i := 0; i < len(n.sinks); i++ {

--- a/p2p/host/eventbus/basic_test.go
+++ b/p2p/host/eventbus/basic_test.go
@@ -150,6 +150,12 @@ func (m *mockLogger) Logs() []string {
 	return m.logs
 }
 
+func (m *mockLogger) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = nil
+}
+
 func TestEmitLogsErrorOnStall(t *testing.T) {
 	oldLogger := log
 	defer func() {
@@ -158,38 +164,52 @@ func TestEmitLogsErrorOnStall(t *testing.T) {
 	ml := &mockLogger{}
 	log = ml
 
-	bus := NewBus()
-	sub, err := bus.Subscribe(new(EventA))
+	bus1 := NewBus()
+	bus2 := NewBus()
+
+	eventSub, err := bus1.Subscribe(new(EventA))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	em, err := bus.Emitter(new(EventA))
+	wildcardSub, err := bus2.Subscribe(event.WildcardSubscription)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer em.Close()
 
-	go func() {
-		for i := 0; i < subSettingsDefault.buffer+2; i++ {
-			em.Emit(EventA{})
+	testCases := []event.Subscription{eventSub, wildcardSub}
+	eventBuses := []event.Bus{bus1, bus2}
+
+	for i, sub := range testCases {
+		bus := eventBuses[i]
+		em, err := bus.Emitter(new(EventA))
+		if err != nil {
+			t.Fatal(err)
 		}
-	}()
+		defer em.Close()
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		logs := ml.Logs()
-		found := false
-		for _, log := range logs {
-			if strings.Contains(log, "slow consumer") {
-				found = true
-				break
+		go func() {
+			for i := 0; i < subSettingsDefault.buffer+2; i++ {
+				em.Emit(EventA{})
 			}
-		}
-		assert.True(collect, found, "expected to find slow consumer log")
-	}, 3*time.Second, 500*time.Millisecond)
+		}()
 
-	// Close the subscriber so the worker can finish.
-	sub.Close()
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			logs := ml.Logs()
+			found := false
+			for _, log := range logs {
+				if strings.Contains(log, "slow consumer") {
+					found = true
+					break
+				}
+			}
+			assert.True(collect, found, "expected to find slow consumer log")
+		}, 3*time.Second, 500*time.Millisecond)
+		ml.Clear()
+
+		// Close the subscriber so the worker can finish.
+		sub.Close()
+	}
 }
 
 func TestEmitOnClosed(t *testing.T) {


### PR DESCRIPTION
Slow consumers can stall libp2p in hard to debug ways. For example, a slow consumer of Identify events can prevent NewStreams from opening. In some cases we do want this back-pressure, but in other cases it is a bug in the user's application (or even in go-libp2p). The recommended approach has been to use metrics with Grafana and Prometheus to identify these issues. In practice, that's been a non-trivial task for users to setup. A simple log would help identify these issues.

Note that the codepath is relatively unchanged in the normal case. Only if a producer is stalled will the extra work be put in.

Closes #2361 . See my comment https://github.com/libp2p/go-libp2p/issues/2983#issuecomment-2463270292 for why this is brought up again.

@vyzo Could you please try to repro your issue on this branch?