### PR TITLE
fix: identify: push should not dial a new connection

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -347,6 +347,10 @@ func (ids *idService) sendPushes(ctx context.Context) {
 			defer func() { <-sem }()
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
+
+			// We only want to send an identify push if we already have an open
+			// connection.
+			ctx = network.WithNoDial(ctx, "id push")
 			str, err := ids.Host.NewStream(ctx, c.RemotePeer(), IDPush)
 			if err != nil { // connection might have been closed recently
 				return


### PR DESCRIPTION
There a small window after a peer disconnects, but before identify has updated its conn map that would cause the host to dial a peer in order to send a push message. This prevents that