### PR TITLE
fix(tcpreuse): handle connection that failed to be sampled

### DIFF
--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -48,27 +48,27 @@ func identifyConnType(c manet.Conn) (DemultiplexedConnType, manet.Conn, error) {
 		return 0, nil, errors.Join(err, closeErr)
 	}
 
-	s, peekableConn, err := sampledconn.PeekBytes(c)
+	s, peekedConn, err := sampledconn.PeekBytes(c)
 	if err != nil {
 		closeErr := c.Close()
 		return 0, nil, errors.Join(err, closeErr)
 	}
 
-	if err := peekableConn.SetReadDeadline(time.Time{}); err != nil {
-		closeErr := peekableConn.Close()
+	if err := peekedConn.SetReadDeadline(time.Time{}); err != nil {
+		closeErr := peekedConn.Close()
 		return 0, nil, errors.Join(err, closeErr)
 	}
 
 	if IsMultistreamSelect(s) {
-		return DemultiplexedConnType_MultistreamSelect, peekableConn, nil
+		return DemultiplexedConnType_MultistreamSelect, peekedConn, nil
 	}
 	if IsTLS(s) {
-		return DemultiplexedConnType_TLS, peekableConn, nil
+		return DemultiplexedConnType_TLS, peekedConn, nil
 	}
 	if IsHTTP(s) {
-		return DemultiplexedConnType_HTTP, peekableConn, nil
+		return DemultiplexedConnType_HTTP, peekedConn, nil
 	}
-	return DemultiplexedConnType_Unknown, peekableConn, nil
+	return DemultiplexedConnType_Unknown, peekedConn, nil
 }
 
 // Matchers are implemented here instead of in the transports so we can easily fuzz them together.

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -9,9 +9,11 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-// This is reading the first 3 bytes of the packet. It should be instant.
+// This is reading the first 3 bytes of the first packet after the handshake.
+// It's set to the default TCP connect timeout in the TCP Transport.
+//
 // A var so we can change it in tests.
-var identifyConnTimeout = 1 * time.Second
+var identifyConnTimeout = 5 * time.Second
 
 type DemultiplexedConnType int
 

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -9,8 +9,9 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-// This is readiung the first 3 bytes of the packet. It should be instant.
-const identifyConnTimeout = 1 * time.Second
+// This is reading the first 3 bytes of the packet. It should be instant.
+// A var so we can change it in tests.
+var identifyConnTimeout = 1 * time.Second
 
 type DemultiplexedConnType int
 

--- a/p2p/transport/tcpreuse/listener.go
+++ b/p2p/transport/tcpreuse/listener.go
@@ -231,8 +231,6 @@ func (m *multiplexedListener) run() error {
 			t, c, err := identifyConnType(c)
 			if err != nil {
 				connScope.Done()
-				closeErr := c.Close()
-				err = errors.Join(err, closeErr)
 				log.Debugf("error demultiplexing connection: %s", err.Error())
 				return
 			}


### PR DESCRIPTION
There was an oversight here in the error reporting. A test should be added, but also probably this should've been caught by automated tooling (e.g. one of the linters), maybe there are more we should be enabling.