### PR TITLE
fix: Defer resource usage cleanup until the very end

### DIFF
--- a/p2p/protocol/circuitv2/relay/relay.go
+++ b/p2p/protocol/circuitv2/relay/relay.go
@@ -118,7 +118,7 @@ func (r *Relay) Close() error {
 
 		r.host.RemoveStreamHandler(proto.ProtoIDv2Hop)
 		r.host.Network().StopNotify(r.notifiee)
-		r.scope.Done()
+		defer r.scope.Done()
 		r.cancel()
 		r.gc()
 		if r.metricsTracer != nil {
@@ -315,7 +315,7 @@ func (r *Relay) handleConnect(s network.Stream, msg *pbv2.HopMessage) pbv2.Statu
 	connStTime := time.Now()
 
 	cleanup := func() {
-		span.Done()
+		defer span.Done()
 		r.mx.Lock()
 		r.rmConn(src)
 		r.rmConn(dest.ID)

--- a/p2p/transport/webtransport/conn.go
+++ b/p2p/transport/webtransport/conn.go
@@ -71,7 +71,7 @@ func (c *conn) allowWindowIncrease(size uint64) bool {
 // It must be called even if the peer closed the connection in order for
 // garbage collection to properly work in this package.
 func (c *conn) Close() error {
-	c.scope.Done()
+	defer c.scope.Done()
 	c.transport.removeConn(c.session)
 	err := c.session.CloseWithError(0, "")
 	_ = c.qconn.CloseWithError(1, "")


### PR DESCRIPTION
There is a slight race condition when resource accounting the closed connection. We should update the state in the resource manager _after_ the connection is closed.

We do this correctly everywhere else. These are the exceptions.