### PR TITLE
fix(dcutr): Fix end to end tests and add legacy behavior flag (default=true)

### DIFF
--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -97,9 +97,9 @@ func New(h host.Host, options ...Option) (AutoNAT, error) {
 		service.Enable()
 	}
 
-	// Emit initial reachability event
-	_ = emitReachabilityChanged.Emit(event.EvtLocalReachabilityChanged{Reachability: conf.reachability})
 	if conf.forceReachability {
+		emitReachabilityChanged.Emit(event.EvtLocalReachabilityChanged{Reachability: conf.reachability})
+
 		return &StaticAutoNAT{
 			host:         h,
 			reachability: conf.reachability,

--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -2,7 +2,6 @@ package autonat
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"slices"
 	"sync/atomic"

--- a/p2p/host/autonat/autonat.go
+++ b/p2p/host/autonat/autonat.go
@@ -2,6 +2,7 @@ package autonat
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"slices"
 	"sync/atomic"
@@ -97,9 +98,9 @@ func New(h host.Host, options ...Option) (AutoNAT, error) {
 		service.Enable()
 	}
 
+	// Emit initial reachability event
+	_ = emitReachabilityChanged.Emit(event.EvtLocalReachabilityChanged{Reachability: conf.reachability})
 	if conf.forceReachability {
-		emitReachabilityChanged.Emit(event.EvtLocalReachabilityChanged{Reachability: conf.reachability})
-
 		return &StaticAutoNAT{
 			host:         h,
 			reachability: conf.reachability,

--- a/p2p/net/simconn/router.go
+++ b/p2p/net/simconn/router.go
@@ -1,0 +1,120 @@
+package simconn
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"time"
+)
+
+// PerfectRouter is a router that has no latency or jitter and can route to
+// every node
+type PerfectRouter struct {
+	nodes map[net.Addr]*SimConn
+}
+
+// SendPacket implements Router.
+func (r *PerfectRouter) SendPacket(deadline time.Time, p Packet) error {
+	conn, ok := r.nodes[p.To]
+	if !ok {
+		return errors.New("unknown destination")
+	}
+
+	conn.RecvPacket(p)
+	return nil
+}
+
+func (r *PerfectRouter) AddNode(addr net.Addr, conn *SimConn) {
+	r.nodes[addr] = conn
+}
+
+func (r *PerfectRouter) RemoveNode(addr net.Addr) {
+	delete(r.nodes, addr)
+}
+
+var _ Router = &PerfectRouter{}
+
+type FixedLatencyRouter struct {
+	PerfectRouter
+	latency time.Duration
+}
+
+func (r *FixedLatencyRouter) SendPacket(deadline time.Time, p Packet) error {
+	if !deadline.IsZero() {
+		select {
+		case <-time.After(r.latency):
+		case <-time.After(time.Until(deadline)):
+			return ErrDeadlineExceeded
+		}
+	} else {
+		time.Sleep(r.latency)
+	}
+	return r.PerfectRouter.SendPacket(deadline, p)
+}
+
+var _ Router = &FixedLatencyRouter{}
+
+type simpleNodeFirewall struct {
+	mu           sync.Mutex
+	public       bool
+	packetsOutTo map[string]struct{}
+	node         *SimConn
+}
+
+func (f *simpleNodeFirewall) IsPacketInAllowed(p Packet) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.public {
+		return true
+	}
+
+	_, ok := f.packetsOutTo[p.From.String()]
+	return ok
+}
+
+type SimpleFirewallRouter struct {
+	nodes map[net.Addr]*simpleNodeFirewall
+}
+
+func (r *SimpleFirewallRouter) SendPacket(deadline time.Time, p Packet) error {
+	toNode, exists := r.nodes[p.To]
+	if !exists {
+		return errors.New("unknown destination")
+	}
+
+	// Record that this node is sending a packet to the destination
+	fromNode, exists := r.nodes[p.From]
+	if !exists {
+		return errors.New("unknown source")
+	}
+	fromNode.mu.Lock()
+	fromNode.packetsOutTo[p.To.String()] = struct{}{}
+	fromNode.mu.Unlock()
+
+	if !toNode.IsPacketInAllowed(p) {
+		return nil // Silently drop blocked packets
+	}
+
+	toNode.node.RecvPacket(p)
+	return nil
+}
+
+func (r *SimpleFirewallRouter) AddNode(addr net.Addr, conn *SimConn) {
+	r.nodes[addr] = &simpleNodeFirewall{
+		packetsOutTo: make(map[string]struct{}),
+		node:         conn,
+	}
+}
+
+func (r *SimpleFirewallRouter) AddPublicNode(addr net.Addr, conn *SimConn) {
+	r.nodes[addr] = &simpleNodeFirewall{
+		public: true,
+		node:   conn,
+	}
+}
+
+func (r *SimpleFirewallRouter) RemoveNode(addr net.Addr) {
+	delete(r.nodes, addr)
+}
+
+var _ Router = &SimpleFirewallRouter{}

--- a/p2p/net/simconn/router.go
+++ b/p2p/net/simconn/router.go
@@ -20,7 +20,7 @@ type PerfectRouter struct {
 }
 
 // SendPacket implements Router.
-func (r *PerfectRouter) SendPacket(deadline time.Time, p Packet) error {
+func (r *PerfectRouter) SendPacket(p Packet) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	conn, ok := r.nodes[p.To]
@@ -61,12 +61,8 @@ type FixedLatencyRouter struct {
 	latency time.Duration
 }
 
-func (r *FixedLatencyRouter) SendPacket(deadline time.Time, p Packet) error {
-	if !deadline.IsZero() && time.Now().After(deadline) {
-		return ErrDeadlineExceeded
-	}
-
-	return r.PerfectRouter.SendPacket(deadline, p)
+func (r *FixedLatencyRouter) SendPacket(p Packet) error {
+	return r.PerfectRouter.SendPacket(p)
 }
 
 func (r *FixedLatencyRouter) AddNode(addr net.Addr, conn PacketReciever) {
@@ -124,7 +120,7 @@ func (r *SimpleFirewallRouter) String() string {
 	return fmt.Sprintf("%v", nodes)
 }
 
-func (r *SimpleFirewallRouter) SendPacket(deadline time.Time, p Packet) error {
+func (r *SimpleFirewallRouter) SendPacket(p Packet) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	toNode, exists := r.nodes[p.To.String()]

--- a/p2p/net/simconn/router.go
+++ b/p2p/net/simconn/router.go
@@ -126,6 +126,9 @@ func (r *SimpleFirewallRouter) AddNode(addr net.Addr, conn *SimConn) {
 }
 
 func (r *SimpleFirewallRouter) AddPublicNode(addr net.Addr, conn *SimConn) {
+	if r.nodes == nil {
+		r.nodes = make(map[string]*simpleNodeFirewall)
+	}
 	r.nodes[addr.String()] = &simpleNodeFirewall{
 		public: true,
 		node:   conn,

--- a/p2p/net/simconn/router.go
+++ b/p2p/net/simconn/router.go
@@ -11,11 +11,14 @@ import (
 // PerfectRouter is a router that has no latency or jitter and can route to
 // every node
 type PerfectRouter struct {
+	mu    sync.Mutex
 	nodes map[net.Addr]*SimConn
 }
 
 // SendPacket implements Router.
 func (r *PerfectRouter) SendPacket(deadline time.Time, p Packet) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	conn, ok := r.nodes[p.To]
 	if !ok {
 		return errors.New("unknown destination")

--- a/p2p/net/simconn/router.go
+++ b/p2p/net/simconn/router.go
@@ -59,16 +59,16 @@ func (r *FixedLatencyRouter) SendPacket(deadline time.Time, p Packet) error {
 var _ Router = &FixedLatencyRouter{}
 
 type simpleNodeFirewall struct {
-	mu           sync.Mutex
-	public       bool
-	packetsOutTo map[string]struct{}
-	node         *SimConn
+	mu                sync.Mutex
+	publiclyReachable bool
+	packetsOutTo      map[string]struct{}
+	node              *SimConn
 }
 
 func (f *simpleNodeFirewall) IsPacketInAllowed(p Packet) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.public {
+	if f.publiclyReachable {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (f *simpleNodeFirewall) IsPacketInAllowed(p Packet) bool {
 }
 
 func (f *simpleNodeFirewall) String() string {
-	return fmt.Sprintf("public: %v, packetsOutTo: %v", f.public, f.packetsOutTo)
+	return fmt.Sprintf("public: %v, packetsOutTo: %v", f.publiclyReachable, f.packetsOutTo)
 }
 
 type SimpleFirewallRouter struct {
@@ -142,8 +142,8 @@ func (r *SimpleFirewallRouter) AddPublicNode(addr net.Addr, conn *SimConn) {
 		r.nodes = make(map[string]*simpleNodeFirewall)
 	}
 	r.nodes[addr.String()] = &simpleNodeFirewall{
-		public: true,
-		node:   conn,
+		publiclyReachable: true,
+		node:              conn,
 	}
 }
 

--- a/p2p/net/simconn/router.go
+++ b/p2p/net/simconn/router.go
@@ -78,10 +78,13 @@ func (f *simpleNodeFirewall) String() string {
 }
 
 type SimpleFirewallRouter struct {
+	mu    sync.Mutex
 	nodes map[string]*simpleNodeFirewall
 }
 
 func (r *SimpleFirewallRouter) String() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	nodes := make([]string, 0, len(r.nodes))
 	for _, node := range r.nodes {
 		nodes = append(nodes, node.String())
@@ -90,6 +93,8 @@ func (r *SimpleFirewallRouter) String() string {
 }
 
 func (r *SimpleFirewallRouter) SendPacket(deadline time.Time, p Packet) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	toNode, exists := r.nodes[p.To.String()]
 	if !exists {
 		return errors.New("unknown destination")
@@ -116,6 +121,8 @@ func (r *SimpleFirewallRouter) SendPacket(deadline time.Time, p Packet) error {
 }
 
 func (r *SimpleFirewallRouter) AddNode(addr net.Addr, conn *SimConn) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.nodes == nil {
 		r.nodes = make(map[string]*simpleNodeFirewall)
 	}
@@ -126,6 +133,8 @@ func (r *SimpleFirewallRouter) AddNode(addr net.Addr, conn *SimConn) {
 }
 
 func (r *SimpleFirewallRouter) AddPublicNode(addr net.Addr, conn *SimConn) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.nodes == nil {
 		r.nodes = make(map[string]*simpleNodeFirewall)
 	}
@@ -136,6 +145,8 @@ func (r *SimpleFirewallRouter) AddPublicNode(addr net.Addr, conn *SimConn) {
 }
 
 func (r *SimpleFirewallRouter) RemoveNode(addr net.Addr) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.nodes == nil {
 		return
 	}

--- a/p2p/net/simconn/simconn.go
+++ b/p2p/net/simconn/simconn.go
@@ -10,10 +10,6 @@ import (
 
 var ErrDeadlineExceeded = errors.New("deadline exceeded")
 
-type sendPacketer interface {
-	SendPacket(p Packet)
-}
-
 type Router interface {
 	SendPacket(deadline time.Time, p Packet) error
 }
@@ -27,8 +23,6 @@ type Packet struct {
 type SimConn struct {
 	mu     sync.Mutex
 	closed bool
-
-	mtu int
 
 	packetsSent atomic.Uint64
 	packetsRcvd atomic.Uint64

--- a/p2p/net/simconn/simconn.go
+++ b/p2p/net/simconn/simconn.go
@@ -12,7 +12,7 @@ import (
 var ErrDeadlineExceeded = errors.New("deadline exceeded")
 
 type Router interface {
-	SendPacket(deadline time.Time, p Packet) error
+	SendPacket(p Packet) error
 }
 
 type Packet struct {
@@ -158,7 +158,7 @@ func (c *SimConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 		To:   addr,
 		buf:  slices.Clone(p),
 	}
-	return len(p), c.router.SendPacket(deadline, pkt)
+	return len(p), c.router.SendPacket(pkt)
 }
 
 func (c *SimConn) UnicastAddr() net.Addr {

--- a/p2p/net/simconn/simconn.go
+++ b/p2p/net/simconn/simconn.go
@@ -1,0 +1,234 @@
+package simconn
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var ErrDeadlineExceeded = errors.New("deadline exceeded")
+
+type sendPacketer interface {
+	SendPacket(p Packet)
+}
+
+type Router interface {
+	SendPacket(deadline time.Time, p Packet) error
+}
+
+type Packet struct {
+	To   net.Addr
+	From net.Addr
+	buf  []byte
+}
+
+type SimConn struct {
+	mu     sync.Mutex
+	closed bool
+
+	mtu int
+
+	packetsSent atomic.Uint64
+	packetsRcvd atomic.Uint64
+	bytesSent   atomic.Int64
+	bytesRcvd   atomic.Int64
+
+	router Router
+
+	myAddr        *net.UDPAddr
+	myLocalAddr   net.Addr
+	packetsToRead chan Packet
+
+	// In case we don't fully read the packet in ReadFrom, we need to store the current packet
+	currentPacketToRead *Packet
+
+	readDeadline  time.Time
+	writeDeadline time.Time
+}
+
+// NewSimConn creates a new simulated connection with the specified parameters
+func NewSimConn(addr *net.UDPAddr, rtr Router) *SimConn {
+	return &SimConn{
+		router:        rtr,
+		myAddr:        addr,
+		packetsToRead: make(chan Packet, 512), // buffered channel to prevent blocking
+		closed:        false,
+	}
+}
+
+type ConnStats struct {
+	BytesSent   int
+	BytesRcvd   int
+	PacketsSent int
+	PacketsRcvd int
+}
+
+func (c *SimConn) Stats() ConnStats {
+	return ConnStats{
+		BytesSent:   int(c.bytesSent.Load()),
+		BytesRcvd:   int(c.bytesRcvd.Load()),
+		PacketsSent: int(c.packetsSent.Load()),
+		PacketsRcvd: int(c.packetsRcvd.Load()),
+	}
+}
+
+// SetLocalAddr only changes what `.LocalAddr()` returns.
+// Packets will still come From the initially configured addr.
+func (c *SimConn) SetLocalAddr(addr net.Addr) {
+	c.myLocalAddr = addr
+}
+
+func (c *SimConn) RecvPacket(p Packet) {
+	c.packetsRcvd.Add(1)
+	c.bytesRcvd.Add(int64(len(p.buf)))
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
+
+	select {
+	case c.packetsToRead <- p:
+	default:
+		// drop the packet if the channel is full
+	}
+}
+
+var _ net.PacketConn = &SimConn{}
+
+// Close implements net.PacketConn
+func (c *SimConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	close(c.packetsToRead)
+	return nil
+}
+
+// ReadFrom implements net.PacketConn
+func (c *SimConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0, nil, net.ErrClosed
+	}
+	deadline := c.readDeadline
+	c.mu.Unlock()
+
+	if !deadline.IsZero() && time.Now().After(deadline) {
+		return 0, nil, ErrDeadlineExceeded
+	}
+
+	var pkt Packet
+	if c.currentPacketToRead != nil {
+		pkt = *c.currentPacketToRead
+		c.currentPacketToRead = nil
+	} else {
+		if !deadline.IsZero() {
+			select {
+			case pkt = <-c.packetsToRead:
+			case <-time.After(time.Until(deadline)):
+				return 0, nil, ErrDeadlineExceeded
+			}
+		} else {
+			pkt = <-c.packetsToRead
+		}
+	}
+
+	n = copy(p, pkt.buf)
+	if n < len(pkt.buf) {
+		// Store remaining data for next read
+		c.currentPacketToRead = &Packet{
+			From: pkt.From,
+			buf:  pkt.buf[n:],
+		}
+	}
+	return n, pkt.From, nil
+}
+
+// WriteTo implements net.PacketConn
+func (c *SimConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0, net.ErrClosed
+	}
+	deadline := c.writeDeadline
+	c.mu.Unlock()
+
+	if !deadline.IsZero() && time.Now().After(deadline) {
+		return 0, ErrDeadlineExceeded
+	}
+
+	c.packetsSent.Add(1)
+	c.bytesSent.Add(int64(len(p)))
+
+	pkt := Packet{
+		From: c.myAddr,
+		To:   addr,
+		buf:  append([]byte(nil), p...),
+	}
+	return len(p), c.router.SendPacket(deadline, pkt)
+}
+
+func (c *SimConn) UnicastAddr() net.Addr {
+	return c.myAddr
+}
+
+// LocalAddr implements net.PacketConn
+func (c *SimConn) LocalAddr() net.Addr {
+	if c.myLocalAddr != nil {
+		return c.myLocalAddr
+	}
+	return c.myAddr
+}
+
+// SetDeadline implements net.PacketConn
+func (c *SimConn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.readDeadline = t
+	c.writeDeadline = t
+	return nil
+}
+
+// SetReadDeadline implements net.PacketConn
+func (c *SimConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.readDeadline = t
+	return nil
+}
+
+// SetWriteDeadline implements net.PacketConn
+func (c *SimConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writeDeadline = t
+	return nil
+}
+
+func IntToPublicIPv4(n int) net.IP {
+	n += 1
+	// Avoid private IP ranges
+	b := make([]byte, 4)
+	b[0] = byte((n>>24)&0xFF | 1)
+	b[1] = byte((n >> 16) & 0xFF)
+	b[2] = byte((n >> 8) & 0xFF)
+	b[3] = byte(n & 0xFF)
+
+	// Check and modify if it's in private ranges
+	if (b[0] == 10) || // 10.0.0.0/8
+		(b[0] == 172 && b[1] >= 16 && b[1] <= 31) || // 172.16.0.0/12
+		(b[0] == 192 && b[1] == 168) { // 192.168.0.0/16
+		b[0] = 203 // Use 203.x.x.x as public range
+	}
+
+	return net.IPv4(b[0], b[1], b[2], b[3])
+}

--- a/p2p/net/simconn/simconn_test.go
+++ b/p2p/net/simconn/simconn_test.go
@@ -228,6 +228,7 @@ func TestSimConnDeadlinesWithLatency(t *testing.T) {
 	})
 
 	t.Run("read fails after deadline", func(t *testing.T) {
+		defer reset()
 		// Set a short deadline
 		deadline := time.Now().Add(50 * time.Millisecond) // Less than router latency
 		err := conn2.SetReadDeadline(deadline)
@@ -239,7 +240,7 @@ func TestSimConnDeadlinesWithLatency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			// Send data after setting deadline
-			_, err = conn1.WriteTo([]byte("test"), addr2)
+			_, err := conn1.WriteTo([]byte("test"), addr2)
 			require.NoError(t, err)
 		}()
 
@@ -247,7 +248,6 @@ func TestSimConnDeadlinesWithLatency(t *testing.T) {
 		buf := make([]byte, 1024)
 		_, _, err = conn2.ReadFrom(buf)
 		require.ErrorIs(t, err, ErrDeadlineExceeded)
-		reset()
 	})
 }
 

--- a/p2p/net/simconn/simconn_test.go
+++ b/p2p/net/simconn/simconn_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -350,4 +351,12 @@ func TestSimpleHolePunch(t *testing.T) {
 			require.Equal(t, string(testMsg), string(buf[:n]))
 		})
 	})
+}
+
+func TestPublicIP(t *testing.T) {
+	err := quick.Check(func(n int) bool {
+		ip := IntToPublicIPv4(n)
+		return !ip.IsPrivate()
+	}, nil)
+	require.NoError(t, err)
 }

--- a/p2p/net/simconn/simconn_test.go
+++ b/p2p/net/simconn/simconn_test.go
@@ -253,7 +253,7 @@ func TestSimConnDeadlinesWithLatency(t *testing.T) {
 
 func TestSimpleHolePunch(t *testing.T) {
 	router := &SimpleFirewallRouter{
-		nodes: make(map[net.Addr]*simpleNodeFirewall),
+		nodes: make(map[string]*simpleNodeFirewall),
 	}
 
 	// Create two peers

--- a/p2p/net/simconn/simconn_test.go
+++ b/p2p/net/simconn/simconn_test.go
@@ -1,0 +1,353 @@
+package simconn
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimConnBasicConnectivity(t *testing.T) {
+	router := &PerfectRouter{
+		nodes: make(map[net.Addr]*SimConn),
+	}
+
+	// Create two endpoints
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	addr2 := &net.UDPAddr{IP: IntToPublicIPv4(2), Port: 1234}
+
+	conn1 := NewSimConn(addr1, router)
+	conn2 := NewSimConn(addr2, router)
+
+	router.AddNode(addr1, conn1)
+	router.AddNode(addr2, conn2)
+
+	// Test sending data from conn1 to conn2
+	testData := []byte("hello world")
+	n, err := conn1.WriteTo(testData, addr2)
+	require.NoError(t, err)
+	require.Equal(t, len(testData), n)
+
+	// Read data from conn2
+	buf := make([]byte, 1024)
+	n, addr, err := conn2.ReadFrom(buf)
+	require.NoError(t, err)
+	require.Equal(t, addr1, addr)
+	require.Equal(t, testData, buf[:n])
+
+	// Check stats
+	stats1 := conn1.Stats()
+	require.Equal(t, len(testData), stats1.BytesSent)
+	require.Equal(t, 1, stats1.PacketsSent)
+
+	stats2 := conn2.Stats()
+	require.Equal(t, len(testData), stats2.BytesRcvd)
+	require.Equal(t, 1, stats2.PacketsRcvd)
+}
+
+func TestSimConnDeadlines(t *testing.T) {
+	router := &PerfectRouter{
+		nodes: make(map[net.Addr]*SimConn),
+	}
+
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	conn := NewSimConn(addr1, router)
+	router.AddNode(addr1, conn)
+
+	t.Run("read deadline", func(t *testing.T) {
+		deadline := time.Now().Add(10 * time.Millisecond)
+		err := conn.SetReadDeadline(deadline)
+		require.NoError(t, err)
+
+		buf := make([]byte, 1024)
+		_, _, err = conn.ReadFrom(buf)
+		require.ErrorIs(t, err, ErrDeadlineExceeded)
+	})
+
+	t.Run("write deadline", func(t *testing.T) {
+		deadline := time.Now().Add(-time.Second) // Already expired
+		err := conn.SetWriteDeadline(deadline)
+		require.NoError(t, err)
+
+		_, err = conn.WriteTo([]byte("test"), &net.UDPAddr{})
+		require.ErrorIs(t, err, ErrDeadlineExceeded)
+	})
+}
+
+func TestSimConnClose(t *testing.T) {
+	router := &PerfectRouter{
+		nodes: make(map[net.Addr]*SimConn),
+	}
+
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	conn := NewSimConn(addr1, router)
+	router.AddNode(addr1, conn)
+
+	err := conn.Close()
+	require.NoError(t, err)
+
+	// Verify operations fail after close
+	_, err = conn.WriteTo([]byte("test"), addr1)
+	require.ErrorIs(t, err, net.ErrClosed)
+
+	buf := make([]byte, 1024)
+	_, _, err = conn.ReadFrom(buf)
+	require.ErrorIs(t, err, net.ErrClosed)
+
+	// Second close should not error
+	err = conn.Close()
+	require.NoError(t, err)
+}
+
+func TestSimConnPartialReads(t *testing.T) {
+	router := &PerfectRouter{
+		nodes: make(map[net.Addr]*SimConn),
+	}
+
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	addr2 := &net.UDPAddr{IP: IntToPublicIPv4(2), Port: 1234}
+
+	conn1 := NewSimConn(addr1, router)
+	conn2 := NewSimConn(addr2, router)
+
+	router.AddNode(addr1, conn1)
+	router.AddNode(addr2, conn2)
+
+	// Send large data
+	largeData := make([]byte, 1000)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	_, err := conn1.WriteTo(largeData, addr2)
+	require.NoError(t, err)
+
+	// Read in small chunks
+	buf := make([]byte, 100)
+	var received []byte
+
+	for len(received) < len(largeData) {
+		n, addr, err := conn2.ReadFrom(buf)
+		require.NoError(t, err)
+		require.Equal(t, addr1, addr)
+		received = append(received, buf[:n]...)
+	}
+
+	require.Equal(t, largeData, received)
+}
+
+func TestSimConnLocalAddr(t *testing.T) {
+	router := &PerfectRouter{
+		nodes: make(map[net.Addr]*SimConn),
+	}
+
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	conn := NewSimConn(addr1, router)
+
+	// Test default local address
+	require.Equal(t, addr1, conn.LocalAddr())
+
+	// Test setting custom local address
+	customAddr := &net.UDPAddr{IP: IntToPublicIPv4(3), Port: 5678}
+	conn.SetLocalAddr(customAddr)
+	require.Equal(t, customAddr, conn.LocalAddr())
+}
+
+func TestSimConnDeadlinesWithLatency(t *testing.T) {
+	router := &FixedLatencyRouter{
+		PerfectRouter: PerfectRouter{
+			nodes: make(map[net.Addr]*SimConn),
+		},
+		latency: 100 * time.Millisecond,
+	}
+
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	addr2 := &net.UDPAddr{IP: IntToPublicIPv4(2), Port: 1234}
+
+	conn1 := NewSimConn(addr1, router)
+	conn2 := NewSimConn(addr2, router)
+
+	router.AddNode(addr1, conn1)
+	router.AddNode(addr2, conn2)
+
+	reset := func() {
+		router.RemoveNode(addr1)
+		router.RemoveNode(addr2)
+
+		conn1 = NewSimConn(addr1, router)
+		conn2 = NewSimConn(addr2, router)
+
+		router.AddNode(addr1, conn1)
+		router.AddNode(addr2, conn2)
+	}
+
+	t.Run("write succeeds within deadline", func(t *testing.T) {
+		deadline := time.Now().Add(200 * time.Millisecond)
+		err := conn1.SetWriteDeadline(deadline)
+		require.NoError(t, err)
+
+		n, err := conn1.WriteTo([]byte("test"), addr2)
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		reset()
+	})
+
+	t.Run("write fails after deadline", func(t *testing.T) {
+		deadline := time.Now().Add(50 * time.Millisecond) // Less than router latency
+		err := conn1.SetWriteDeadline(deadline)
+		require.NoError(t, err)
+
+		_, err = conn1.WriteTo([]byte("test"), addr2)
+		require.ErrorIs(t, err, ErrDeadlineExceeded)
+		reset()
+	})
+
+	t.Run("read succeeds within deadline", func(t *testing.T) {
+		// Reset deadline and send a message
+		conn2.SetReadDeadline(time.Time{})
+		testData := []byte("hello")
+		deadline := time.Now().Add(200 * time.Millisecond)
+		conn1.SetWriteDeadline(deadline)
+		_, err := conn1.WriteTo(testData, addr2)
+		require.NoError(t, err)
+
+		// Set read deadline and try to read
+		deadline = time.Now().Add(200 * time.Millisecond)
+		err = conn2.SetReadDeadline(deadline)
+		require.NoError(t, err)
+
+		buf := make([]byte, 1024)
+		n, addr, err := conn2.ReadFrom(buf)
+		require.NoError(t, err)
+		require.Equal(t, addr1, addr)
+		require.Equal(t, testData, buf[:n])
+		reset()
+	})
+
+	t.Run("read fails after deadline", func(t *testing.T) {
+		// Set a short deadline
+		deadline := time.Now().Add(50 * time.Millisecond) // Less than router latency
+		err := conn2.SetReadDeadline(deadline)
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Send data after setting deadline
+			_, err = conn1.WriteTo([]byte("test"), addr2)
+			require.NoError(t, err)
+		}()
+
+		// Read should fail due to deadline
+		buf := make([]byte, 1024)
+		_, _, err = conn2.ReadFrom(buf)
+		require.ErrorIs(t, err, ErrDeadlineExceeded)
+		reset()
+	})
+}
+
+func TestSimpleHolePunch(t *testing.T) {
+	router := &SimpleFirewallRouter{
+		nodes: make(map[net.Addr]*simpleNodeFirewall),
+	}
+
+	// Create two peers
+	addr1 := &net.UDPAddr{IP: IntToPublicIPv4(1), Port: 1234}
+	addr2 := &net.UDPAddr{IP: IntToPublicIPv4(2), Port: 1234}
+
+	peer1 := NewSimConn(addr1, router)
+	peer2 := NewSimConn(addr2, router)
+
+	router.AddNode(addr1, peer1)
+	router.AddNode(addr2, peer2)
+
+	reset := func() {
+		router.RemoveNode(addr1)
+		router.RemoveNode(addr2)
+
+		peer1 = NewSimConn(addr1, router)
+		peer2 = NewSimConn(addr2, router)
+
+		router.AddNode(addr1, peer1)
+		router.AddNode(addr2, peer2)
+	}
+
+	// Initially, direct communication between peer1 and peer2 should fail
+	t.Run("direct communication blocked initially", func(t *testing.T) {
+		_, err := peer1.WriteTo([]byte("direct message"), addr2)
+		require.NoError(t, err) // Write succeeds but packet is dropped
+
+		// Try to read from peer2
+		peer2.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		buf := make([]byte, 1024)
+		_, _, err = peer2.ReadFrom(buf)
+		require.ErrorIs(t, err, ErrDeadlineExceeded)
+		reset()
+	})
+
+	holePunchMsg := []byte("hole punch")
+	// Simulate hole punching
+	t.Run("hole punch and direct communication", func(t *testing.T) {
+		// Both peers send packets to each other simultaneously
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			_, err := peer1.WriteTo(holePunchMsg, addr2)
+			require.NoError(t, err)
+		}()
+
+		go func() {
+			defer wg.Done()
+			_, err := peer2.WriteTo(holePunchMsg, addr1)
+			require.NoError(t, err)
+		}()
+
+		wg.Wait()
+
+		// Now direct communication should work both ways
+		t.Run("peer1 to peer2", func(t *testing.T) {
+			testMsg := []byte("direct message after hole punch")
+			_, err := peer1.WriteTo(testMsg, addr2)
+			require.NoError(t, err)
+
+			buf := make([]byte, 1024)
+			peer2.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, addr, err := peer2.ReadFrom(buf)
+			require.NoError(t, err)
+			require.Equal(t, addr1, addr)
+			if bytes.Equal(buf[:n], holePunchMsg) {
+				// Read again to get the actual message
+				n, addr, err = peer2.ReadFrom(buf)
+				require.NoError(t, err)
+				require.Equal(t, addr1, addr)
+			}
+			require.Equal(t, string(testMsg), string(buf[:n]))
+		})
+
+		t.Run("peer2 to peer1", func(t *testing.T) {
+			testMsg := []byte("response from peer2")
+			_, err := peer2.WriteTo(testMsg, addr1)
+			require.NoError(t, err)
+
+			buf := make([]byte, 1024)
+			peer1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, addr, err := peer1.ReadFrom(buf)
+			require.NoError(t, err)
+			require.Equal(t, addr2, addr)
+			if bytes.Equal(buf[:n], holePunchMsg) {
+				// Read again to get the actual message
+				n, addr, err = peer1.ReadFrom(buf)
+				require.NoError(t, err)
+				require.Equal(t, addr2, addr)
+			}
+			require.Equal(t, string(testMsg), string(buf[:n]))
+		})
+	})
+}

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -130,6 +130,8 @@ func TestDirectDialWorks(t *testing.T) {
 }
 
 func TestEndToEndSimConnect(t *testing.T) {
+	t.Skip("This test is broken. It is hard to do an end-to-end test without mocking the separate networks that holepunching is supposed to connect. It only worked previously because one of the hosts was able to learn about a non-holepunched direct connection via identify.")
+
 	h1tr := &mockEventTracer{}
 	h2tr := &mockEventTracer{}
 	h1, h2, relay, _ := makeRelayedHosts(t, []holepunch.Option{holepunch.WithTracer(h1tr)}, []holepunch.Option{holepunch.WithTracer(h2tr)}, true)

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -635,7 +635,7 @@ func (m *MockSourceIPSelector) PreferredSourceIPForDestination(dst *net.UDPAddr)
 	return *m.ip.Load(), nil
 }
 
-func quicSimConn(isPublic bool, router *simconn.SimpleFirewallRouter) libp2p.Option {
+func quicSimConn(isPubliclyReachably bool, router *simconn.SimpleFirewallRouter) libp2p.Option {
 	m := &MockSourceIPSelector{}
 	return libp2p.QUICReuse(
 		quicreuse.NewConnManager,
@@ -648,8 +648,8 @@ func quicSimConn(isPublic bool, router *simconn.SimpleFirewallRouter) libp2p.Opt
 				address.Port = int(lastPort.Add(1))
 			}
 			c := simconn.NewSimConn(address, router)
-			if isPublic {
-				router.AddPublicNode(address, c)
+			if isPubliclyReachably {
+				router.AddPubliclyReachableNode(address, c)
 			} else {
 				router.AddNode(address, c)
 			}

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -166,6 +166,7 @@ func TestDirectDialWorks(t *testing.T) {
 		libp2p.ResourceManager(&network.NullResourceManager{}),
 		connectToRelay(&relay),
 		libp2p.EnableHolePunching(holepunch.WithTracer(tr), holepunch.DirectDialTimeout(100*time.Millisecond)),
+		libp2p.ForceReachabilityPrivate(),
 	)
 
 	defer h1.Close()
@@ -261,6 +262,7 @@ func TestEndToEndSimConnect(t *testing.T) {
 				libp2p.EnableHolePunching(holepunch.WithTracer(h1tr), holepunch.DirectDialTimeout(100*time.Millisecond), SetLegacyBehavior(useLegacyHolePunchingBehavior)),
 				libp2p.ListenAddrs(ma.StringCast("/ip4/2.2.0.1/udp/8000/quic-v1")),
 				libp2p.ResourceManager(&network.NullResourceManager{}),
+				libp2p.ForceReachabilityPrivate(),
 			)
 
 			h2 := MustNewHost(t,
@@ -269,6 +271,7 @@ func TestEndToEndSimConnect(t *testing.T) {
 				libp2p.ResourceManager(&network.NullResourceManager{}),
 				connectToRelay(&relay),
 				libp2p.EnableHolePunching(holepunch.WithTracer(h2tr), holepunch.DirectDialTimeout(100*time.Millisecond), SetLegacyBehavior(useLegacyHolePunchingBehavior)),
+				libp2p.ForceReachabilityPrivate(),
 			)
 
 			defer h1.Close()
@@ -525,19 +528,19 @@ func TestFailuresOnResponder(t *testing.T) {
 			)
 			h1 := MustNewHost(t,
 				quicSimConn(false, router),
-				// libp2p.ForceReachabilityPrivate(),
 				libp2p.EnableHolePunching(opts...),
 				libp2p.ListenAddrs(ma.StringCast("/ip4/2.2.0.1/udp/8000/quic-v1")),
 				libp2p.ResourceManager(&network.NullResourceManager{}),
 				connectToRelay(&relay),
+				libp2p.ForceReachabilityPrivate(),
 			)
 
 			h2 := MustNewHost(t,
 				quicSimConn(false, router),
-				// libp2p.ForceReachabilityPrivate(),
 				libp2p.ListenAddrs(ma.StringCast("/ip4/2.2.0.2/udp/8001/quic-v1")),
 				libp2p.ResourceManager(&network.NullResourceManager{}),
 				connectToRelay(&relay),
+				libp2p.ForceReachabilityPrivate(),
 			)
 
 			defer h1.Close()

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -625,8 +625,6 @@ func ensureDirectConn(t *testing.T, h1, h2 host.Host) {
 	}, 5*time.Second, 50*time.Millisecond)
 }
 
-var lastPort atomic.Uint32
-
 type MockSourceIPSelector struct {
 	ip atomic.Pointer[net.IP]
 }
@@ -644,9 +642,6 @@ func quicSimConn(isPubliclyReachably bool, router *simconn.SimpleFirewallRouter)
 		}),
 		quicreuse.OverrideListenUDP(func(network string, address *net.UDPAddr) (net.PacketConn, error) {
 			m.ip.Store(&address.IP)
-			if address.Port == 0 {
-				address.Port = int(lastPort.Add(1))
-			}
 			c := simconn.NewSimConn(address, router)
 			if isPubliclyReachably {
 				router.AddPubliclyReachableNode(address, c)

--- a/p2p/protocol/holepunch/holepunch_test.go
+++ b/p2p/protocol/holepunch/holepunch_test.go
@@ -157,6 +157,7 @@ func learnAddrs(h1, h2 host.Host) {
 }
 
 func pingAtoB(t *testing.T, a, b host.Host) {
+	t.Helper()
 	p1 := ping.NewPingService(a)
 	require.NoError(t, a.Connect(context.Background(), peer.AddrInfo{
 		ID:    b.ID(),
@@ -170,6 +171,7 @@ func pingAtoB(t *testing.T, a, b host.Host) {
 }
 
 func MustNewHost(t *testing.T, opts ...libp2p.Option) host.Host {
+	t.Helper()
 	h, err := libp2p.New(opts...)
 	require.NoError(t, err)
 	return h
@@ -193,14 +195,13 @@ func TestEndToEndSimConnect(t *testing.T) {
 	)
 	h1 := MustNewHost(t,
 		quicSimConn(false, router),
-		libp2p.ForceReachabilityPrivate(),
 		libp2p.EnableHolePunching(holepunch.WithTracer(h1tr), holepunch.DirectDialTimeout(100*time.Millisecond)),
 		libp2p.ListenAddrs(ma.StringCast("/ip4/2.2.0.1/udp/8000/quic-v1")),
 		libp2p.ResourceManager(&network.NullResourceManager{}),
 	)
+
 	h2 := MustNewHost(t,
 		quicSimConn(false, router),
-		libp2p.ForceReachabilityPrivate(),
 		libp2p.ListenAddrs(ma.StringCast("/ip4/2.2.0.2/udp/8001/quic-v1")),
 		libp2p.ResourceManager(&network.NullResourceManager{}),
 		connectToRelay(&relay),

--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -223,6 +223,7 @@ func (hp *holePuncher) initiateHolePunchImpl(str network.Stream) ([]ma.Multiaddr
 	if len(obsAddrs) == 0 {
 		return nil, nil, 0, errors.New("aborting hole punch initiation as we have no public address")
 	}
+	log.Debugf("initiating hole punch with %s", obsAddrs)
 
 	start := time.Now()
 	if err := w.WriteMsg(&pb.HolePunch{

--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -49,6 +49,11 @@ type holePuncher struct {
 
 	tracer *tracer
 	filter AddrFilter
+
+	// Prior to https://github.com/libp2p/go-libp2p/pull/3044, go-libp2p would
+	// pick the opposite roles for client/server a hole punch. Setting this to
+	// true preserves that behavior
+	legacyBehavior bool
 }
 
 func newHolePuncher(h host.Host, ids identify.IDService, listenAddrs func() []ma.Multiaddr, tracer *tracer, filter AddrFilter) *holePuncher {

--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -63,6 +63,8 @@ func newHolePuncher(h host.Host, ids identify.IDService, listenAddrs func() []ma
 		tracer:      tracer,
 		filter:      filter,
 		listenAddrs: listenAddrs,
+
+		legacyBehavior: true,
 	}
 	hp.ctx, hp.ctxCancel = context.WithCancel(context.Background())
 	h.Network().Notify((*netNotifiee)(hp))
@@ -159,7 +161,11 @@ func (hp *holePuncher) directConnect(rp peer.ID) error {
 			hp.tracer.StartHolePunch(rp, addrs, rtt)
 			hp.tracer.HolePunchAttempt(pi.ID)
 			ctx, cancel := context.WithTimeout(hp.ctx, hp.directDialTimeout)
-			err := holePunchConnect(ctx, hp.host, pi, false)
+			isClient := true
+			if hp.legacyBehavior {
+				isClient = false
+			}
+			err := holePunchConnect(ctx, hp.host, pi, isClient)
 			cancel()
 			dt := time.Since(start)
 			hp.tracer.EndHolePunch(rp, dt, err)

--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -150,7 +150,7 @@ func (hp *holePuncher) directConnect(rp peer.ID) error {
 			}
 			hp.tracer.StartHolePunch(rp, addrs, rtt)
 			hp.tracer.HolePunchAttempt(pi.ID)
-			err := holePunchConnect(hp.ctx, hp.host, pi, true)
+			err := holePunchConnect(hp.ctx, hp.host, pi, false)
 			dt := time.Since(start)
 			hp.tracer.EndHolePunch(rp, dt, err)
 			if err == nil {

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -258,7 +258,7 @@ func (s *Service) handleNewStream(str network.Stream) {
 	log.Debugw("starting hole punch", "peer", rp)
 	start := time.Now()
 	s.tracer.HolePunchAttempt(pi.ID)
-	err = holePunchConnect(s.ctx, s.host, pi, false)
+	err = holePunchConnect(s.ctx, s.host, pi, true)
 	dt := time.Since(start)
 	s.tracer.EndHolePunch(rp, dt, err)
 	s.tracer.HolePunchFinished("receiver", 1, addrs, ownAddrs, getDirectConnection(s.host, rp))

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -19,7 +19,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-const defaultDirectDialTimeout = 5 * time.Second
+const defaultDirectDialTimeout = 10 * time.Second
 
 // Protocol is the libp2p protocol for Hole Punching.
 const Protocol protocol.ID = "/libp2p/dcutr"
@@ -137,7 +137,7 @@ func (s *Service) waitForPublicAddr() {
 	defer t.Stop()
 	for {
 		if len(s.listenAddrs()) > 0 {
-			log.Debugf("Host %s now has a public address. Starting holepunch protocol.", s.host.ID())
+			log.Debugf("Host %s now has a public address (%s). Starting holepunch protocol.", s.host.ID(), s.host.Addrs())
 			s.host.SetStreamHandler(Protocol, s.handleNewStream)
 			break
 		}

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -102,7 +102,7 @@ func NewService(h host.Host, ids identify.IDService, listenAddrs func() []ma.Mul
 func (s *Service) waitForPublicAddr() {
 	defer s.refCount.Done()
 
-	log.Debug("waiting until we have at least one public address", "peer", s.host.ID())
+	log.Debugw("waiting until we have at least one public address", "peer", s.host.ID())
 
 	// TODO: We should have an event here that fires when identify discovers a new
 	// address.
@@ -114,7 +114,7 @@ func (s *Service) waitForPublicAddr() {
 	defer t.Stop()
 	for {
 		if len(s.listenAddrs()) > 0 {
-			log.Debug("Host now has a public address. Starting holepunch protocol.")
+			log.Debugf("Host %s now has a public address. Starting holepunch protocol.", s.host.ID())
 			s.host.SetStreamHandler(Protocol, s.handleNewStream)
 			break
 		}

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -71,6 +71,17 @@ type Service struct {
 	filter AddrFilter
 
 	refCount sync.WaitGroup
+
+	// Prior to https://github.com/libp2p/go-libp2p/pull/3044, go-libp2p would
+	// pick the opposite roles for client/server a hole punch. Setting this to
+	// true preserves that behavior
+	legacyBehavior bool
+}
+
+// SetLegacyBehavior is only exposed for testing purposes.
+// Do not set this unless you know what you are doing.
+func (s *Service) SetLegacyBehavior(legacyBehavior bool) {
+	s.legacyBehavior = legacyBehavior
 }
 
 // NewService creates a new service that can be used for hole punching
@@ -94,6 +105,7 @@ func NewService(h host.Host, ids identify.IDService, listenAddrs func() []ma.Mul
 		listenAddrs:        listenAddrs,
 		hasPublicAddrsChan: make(chan struct{}),
 		directDialTimeout:  defaultDirectDialTimeout,
+		legacyBehavior:     true,
 	}
 
 	for _, opt := range opts {
@@ -149,6 +161,7 @@ func (s *Service) waitForPublicAddr() {
 	}
 	s.holePuncher = newHolePuncher(s.host, s.ids, s.listenAddrs, s.tracer, s.filter)
 	s.holePuncher.directDialTimeout = s.directDialTimeout
+	s.holePuncher.legacyBehavior = s.legacyBehavior
 	s.holePuncherMx.Unlock()
 	close(s.hasPublicAddrsChan)
 }
@@ -271,7 +284,11 @@ func (s *Service) handleNewStream(str network.Stream) {
 	start := time.Now()
 	s.tracer.HolePunchAttempt(pi.ID)
 	ctx, cancel := context.WithTimeout(s.ctx, s.directDialTimeout)
-	err = holePunchConnect(ctx, s.host, pi, true)
+	isClient := false
+	if s.legacyBehavior {
+		isClient = true
+	}
+	err = holePunchConnect(ctx, s.host, pi, isClient)
 	cancel()
 	dt := time.Since(start)
 	s.tracer.EndHolePunch(rp, dt, err)

--- a/p2p/protocol/holepunch/util.go
+++ b/p2p/protocol/holepunch/util.go
@@ -51,11 +51,9 @@ func getDirectConnection(h host.Host, p peer.ID) network.Conn {
 func holePunchConnect(ctx context.Context, host host.Host, pi peer.AddrInfo, isClient bool) error {
 	holePunchCtx := network.WithSimultaneousConnect(ctx, isClient, "hole-punching")
 	forceDirectConnCtx := network.WithForceDirectDial(holePunchCtx, "hole-punching")
-	dialCtx, cancel := context.WithTimeout(forceDirectConnCtx, dialTimeout)
-	defer cancel()
 
 	log.Debugw("holepunchConnect", "host", host.ID(), "peer", pi.ID, "addrs", pi.Addrs)
-	if err := host.Connect(dialCtx, pi); err != nil {
+	if err := host.Connect(forceDirectConnCtx, pi); err != nil {
 		log.Debugw("hole punch attempt with peer failed", "peer ID", pi.ID, "error", err)
 		return err
 	}

--- a/p2p/protocol/holepunch/util.go
+++ b/p2p/protocol/holepunch/util.go
@@ -54,6 +54,7 @@ func holePunchConnect(ctx context.Context, host host.Host, pi peer.AddrInfo, isC
 	dialCtx, cancel := context.WithTimeout(forceDirectConnCtx, dialTimeout)
 	defer cancel()
 
+	log.Debugw("holepunchConnect", "host", host.ID(), "peer", pi.ID, "addrs", pi.Addrs)
 	if err := host.Connect(dialCtx, pi); err != nil {
 		log.Debugw("hole punch attempt with peer failed", "peer ID", pi.ID, "error", err)
 		return err

--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -82,12 +82,12 @@ func NewConnManager(statelessResetKey quic.StatelessResetKey, tokenKey quic.Toke
 		cm.reuseUDP4 = newReuse(&statelessResetKey, &tokenKey)
 		cm.reuseUDP4.overrideListenUDP = cm.overrideListenUDP
 		if cm.overrideSourceIPSelectorFn != nil {
-			cm.reuseUDP4.overrideSourceIPSelectorFn = cm.overrideSourceIPSelectorFn
+			cm.reuseUDP4.sourceIPSelectorFn = cm.overrideSourceIPSelectorFn
 		}
 
 		cm.reuseUDP6 = newReuse(&statelessResetKey, &tokenKey)
 		if cm.overrideSourceIPSelectorFn != nil {
-			cm.reuseUDP6.overrideSourceIPSelectorFn = cm.overrideSourceIPSelectorFn
+			cm.reuseUDP6.sourceIPSelectorFn = cm.overrideSourceIPSelectorFn
 		}
 		cm.reuseUDP6.overrideListenUDP = cm.overrideListenUDP
 	}

--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -63,18 +63,20 @@ func defaultListenUDP(network string, laddr *net.UDPAddr) (net.PacketConn, error
 	return net.ListenUDP(network, laddr)
 }
 
+func defaultSourceIPSelectorFn() (SourceIPSelector, error) {
+	r, err := netroute.New()
+	return &netrouteSourceIPSelector{routes: r}, err
+}
+
 func NewConnManager(statelessResetKey quic.StatelessResetKey, tokenKey quic.TokenGeneratorKey, opts ...Option) (*ConnManager, error) {
 	cm := &ConnManager{
-		enableReuseport: true,
-		quicListeners:   make(map[string]quicListenerEntry),
-		srk:             statelessResetKey,
-		tokenKey:        tokenKey,
-		registerer:      prometheus.DefaultRegisterer,
-		listenUDP:       defaultListenUDP,
-		sourceIPSelectorFn: func() (SourceIPSelector, error) {
-			r, err := netroute.New()
-			return &netrouteSourceIPSelector{routes: r}, err
-		},
+		enableReuseport:    true,
+		quicListeners:      make(map[string]quicListenerEntry),
+		srk:                statelessResetKey,
+		tokenKey:           tokenKey,
+		registerer:         prometheus.DefaultRegisterer,
+		listenUDP:          defaultListenUDP,
+		sourceIPSelectorFn: defaultSourceIPSelectorFn,
 	}
 	for _, o := range opts {
 		if err := o(cm); err != nil {

--- a/p2p/transport/quicreuse/options.go
+++ b/p2p/transport/quicreuse/options.go
@@ -12,14 +12,14 @@ type listenUDP func(network string, laddr *net.UDPAddr) (net.PacketConn, error)
 
 func OverrideListenUDP(f listenUDP) Option {
 	return func(m *ConnManager) error {
-		m.overrideListenUDP = f
+		m.listenUDP = f
 		return nil
 	}
 }
 
 func OverrideSourceIPSelector(f func() (SourceIPSelector, error)) Option {
 	return func(m *ConnManager) error {
-		m.overrideSourceIPSelectorFn = f
+		m.sourceIPSelectorFn = f
 		return nil
 	}
 }

--- a/p2p/transport/quicreuse/options.go
+++ b/p2p/transport/quicreuse/options.go
@@ -10,9 +10,16 @@ type Option func(*ConnManager) error
 
 type listenUDP func(network string, laddr *net.UDPAddr) (net.PacketConn, error)
 
-func CustomListenUDP(f listenUDP) Option {
+func OverrideListenUDP(f listenUDP) Option {
 	return func(m *ConnManager) error {
-		m.customListenUDP = f
+		m.overrideListenUDP = f
+		return nil
+	}
+}
+
+func OverrideSourceIPSelector(f func() (SourceIPSelector, error)) Option {
+	return func(m *ConnManager) error {
+		m.overrideSourceIPSelectorFn = f
 		return nil
 	}
 }

--- a/p2p/transport/quicreuse/options.go
+++ b/p2p/transport/quicreuse/options.go
@@ -1,8 +1,21 @@
 package quicreuse
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"net"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type Option func(*ConnManager) error
+
+type listenUDP func(network string, laddr *net.UDPAddr) (net.PacketConn, error)
+
+func CustomListenUDP(f listenUDP) Option {
+	return func(m *ConnManager) error {
+		m.customListenUDP = f
+		return nil
+	}
+}
 
 func DisableReuseport() Option {
 	return func(m *ConnManager) error {

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -165,8 +165,9 @@ func (c *refcountedTransport) ShouldGarbageCollect(now time.Time) bool {
 type reuse struct {
 	mutex sync.Mutex
 
-	closeChan  chan struct{}
-	gcStopChan chan struct{}
+	closeChan       chan struct{}
+	gcStopChan      chan struct{}
+	customListenUDP listenUDP
 
 	routes  routing.Router
 	unicast map[string] /* IP.String() */ map[int] /* port */ *refcountedTransport
@@ -323,7 +324,13 @@ func (r *reuse) transportForDialLocked(association any, network string, source *
 	case "udp6":
 		addr = &net.UDPAddr{IP: net.IPv6zero, Port: 0}
 	}
-	conn, err := net.ListenUDP(network, addr)
+	var conn net.PacketConn
+	var err error
+	if r.customListenUDP != nil {
+		conn, err = r.customListenUDP(network, addr)
+	} else {
+		conn, err = net.ListenUDP(network, addr)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +396,13 @@ func (r *reuse) TransportForListen(network string, laddr *net.UDPAddr) (*refcoun
 		}
 	}
 
-	conn, err := net.ListenUDP(network, laddr)
+	var conn net.PacketConn
+	var err error
+	if r.customListenUDP != nil {
+		conn, err = r.customListenUDP(network, laddr)
+	} else {
+		conn, err = net.ListenUDP(network, laddr)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/transport/quicreuse/reuse_test.go
+++ b/p2p/transport/quicreuse/reuse_test.go
@@ -61,7 +61,7 @@ func cleanup(t *testing.T, reuse *reuse) {
 }
 
 func TestReuseListenOnAllIPv4(t *testing.T) {
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	require.Eventually(t, isGarbageCollectorRunning, 500*time.Millisecond, 50*time.Millisecond, "expected garbage collector to be running")
 	cleanup(t, reuse)
 
@@ -73,7 +73,7 @@ func TestReuseListenOnAllIPv4(t *testing.T) {
 }
 
 func TestReuseListenOnAllIPv6(t *testing.T) {
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	require.Eventually(t, isGarbageCollectorRunning, 500*time.Millisecond, 50*time.Millisecond, "expected garbage collector to be running")
 	cleanup(t, reuse)
 
@@ -86,7 +86,7 @@ func TestReuseListenOnAllIPv6(t *testing.T) {
 }
 
 func TestReuseCreateNewGlobalConnOnDial(t *testing.T) {
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	cleanup(t, reuse)
 
 	addr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
@@ -100,7 +100,7 @@ func TestReuseCreateNewGlobalConnOnDial(t *testing.T) {
 }
 
 func TestReuseConnectionWhenDialing(t *testing.T) {
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	cleanup(t, reuse)
 
 	addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
@@ -117,7 +117,7 @@ func TestReuseConnectionWhenDialing(t *testing.T) {
 }
 
 func TestReuseConnectionWhenListening(t *testing.T) {
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	cleanup(t, reuse)
 
 	raddr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
@@ -132,7 +132,7 @@ func TestReuseConnectionWhenListening(t *testing.T) {
 }
 
 func TestReuseConnectionWhenDialBeforeListen(t *testing.T) {
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	cleanup(t, reuse)
 
 	// dial any address
@@ -166,7 +166,7 @@ func TestReuseListenOnSpecificInterface(t *testing.T) {
 	if platformHasRoutingTables() {
 		t.Skip("this test only works on platforms that support routing tables")
 	}
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	cleanup(t, reuse)
 
 	router, err := netroute.New()
@@ -203,7 +203,7 @@ func TestReuseGarbageCollect(t *testing.T) {
 		maxUnusedDuration = 10 * maxUnusedDuration
 	}
 
-	reuse := newReuse(nil, nil)
+	reuse := newReuse(nil, nil, defaultListenUDP, defaultSourceIPSelectorFn)
 	cleanup(t, reuse)
 
 	numGlobals := func() int {


### PR DESCRIPTION
Previously this PR sought to migrate away from the legacy behavior. Now it just tests the hole punching behavior using a simulated network. It also adds a flag to control the legacy behavior, but this is set to default to the current behavior.

Most of the code introduced here is related to the new `simconn` package which lets us create simulated UDP connections for use with the QUIC transport. This lets us set up arbitrary networks to test holepunching. The End to End test now places hosts A and B behind a firewall that requires holepunching for a direct connection.

The plan is to merge this PR to actually test holepunching, then #3171 by coming up with a migration strategy and use these tests to verify the strategy.