### PR TITLE
fix(holepunch/tracer): replace inline peer struct with peerInfo type

### DIFF
--- a/p2p/protocol/holepunch/tracer.go
+++ b/p2p/protocol/holepunch/tracer.go
@@ -20,13 +20,10 @@ const (
 func WithTracer(et EventTracer) Option {
 	return func(hps *Service) error {
 		hps.tracer = &tracer{
-			et:   et,
-			mt:   nil,
-			self: hps.host.ID(),
-			peers: make(map[peer.ID]struct {
-				counter int
-				last    time.Time
-			}),
+			et:    et,
+			mt:    nil,
+			self:  hps.host.ID(),
+			peers: make(map[peer.ID]peerInfo),
 		}
 		return nil
 	}
@@ -36,13 +33,10 @@ func WithTracer(et EventTracer) Option {
 func WithMetricsTracer(mt MetricsTracer) Option {
 	return func(hps *Service) error {
 		hps.tracer = &tracer{
-			et:   nil,
-			mt:   mt,
-			self: hps.host.ID(),
-			peers: make(map[peer.ID]struct {
-				counter int
-				last    time.Time
-			}),
+			et:    nil,
+			mt:    mt,
+			self:  hps.host.ID(),
+			peers: make(map[peer.ID]peerInfo),
 		}
 		return nil
 	}
@@ -52,13 +46,10 @@ func WithMetricsTracer(mt MetricsTracer) Option {
 func WithMetricsAndEventTracer(mt MetricsTracer, et EventTracer) Option {
 	return func(hps *Service) error {
 		hps.tracer = &tracer{
-			et:   et,
-			mt:   mt,
-			self: hps.host.ID(),
-			peers: make(map[peer.ID]struct {
-				counter int
-				last    time.Time
-			}),
+			et:    et,
+			mt:    mt,
+			self:  hps.host.ID(),
+			peers: make(map[peer.ID]peerInfo),
 		}
 		return nil
 	}
@@ -74,10 +65,12 @@ type tracer struct {
 	ctxCancel context.CancelFunc
 
 	mutex sync.Mutex
-	peers map[peer.ID]struct {
-		counter int
-		last    time.Time
-	}
+	peers map[peer.ID]peerInfo
+}
+
+type peerInfo struct {
+	counter int
+	last    time.Time
 }
 
 type EventTracer interface {


### PR DESCRIPTION
- Introduced the `peerInfo` struct to encapsulate peer metadata.
- Updated the `peers` map in the `tracer` struct to use `peerInfo`.
- Simplified code by avoiding inline struct definition for peers.