### PR TITLE
fix(libp2phttp): Return ErrServerClosed on Close

### DIFF
--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -359,6 +359,7 @@ func (h *Host) Serve() error {
 	expectedErrCount := len(h.httpTransport.listeners)
 	select {
 	case <-h.httpTransport.closeListeners:
+		err = http.ErrServerClosed
 	case err = <-errCh:
 		expectedErrCount--
 	}

--- a/p2p/http/libp2phttp_test.go
+++ b/p2p/http/libp2phttp_test.go
@@ -30,6 +30,7 @@ import (
 	httpping "github.com/libp2p/go-libp2p/p2p/http/ping"
 	libp2pquic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -995,4 +996,21 @@ func TestImpliedHostIsSet(t *testing.T) {
 		})
 	}
 
+}
+
+func TestErrServerClosed(t *testing.T) {
+	server := libp2phttp.Host{
+		InsecureAllowHTTP: true,
+		ListenAddrs:       []ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/0/http")},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		err := server.Serve()
+		assert.Equal(t, http.ErrServerClosed, err)
+		close(done)
+	}()
+
+	server.Close()
+	<-done
 }


### PR DESCRIPTION
This should match the semantics of the Go stdlib http server .Close which always returns an error