### PR TITLE
tcp: fix metrics test build directive

### DIFF
--- a/p2p/transport/tcp/metrics_test.go
+++ b/p2p/transport/tcp/metrics_test.go
@@ -1,5 +1,3 @@
-//go:build: unix
-
 package tcp
 
 import (

--- a/p2p/transport/tcp/metrics_unix_test.go
+++ b/p2p/transport/tcp/metrics_unix_test.go
@@ -1,4 +1,4 @@
-// go:build: unix
+//go:build: unix
 
 package tcp
 


### PR DESCRIPTION
This test works on all platforms. It tests for transport correctness in case we have metrics enabled. 
This removes the incorrect directive(whitespace in front of the name) and the platform specific file suffix. 