### PR TITLE
chore(dashboard/alertmanager): update api version from v1 to v2

### DIFF
--- a/dashboards/prometheus.yml
+++ b/dashboards/prometheus.yml
@@ -6,7 +6,7 @@ alerting:
   alertmanagers:
   - scheme: http
     timeout: 10s
-    api_version: v1
+    api_version: v2
     static_configs:
     - targets: []
 scrape_configs:


### PR DESCRIPTION
The error message was:
Error loading config (--config.file=/etc/prometheus/prometheus.yml): expected Alertmanager API version to be one of [v2] but got v1