### PR TITLE
chore: fix broken link to record envelope protobuf file

### DIFF
--- a/core/peer/pb/peer_record.pb.go
+++ b/core/peer/pb/peer_record.pb.go
@@ -26,7 +26,7 @@ const (
 //
 // PeerRecords are designed to be serialized to bytes and placed inside of
 // SignedEnvelopes before sharing with other peers.
-// See https://github.com/libp2p/go-libp2p/core/record/pb/envelope.proto for
+// See https://github.com/libp2p/go-libp2p/blob/master/core/record/pb/envelope.proto for
 // the SignedEnvelope definition.
 type PeerRecord struct {
 	state         protoimpl.MessageState

--- a/core/peer/pb/peer_record.proto
+++ b/core/peer/pb/peer_record.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/libp2p/go-libp2p/core/peer/pb";
 //
 // PeerRecords are designed to be serialized to bytes and placed inside of
 // SignedEnvelopes before sharing with other peers.
-// See https://github.com/libp2p/go-libp2p/core/record/pb/envelope.proto for
+// See https://github.com/libp2p/go-libp2p/blob/master/core/record/pb/envelope.proto for
 // the SignedEnvelope definition.
 message PeerRecord {
 


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.