### PR TITLE
swarm: delay /webrtc-direct dials by 1 second

### DIFF
--- a/p2p/net/swarm/dial_ranker_test.go
+++ b/p2p/net/swarm/dial_ranker_test.go
@@ -29,6 +29,7 @@ func TestNoDelayDialRanker(t *testing.T) {
 	q3v1 := ma.StringCast("/ip4/1.2.3.4/udp/3/quic-v1")
 	q4 := ma.StringCast("/ip4/1.2.3.4/udp/4/quic-v1")
 	t1 := ma.StringCast("/ip4/1.2.3.5/tcp/1/")
+	wrtc1 := ma.StringCast("/ip4/1.1.1.1/udp/1/webrtc-direct")
 
 	testCase := []struct {
 		name   string
@@ -37,7 +38,7 @@ func TestNoDelayDialRanker(t *testing.T) {
 	}{
 		{
 			name:  "quic+webtransport filtered when quicv1",
-			addrs: []ma.Multiaddr{q1, q2, q3, q4, q1v1, q2v1, q3v1, wt1, t1},
+			addrs: []ma.Multiaddr{q1, q2, q3, q4, q1v1, q2v1, q3v1, wt1, t1, wrtc1},
 			output: []network.AddrDelay{
 				{Addr: q1, Delay: 0},
 				{Addr: q2, Delay: 0},
@@ -48,6 +49,7 @@ func TestNoDelayDialRanker(t *testing.T) {
 				{Addr: q3v1, Delay: 0},
 				{Addr: wt1, Delay: 0},
 				{Addr: t1, Delay: 0},
+				{Addr: wrtc1, Delay: 0},
 			},
 		},
 	}
@@ -276,6 +278,65 @@ func TestDelayRankerRelay(t *testing.T) {
 			if len(res) != len(tc.output) {
 				log.Errorf("expected %s got %s", tc.output, res)
 				t.Errorf("expected elems: %d got: %d", len(tc.output), len(res))
+			}
+			sortAddrDelays(res)
+			sortAddrDelays(tc.output)
+			for i := 0; i < len(tc.output); i++ {
+				if !tc.output[i].Addr.Equal(res[i].Addr) || tc.output[i].Delay != res[i].Delay {
+					t.Fatalf("expected %+v got %+v", tc.output, res)
+				}
+			}
+		})
+	}
+}
+
+func TestDelayRankerOtherTransportDelay(t *testing.T) {
+	q1v1 := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
+	q1v16 := ma.StringCast("/ip6/1::2/udp/1/quic-v1")
+	t1 := ma.StringCast("/ip4/1.2.3.5/tcp/1/")
+	t1v6 := ma.StringCast("/ip6/1::2/tcp/1")
+	wrtc1 := ma.StringCast("/ip4/1.2.3.4/udp/1/webrtc-direct")
+	wrtc1v6 := ma.StringCast("/ip6/1::2/udp/1/webrtc-direct")
+	onion1 := ma.StringCast("/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234")
+	onlyIP := ma.StringCast("/ip4/1.2.3.4/")
+	testCase := []struct {
+		name   string
+		addrs  []ma.Multiaddr
+		output []network.AddrDelay
+	}{
+		{
+			name:  "quic-with-other",
+			addrs: []ma.Multiaddr{q1v1, q1v16, wrtc1, wrtc1v6, onion1, onlyIP},
+			output: []network.AddrDelay{
+				{Addr: q1v16, Delay: 0},
+				{Addr: q1v1, Delay: PublicQUICDelay},
+				{Addr: wrtc1, Delay: PublicQUICDelay + PublicOtherDelay},
+				{Addr: wrtc1v6, Delay: PublicQUICDelay + PublicOtherDelay},
+				{Addr: onlyIP, Delay: PublicQUICDelay + PublicOtherDelay},
+				{Addr: onion1, Delay: PublicQUICDelay + 2*PublicOtherDelay},
+			},
+		},
+		{
+			name:  "quic-and-tcp-with-other",
+			addrs: []ma.Multiaddr{q1v1, t1, t1v6, wrtc1, wrtc1v6, onion1, onlyIP},
+			output: []network.AddrDelay{
+				{Addr: q1v1, Delay: 0},
+				{Addr: t1v6, Delay: PublicQUICDelay},
+				{Addr: t1, Delay: 2 * PublicQUICDelay},
+				{Addr: wrtc1, Delay: 2*PublicQUICDelay + PublicOtherDelay},
+				{Addr: wrtc1v6, Delay: 2*PublicQUICDelay + PublicOtherDelay},
+				{Addr: onlyIP, Delay: 2*PublicQUICDelay + PublicOtherDelay},
+				{Addr: onion1, Delay: 2*PublicQUICDelay + 2*PublicOtherDelay},
+			},
+		},
+	}
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			res := DefaultDialRanker(tc.addrs)
+			if len(res) != len(tc.output) {
+				log.Errorf("expected %s got %s", tc.output, res)
+				t.Errorf("expected elems: %d got: %d", len(tc.output), len(res))
+				return
 			}
 			sortAddrDelays(res)
 			sortAddrDelays(tc.output)

--- a/p2p/net/swarm/dial_ranker_test.go
+++ b/p2p/net/swarm/dial_ranker_test.go
@@ -329,6 +329,13 @@ func TestDelayRankerOtherTransportDelay(t *testing.T) {
 				{Addr: onion1, Delay: 2*PublicQUICDelay + 2*PublicOtherDelay},
 			},
 		},
+		{
+			name:  "only-non-ip-addr",
+			addrs: []ma.Multiaddr{onion1},
+			output: []network.AddrDelay{
+				{Addr: onion1, Delay: PublicOtherDelay},
+			},
+		},
 	}
 	for _, tc := range testCase {
 		t.Run(tc.name, func(t *testing.T) {

--- a/p2p/net/swarm/dial_worker.go
+++ b/p2p/net/swarm/dial_worker.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -295,6 +296,9 @@ loop:
 				}
 				ad.dialed = true
 				ad.dialRankingDelay = now.Sub(ad.createdAt)
+				if _, err := ad.addr.ValueForProtocol(ma.P_WEBRTC_DIRECT); err == nil {
+					fmt.Println("dial ranking delay", ad.addr, ad.dialRankingDelay)
+				}
 				err := w.s.dialNextAddr(ad.ctx, w.peer, ad.addr, w.resch)
 				if err != nil {
 					// Errored without attempting a dial. This happens in case of

--- a/p2p/test/basichost/basic_host_test.go
+++ b/p2p/test/basichost/basic_host_test.go
@@ -207,7 +207,6 @@ func TestAddrFactorCertHashAppend(t *testing.T) {
 func TestWebRTCDirectDialDelay(t *testing.T) {
 	// This tests that only webrtc-direct dials are dialled immediately
 	// and not delayed by dial ranker.
-
 	h1, err := libp2p.New(
 		libp2p.Transport(libp2pwebrtc.New),
 		libp2p.ListenAddrStrings(
@@ -228,6 +227,8 @@ func TestWebRTCDirectDialDelay(t *testing.T) {
 }
 
 func TestWebRTCWithQUICManyConnections(t *testing.T) {
+	// Correctly fixes: https://github.com/libp2p/js-libp2p/issues/2805
+
 	h, err := libp2p.New(
 		libp2p.Transport(libp2pquic.NewTransport),
 		libp2p.Transport(libp2pwebrtc.New),


### PR DESCRIPTION
Previously these addresses weren't delayed at all. When I initially did the ranker implementation, I was too conservative regarding what to delay. So, non QUIC, WebTransport, TCP, WS addresses were ignored in ranking. We only ever need to dial /webrtc-direct when there's no other address available for the peer, in which case we will dial the addresses immediately.

This would have helped with https://github.com/libp2p/js-libp2p/issues/2805 as there would have been fewer peers dialing webrtc and then cancelling because they connected on a better transport.

This also introduces an additional 1 second delay for any fancy non IP transports