### PR TITLE
peerstore: remove sync.Pool for expiringAddrs

### DIFF
--- a/p2p/host/peerstore/test/benchmarks_suite.go
+++ b/p2p/host/peerstore/test/benchmarks_suite.go
@@ -36,11 +36,20 @@ func BenchmarkPeerstore(b *testing.B, factory PeerstoreFactory, variant string) 
 			ps, cleanup := factory()
 			defer cleanup()
 			b.ResetTimer()
+			itersPerBM := 10
 			for i := 0; i < b.N; i++ {
-				pp := peers[i%N]
-				ps.AddAddrs(pp.ID, pp.Addr, pstore.RecentlyConnectedAddrTTL)
-				ps.Addrs(pp.ID)
-				ps.ClearAddrs(pp.ID)
+				for j := 0; j < itersPerBM; j++ {
+					pp := peers[(i+j)%N]
+					ps.AddAddrs(pp.ID, pp.Addr, pstore.RecentlyConnectedAddrTTL)
+				}
+				for j := 0; j < itersPerBM; j++ {
+					pp := peers[(i+j)%N]
+					ps.Addrs(pp.ID)
+				}
+				for j := 0; j < itersPerBM; j++ {
+					pp := peers[(i+j)%N]
+					ps.ClearAddrs(pp.ID)
+				}
 			}
 		})
 


### PR DESCRIPTION
depends on #3092 

My intuition here was way off. The method spends most of the time either doing multiaddr ops or manipulating the heap(see the flamegraph). We don't need the sync.Pool. There's only a 5% difference without the pool. 


```
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem
cpu: AMD Ryzen 7 7840U w/ Radeon  780M Graphics     
                                          │   old.txt   │              new.txt               │
                                          │   sec/op    │   sec/op     vs base               │
InMemoryPeerstore/GetAndClearAddrs-1-16     8.351µ ± 2%   8.711µ ± 6%  +4.31% (p=0.019 n=10)
InMemoryPeerstore/GetAndClearAddrs-10-16    49.04µ ± 1%   49.75µ ± 1%  +1.45% (p=0.000 n=10)
InMemoryPeerstore/GetAndClearAddrs-100-16   462.6µ ± 1%   495.5µ ± 3%  +7.10% (p=0.000 n=10)
geomean                                     57.44µ        59.88µ       +4.26%
```

![addrbook-bm](https://github.com/user-attachments/assets/7a3f1345-4fe7-414d-b3cc-e751ca96a404)
