### PR TITLE
fix: typos in documentation files

### DIFF
--- a/dashboards/resource-manager/resource-manager.json
+++ b/dashboards/resource-manager/resource-manager.json
@@ -379,7 +379,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "How many streams does each protocol have open.\n\nA protocol is similiar to a service except there may be many protocols for a single service. A service may have \nmultiple protocols for backwards compatibility. For example, bitswap the service is a single entity, but it supports bitswap protocols v1.1 and v1.2.\n\nA service is attached to a stream manually by the protocol developer. A service may be missing if there is no `StreamScope.SetService` call.",
+      "description": "How many streams does each protocol have open.\n\nA protocol is similar to a service except there may be many protocols for a single service. A service may have \nmultiple protocols for backwards compatibility. For example, bitswap the service is a single entity, but it supports bitswap protocols v1.1 and v1.2.\n\nA service is attached to a stream manually by the protocol developer. A service may be missing if there is no `StreamScope.SetService` call.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1217,7 +1217,7 @@
           "refId": "A"
         }
       ],
-      "title": "Curent outbound connections per peer histogram. Across all instances",
+      "title": "Current outbound connections per peer histogram. Across all instances",
       "type": "bargauge"
     },
     {

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -402,7 +402,7 @@ func TestHostProtoMismatch(t *testing.T) {
 	defer h2.Close()
 
 	h1.SetStreamHandler("/super", func(s network.Stream) {
-		t.Error("shouldnt get here")
+		t.Error("shouldn't get here")
 		s.Reset()
 	})
 

--- a/p2p/host/peerstore/pstoremem/keybook.go
+++ b/p2p/host/peerstore/pstoremem/keybook.go
@@ -10,7 +10,7 @@ import (
 )
 
 type memoryKeyBook struct {
-	sync.RWMutex // same lock. wont happen a ton.
+	sync.RWMutex // same lock. won't happen a ton.
 	pks          map[peer.ID]ic.PubKey
 	sks          map[peer.ID]ic.PrivKey
 }

--- a/p2p/host/peerstore/pstoremem/sorting.go
+++ b/p2p/host/peerstore/pstoremem/sorting.go
@@ -35,7 +35,7 @@ func (al addrList) Less(i, j int) bool {
 		return fdb
 	}
 
-	// if 'b' doesnt take a file descriptor
+	// if 'b' doesn't take a file descriptor
 	if !fdb {
 		return false
 	}

--- a/p2p/host/peerstore/test/peerstore_suite.go
+++ b/p2p/host/peerstore/test/peerstore_suite.go
@@ -58,7 +58,7 @@ func testAddrStream(ps pstore.Peerstore) func(t *testing.T) {
 		addrch := ps.AddrStream(ctx, pid)
 
 		// while that subscription is active, publish ten more addrs
-		// this tests that it doesnt hang
+		// this tests that it doesn't hang
 		for i := 10; i < 20; i++ {
 			ps.AddAddr(pid, addrs[i], time.Hour)
 		}
@@ -116,7 +116,7 @@ func testAddrStream(ps pstore.Peerstore) func(t *testing.T) {
 
 		cancel2()
 
-		// and add a few more addresses it doesnt hang afterwards
+		// and add a few more addresses it doesn't hang afterwards
 		for _, a := range addrs[80:] {
 			ps.AddAddr(pid, a, time.Hour)
 		}

--- a/p2p/host/resource-manager/scope_test.go
+++ b/p2p/host/resource-manager/scope_test.go
@@ -744,13 +744,13 @@ func TestResourceScopeDAG(t *testing.T) {
 	checkResources(t, &s1.rc, network.ScopeStat{Memory: 3072})
 
 	if err := s4.ReserveMemory(1024, network.ReservationPriorityAlways); err == nil {
-		t.Fatal("expcted ReserveMemory to fail")
+		t.Fatal("expected ReserveMemory to fail")
 	}
 	if err := s5.ReserveMemory(1024, network.ReservationPriorityAlways); err == nil {
-		t.Fatal("expcted ReserveMemory to fail")
+		t.Fatal("expected ReserveMemory to fail")
 	}
 	if err := s6.ReserveMemory(1024, network.ReservationPriorityAlways); err == nil {
-		t.Fatal("expcted ReserveMemory to fail")
+		t.Fatal("expected ReserveMemory to fail")
 	}
 
 	checkResources(t, &s6.rc, network.ScopeStat{Memory: 1024})

--- a/p2p/net/mock/mock_test.go
+++ b/p2p/net/mock/mock_test.go
@@ -226,13 +226,13 @@ func TestNetworkSetup(t *testing.T) {
 		t.Errorf("should have 1 conn on initiator. Got: %d)", len(n2.Conns()))
 	}
 
-	// wait for reciever to see the conn.
+	// wait for receiver to see the conn.
 	for i := 0; i < 10 && len(n3.Conns()) == 0; i++ {
 		time.Sleep(time.Duration(10*i) * time.Millisecond)
 	}
 
 	if len(n3.Conns()) != 1 {
-		t.Errorf("should have 1 conn on reciever. Got: %d", len(n3.Conns()))
+		t.Errorf("should have 1 conn on receiver. Got: %d", len(n3.Conns()))
 	}
 
 	// p := PrinterTo(os.Stdout)


### PR DESCRIPTION
Corrected `similiar` to `similar`
Corrected `Curent` to `Current`
Corrected `shouldnt` to `shouldn't`
Corrected `wont` to `won't`
Corrected `doesnt` to `doesn't` x3
Corrected `expcted` to `expected` x3
Corrected `reciever` to `receiver` x2