### PR TITLE
ci: get back on the main release track of release checker

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -16,4 +16,4 @@ concurrency:
 
 jobs:
   release-check:
-    uses: marcopolo/unified-github-workflows/.github/workflows/release-check.yml@e66cb9667a2e1148efda4591e29c56258eaf385b
+    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0


### PR DESCRIPTION
@MarcoPolo Are we ready to get back to the main release track or is there some feature missing that you'd like us to add there?