### PR TITLE
quicreuse: make it possible to use an application-constructed quic.Transport

### DIFF
--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -138,21 +138,7 @@ func (c *ConnManager) AddTransport(network string, tr QUICTransport, conn net.Pa
 	if err != nil {
 		return err
 	}
-	if err := reuse.AddTransport(refCountedTr, localAddr); err != nil {
-		return err
-	}
-
-	ln, err := newQuicListener(refCountedTr, c.serverConfig)
-	if err != nil {
-		return err
-	}
-
-	key := conn.LocalAddr().String()
-	c.quicListeners[key] = quicListenerEntry{
-		refCount: 1,
-		ln:       ln,
-	}
-	return nil
+	return reuse.AddTransport(refCountedTr, localAddr)
 }
 
 func (c *ConnManager) ListenQUIC(addr ma.Multiaddr, tlsConf *tls.Config, allowWindowIncrease func(conn quic.Connection, delta uint64) bool) (Listener, error) {

--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -15,6 +15,14 @@ import (
 	quicmetrics "github.com/quic-go/quic-go/metrics"
 )
 
+type QUICListener interface {
+	Accept(ctx context.Context) (quic.Connection, error)
+	Close() error
+	Addr() net.Addr
+}
+
+var _ QUICListener = &quic.Listener{}
+
 type ConnManager struct {
 	reuseUDP4       *reuse
 	reuseUDP6       *reuse
@@ -201,7 +209,7 @@ func (c *ConnManager) transportForListen(association any, network string, laddr 
 	}
 	return &singleOwnerTransport{
 		packetConn: conn,
-		Transport: quic.Transport{
+		Transport: &quic.Transport{
 			Conn:              conn,
 			StatelessResetKey: &c.srk,
 			TokenGeneratorKey: &c.tokenKey,
@@ -279,7 +287,7 @@ func (c *ConnManager) TransportWithAssociationForDial(association any, network s
 	if err != nil {
 		return nil, err
 	}
-	return &singleOwnerTransport{Transport: quic.Transport{Conn: conn, StatelessResetKey: &c.srk}, packetConn: conn}, nil
+	return &singleOwnerTransport{Transport: &quic.Transport{Conn: conn, StatelessResetKey: &c.srk}, packetConn: conn}, nil
 }
 
 func (c *ConnManager) Protocols() []int {

--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -244,7 +244,6 @@ func (c *ConnManager) transportForListen(association any, network string, laddr 
 	}
 	return &singleOwnerTransport{
 		packetConn: conn,
-		localAddr:  conn.LocalAddr(),
 		Transport: &wrappedQUICTransport{
 			&quic.Transport{
 				Conn:              conn,

--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -130,7 +130,7 @@ func (c *ConnManager) AddTransport(network string, tr QUICTransport, conn net.Pa
 	refCountedTr := &refcountedTransport{
 		QUICTransport: tr,
 		packetConn:    conn,
-		refCount:      1,
+		isExternal:    true,
 	}
 
 	var reuse *reuse

--- a/p2p/transport/quicreuse/connmgr_test.go
+++ b/p2p/transport/quicreuse/connmgr_test.go
@@ -97,10 +97,9 @@ func TestConnectionPassedToQUICForListening(t *testing.T) {
 	quicTr, err := cm.transportForListen(nil, netw, naddr)
 	require.NoError(t, err)
 	defer quicTr.Close()
-	// TODO: fix test
-	// if _, ok := quicTr.(*singleOwnerTransport).Transport.Conn.(quic.OOBCapablePacketConn); !ok {
-	// 	t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
-	// }
+	if _, ok := quicTr.(*singleOwnerTransport).packetConn.(quic.OOBCapablePacketConn); !ok {
+		t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
+	}
 }
 
 func TestAcceptErrorGetCleanedUp(t *testing.T) {
@@ -157,10 +156,9 @@ func TestConnectionPassedToQUICForDialing(t *testing.T) {
 
 	require.NoError(t, err, "dial error")
 	defer quicTr.Close()
-	// TODO: fix test
-	// if _, ok := quicTr.(*singleOwnerTransport).Transport.Conn.(quic.OOBCapablePacketConn); !ok {
-	// 	t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
-	// }
+	if _, ok := quicTr.(*singleOwnerTransport).packetConn.(quic.OOBCapablePacketConn); !ok {
+		t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
+	}
 }
 
 func getTLSConfForProto(t *testing.T, alpn string) (peer.ID, *tls.Config) {

--- a/p2p/transport/quicreuse/connmgr_test.go
+++ b/p2p/transport/quicreuse/connmgr_test.go
@@ -97,9 +97,10 @@ func TestConnectionPassedToQUICForListening(t *testing.T) {
 	quicTr, err := cm.transportForListen(nil, netw, naddr)
 	require.NoError(t, err)
 	defer quicTr.Close()
-	if _, ok := quicTr.(*singleOwnerTransport).Transport.Conn.(quic.OOBCapablePacketConn); !ok {
-		t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
-	}
+	// TODO: fix test
+	// if _, ok := quicTr.(*singleOwnerTransport).Transport.Conn.(quic.OOBCapablePacketConn); !ok {
+	// 	t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
+	// }
 }
 
 func TestAcceptErrorGetCleanedUp(t *testing.T) {
@@ -156,9 +157,10 @@ func TestConnectionPassedToQUICForDialing(t *testing.T) {
 
 	require.NoError(t, err, "dial error")
 	defer quicTr.Close()
-	if _, ok := quicTr.(*singleOwnerTransport).Transport.Conn.(quic.OOBCapablePacketConn); !ok {
-		t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
-	}
+	// TODO: fix test
+	// if _, ok := quicTr.(*singleOwnerTransport).Transport.Conn.(quic.OOBCapablePacketConn); !ok {
+	// 	t.Fatal("connection passed to quic-go cannot be type asserted to a *net.UDPConn")
+	// }
 }
 
 func getTLSConfForProto(t *testing.T, alpn string) (peer.ID, *tls.Config) {

--- a/p2p/transport/quicreuse/connmgr_test.go
+++ b/p2p/transport/quicreuse/connmgr_test.go
@@ -259,3 +259,53 @@ func testListener(t *testing.T, enableReuseport bool) {
 
 	checkClosed(t, cm)
 }
+
+func TestExternalTransport(t *testing.T) {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero})
+	require.NoError(t, err)
+	defer conn.Close()
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	tr := &quic.Transport{Conn: conn}
+	defer tr.Close()
+
+	cm, err := NewConnManager(quic.StatelessResetKey{}, quic.TokenGeneratorKey{})
+	require.NoError(t, err)
+	require.NoError(t, cm.AddTransport("udp4", &wrappedQUICTransport{tr}, conn))
+
+	// make sure this transport is used when listening on the same port
+	ln, err := cm.ListenQUICAndAssociate(
+		"quic",
+		ma.StringCast(fmt.Sprintf("/ip4/0.0.0.0/udp/%d", port)),
+		&tls.Config{NextProtos: []string{"libp2p"}},
+		func(quic.Connection, uint64) bool { return false },
+	)
+	require.NoError(t, err)
+	defer ln.Close()
+	require.Equal(t, port, ln.Addr().(*net.UDPAddr).Port)
+
+	// make sure this transport is used when dialing out
+	udpLn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer udpLn.Close()
+	addrChan := make(chan net.Addr, 1)
+	go func() {
+		_, addr, _ := udpLn.ReadFrom(make([]byte, 2000))
+		addrChan <- addr
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = cm.DialQUIC(
+		ctx,
+		ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic-v1", udpLn.LocalAddr().(*net.UDPAddr).Port)),
+		&tls.Config{NextProtos: []string{"libp2p"}},
+		func(quic.Connection, uint64) bool { return false },
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	select {
+	case addr := <-addrChan:
+		require.Equal(t, port, addr.(*net.UDPAddr).Port)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/p2p/transport/quicreuse/listener.go
+++ b/p2p/transport/quicreuse/listener.go
@@ -29,7 +29,7 @@ type protoConf struct {
 }
 
 type quicListener struct {
-	l         *quic.Listener
+	l         QUICListener
 	transport refCountedQuicTransport
 	running   chan struct{}
 	addrs     []ma.Multiaddr

--- a/p2p/transport/quicreuse/nonquic_packetconn.go
+++ b/p2p/transport/quicreuse/nonquic_packetconn.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net"
 	"time"
-
-	"github.com/quic-go/quic-go"
 )
 
 // nonQUICPacketConn is a net.PacketConn that can be used to read and write
@@ -13,7 +11,7 @@ import (
 // other transports like WebRTC.
 type nonQUICPacketConn struct {
 	owningTransport refCountedQuicTransport
-	tr              *quic.Transport
+	tr              QUICTransport
 	ctx             context.Context
 	ctxCancel       context.CancelFunc
 	readCtx         context.Context
@@ -32,7 +30,7 @@ func (n *nonQUICPacketConn) Close() error {
 
 // LocalAddr implements net.PacketConn.
 func (n *nonQUICPacketConn) LocalAddr() net.Addr {
-	return n.tr.Conn.LocalAddr()
+	return n.owningTransport.LocalAddr()
 }
 
 // ReadFrom implements net.PacketConn.

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -382,13 +382,16 @@ func (r *reuse) TransportForListen(network string, laddr *net.UDPAddr) (*refcoun
 		packetConn: conn,
 	}
 	tr.IncreaseCount()
+	return tr, r.AddTransport(tr, localAddr)
+}
 
+func (r *reuse) AddTransport(tr *refcountedTransport, localAddr *net.UDPAddr) error {
 	// Deal with listen on a global address
 	if localAddr.IP.IsUnspecified() {
 		// The kernel already checked that the laddr is not already listen
 		// so we need not check here (when we create ListenUDP).
 		r.globalListeners[localAddr.Port] = tr
-		return tr, nil
+		return nil
 	}
 
 	// Deal with listen on a unicast address
@@ -402,7 +405,7 @@ func (r *reuse) TransportForListen(network string, laddr *net.UDPAddr) (*refcoun
 	// The kernel already checked that the laddr is not already listen
 	// so we need not check here (when we create ListenUDP).
 	r.unicast[localAddr.IP.String()][localAddr.Port] = tr
-	return tr, nil
+	return nil
 }
 
 func (r *reuse) Close() error {

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -33,8 +33,6 @@ type refCountedQuicTransport interface {
 type singleOwnerTransport struct {
 	Transport QUICTransport
 
-	localAddr net.Addr
-
 	// Used to write packets directly around QUIC.
 	packetConn net.PacketConn
 }
@@ -44,7 +42,7 @@ var _ QUICTransport = &singleOwnerTransport{}
 func (c *singleOwnerTransport) IncreaseCount() {}
 func (c *singleOwnerTransport) DecreaseCount() { c.Transport.Close() }
 func (c *singleOwnerTransport) LocalAddr() net.Addr {
-	return c.localAddr
+	return c.packetConn.LocalAddr()
 }
 
 func (c *singleOwnerTransport) Dial(ctx context.Context, addr net.Addr, tlsConf *tls.Config, conf *quic.Config) (quic.Connection, error) {


### PR DESCRIPTION
It would be nice if the application was able to construct its own `quic.Transport`, and have that transport used by libp2p.

This would allow an application:
* on the listener side: inject its own `tls.Config` on the `Listen` call, and `Accept` (a subset of) QUIC connections returned by the listener
* on the client side: dial QUIC connections without going through libp2p at all

This would make it possible to run a vanilla HTTP/3 server behind a NAT / firewall and use libp2p's NAT hole punching mechanism to create the NAT bindings.