### PR TITLE
swarm: remove unnecessary error log

### DIFF
--- a/p2p/net/swarm/swarm_transport.go
+++ b/p2p/net/swarm/swarm_transport.go
@@ -60,10 +60,6 @@ func (s *Swarm) TransportForListening(a ma.Multiaddr) transport.Transport {
 	s.transports.RLock()
 	defer s.transports.RUnlock()
 	if len(s.transports.m) == 0 {
-		// make sure we're not just shutting down.
-		if s.transports.m != nil {
-			log.Error("you have no transports configured")
-		}
 		return nil
 	}
 


### PR DESCRIPTION
There's no reason to log this error here, this is perfectly legal. We can make it a debug statement, but even that seems not useful. 