### PR TITLE
Fix typo Update README.md

### DIFF
--- a/examples/pubsub/chat/README.md
+++ b/examples/pubsub/chat/README.md
@@ -155,7 +155,7 @@ func (cr *ChatRoom) readLoop() {
 			return
 		}
 		// only forward messages delivered by others
-		if msg.ReceivedFrom == cr.self {
+		if msg.received from == cr.self {
 			continue
 		}
 		cm := new(ChatMessage)


### PR DESCRIPTION
# Pull Request Title: Fix Typo in README.md

## Description
This pull request corrects a typo in the `README.md` file. Specifically, the phrase `msg.ReceivedFrom == cr.self` has been changed to `msg.received from == cr.self`.

### Changes
- Corrected the typo in line 155 of `examples/pubsub/chat/README.md` from `msg.ReceivedFrom == cr.self` to `msg.received from == cr.self`.

## Related Issue
- No related issue.
