### PR TITLE
feat(transport/websocket): enable pulling http proxy from environment variables

### DIFF
--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -191,7 +191,7 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 		return nil, err
 	}
 	isWss := wsurl.Scheme == "wss"
-	dialer := ws.Dialer{HandshakeTimeout: 30 * time.Second}
+	dialer := ws.Dialer{HandshakeTimeout: 30 * time.Second, Proxy: http.ProxyFromEnvironment}
 	if isWss {
 		sni := ""
 		sni, err = raddr.ValueForProtocol(ma.P_SNI)


### PR DESCRIPTION
related to #286 it seems like there was an undocumented behavioral regression in https://github.com/libp2p/go-ws-transport/pull/116/commits/0ea4a8af2af12617080915a32326158bf8d95684 whereby we no longer respected various standard environment variables related to HTTP(S) proxies for the websocket transport. This puts the behavior back.

@parkan could you try this out in singularity and report back if it's good enough for your use case?

---

A few notes/areas for comment:
1. Any recommendations on testing to prevent regressions here? Importing a socks5 server library just for a test like this seems like overkill, but maybe folks have better ideas
2. Any objections to using the environment variables rather than making it an option?
3. Any recommendations on where to document this behavior? It seems like there's some documentation missing here that'd be nice (e.g. the environment variables go-libp2p users may want to set, even if they're from downstream libraries and we're not committed to them like for HTTP Proxies, go-log, etc.)