### PR TITLE
feat(transport/websocket): support SOCKS proxy with wss

### DIFF
--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -160,6 +160,8 @@ func (t *WebsocketTransport) Resolve(_ context.Context, maddr ma.Multiaddr) ([]m
 	return []ma.Multiaddr{parsed.toMultiaddr()}, nil
 }
 
+// Dial will dial the given multiaddr and expect the given peer. If an
+// HTTPS_PROXY env is set, it will use that for the dial out.
 func (t *WebsocketTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
 	connScope, err := t.rcmgr.OpenConnection(network.DirOutbound, true, raddr)
 	if err != nil {

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -209,7 +209,7 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 			copytlsClientConf := t.tlsClientConf.Clone()
 			copytlsClientConf.ServerName = sni
 			dialer.TLSClientConfig = copytlsClientConf
-			ipAddr := wsurl.Host
+			ipPortAddr := wsurl.Host
 			// We set the `.Host` to the sni field so that the host header gets properly set.
 			wsurl.Host = sni + ":" + wsurl.Port()
 			// Setting the NetDial because we already have the resolved IP address, so we can avoid another resolution.
@@ -217,7 +217,7 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 				var tcpAddr *net.TCPAddr
 				var err error
 				if address == wsurl.Host {
-					tcpAddr, err = net.ResolveTCPAddr(network, ipAddr) // Use our already resolved IP address
+					tcpAddr, err = net.ResolveTCPAddr(network, ipPortAddr) // Use our already resolved IP address
 				} else {
 					tcpAddr, err = net.ResolveTCPAddr(network, address)
 				}

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -615,7 +615,11 @@ func TestHTTPSProxyDoesSocks(t *testing.T) {
 	_, err = tpt.Dial(context.Background(), maToDial, "")
 	require.Error(t, err, "This should error as we don't have a real socks server")
 
-	if err := <-proxyServerErr; err != nil {
-		t.Fatal(err)
+	select {
+	case <-time.After(1 * time.Second):
+	case err := <-proxyServerErr:
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -15,6 +16,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -546,5 +548,74 @@ func TestResolveMultiaddr(t *testing.T) {
 
 			require.Equal(t, expectedMA, addrs[0].String())
 		})
+	}
+}
+
+func TestHTTPSProxyDoesSocks(t *testing.T) {
+	proxyServer, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	proxyServerErr := make(chan error, 1)
+
+	go func() {
+		defer proxyServer.Close()
+		c, err := proxyServer.Accept()
+		if err != nil {
+			proxyServerErr <- err
+			return
+		}
+		fmt.Println("c", c)
+		defer c.Close()
+
+		req := [32]byte{}
+		_, err = io.ReadFull(c, req[:3])
+		if err != nil {
+			proxyServerErr <- err
+			return
+		}
+
+		// Handshake a SOCKS5 client: https://www.rfc-editor.org/rfc/rfc1928.html#section-3
+		if !bytes.Equal([]byte{0x05, 0x01, 0x00}, req[:3]) {
+			t.Log("expected SOCKS5 connect request")
+			proxyServerErr <- err
+			return
+		}
+		_, err = c.Write([]byte{0x05, 0x00})
+		if err != nil {
+			proxyServerErr <- err
+			return
+		}
+
+		expectedBytes := "\x05\x01\x00\x03\x0bexample.com"
+		_, err = io.ReadFull(c, req[:len(expectedBytes)])
+		if err != nil {
+			proxyServerErr <- err
+			return
+		}
+		if !bytes.Equal([]byte(expectedBytes), req[:len(expectedBytes)]) {
+			t.Log("expected SOCKS5 connect request")
+			proxyServerErr <- err
+			return
+		}
+
+		proxyServerErr <- nil
+	}()
+
+	origEnv := os.Getenv("HTTPS_PROXY")
+	defer os.Setenv("HTTPS_PROXY", origEnv)
+
+	os.Setenv("HTTPS_PROXY", "socks5://"+proxyServer.Addr().String())
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true} // Our test server doesn't have a cert signed by a CA
+	_, u := newSecureUpgrader(t)
+	tpt, err := New(u, &network.NullResourceManager{}, nil, WithTLSClientConfig(tlsConfig))
+	require.NoError(t, err)
+
+	// This can be any wss address. We aren't actually going to dial it.
+	maToDial := ma.StringCast("/ip4/127.0.0.1/tcp/1/tls/sni/example.com/ws")
+	_, err = tpt.Dial(context.Background(), maToDial, "")
+	require.Error(t, err, "This should error as we don't have a real socks server")
+
+	if err := <-proxyServerErr; err != nil {
+		t.Fatal(err)
 	}
 }

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -563,7 +563,6 @@ func TestHTTPSProxyDoesSocks(t *testing.T) {
 			proxyServerErr <- err
 			return
 		}
-		fmt.Println("c", c)
 		defer c.Close()
 
 		req := [32]byte{}

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -612,6 +612,7 @@ func TestHTTPSProxyDoesSocks(t *testing.T) {
 	// This can be any wss address. We aren't actually going to dial it.
 	maToDial := ma.StringCast("/ip4/1.2.3.4/tcp/1/tls/sni/example.com/ws")
 	_, err = tpt.Dial(context.Background(), maToDial, "")
+	t.Log(err)
 	require.Error(t, err, "This should error as we don't have a real socks server")
 
 	select {

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -611,7 +611,7 @@ func TestHTTPSProxyDoesSocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// This can be any wss address. We aren't actually going to dial it.
-	maToDial := ma.StringCast("/ip4/127.0.0.1/tcp/1/tls/sni/example.com/ws")
+	maToDial := ma.StringCast("/ip4/1.2.3.4/tcp/1/tls/sni/example.com/ws")
 	_, err = tpt.Dial(context.Background(), maToDial, "")
 	require.Error(t, err, "This should error as we don't have a real socks server")
 


### PR DESCRIPTION
closes https://github.com/libp2p/go-libp2p/issues/286 (a 7 year old issue??)

This PR allows users to use a SOCKS5 proxy when dialing `/wss` addresses by using the `HTTPS_PROXY` environment variable. 

Here's an example using vole to dial through a socks proxy:

```
HTTPS_PROXY="socks5://127.0.0.1:9081" vole libp2p ping /dns4/am6.bootstrap.libp2p.io/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb
```