### PR TITLE
Update the basic-chat-with-rendezvous'Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,6 @@ Some notable users of go-libp2p are:
 - [Oasis Core](https://github.com/oasisprotocol/oasis-core) - The consensus and runtime layers of the [Oasis protocol](https://oasisprotocol.org/).
 - [Spacemesh](https://github.com/spacemeshos/go-spacemesh/) - The Go implementation of the [Spacemesh protocol](https://spacemesh.io/), a novel layer one blockchain
 - [Tau](https://github.com/taubyte/tau/) - Open source distributed Platform as a Service (PaaS)
+- [opBNB](https://github.com/bnb-chain/opbnb) - High-performance layer 2 solution for the BNB Smart Chain(BSC)
 
 Please open a pull request if you want your project (min. 250 GitHub stars) to be added here.

--- a/examples/pubsub/basic-chat-with-rendezvous/README.md
+++ b/examples/pubsub/basic-chat-with-rendezvous/README.md
@@ -32,5 +32,7 @@ go run . -topicName=adifferenttopic
 Try opening several terminals, each running the app. When you type a message and hit enter in one, it
 should appear in all others that are connected to the same topic.
 
+Note: if missing the message in some terminals when opened the terminal at the same time, try to reopen the terminal to execute `go run .`.
+
 To quit, hit `Ctrl-C`.
 


### PR DESCRIPTION
Note: if missing the message in some terminals when opened the terminal at the same time, try to reopen the terminal to execute `go run .`.