### PR TITLE
 fix in sdp.go

### DIFF
--- a/p2p/transport/webrtc/sdp.go
+++ b/p2p/transport/webrtc/sdp.go
@@ -123,7 +123,7 @@ func getSupportedSDPHash(code uint64) (crypto.Hash, bool) {
 // to a string format recognised by pion for fingerprint
 // algorithms
 func getSupportedSDPString(code uint64) (string, error) {
-	// values based on (cryto.Hash).String()
+	// values based on (crypto.Hash).String()
 	switch code {
 	case multihash.MD5:
 		return "md5", nil


### PR DESCRIPTION
# Title:
Fix Typo in `sdp.go`

# Description:
This pull request addresses a minor typo in the `sdp.go` file. Specifically, it corrects the word **"cryto"** to **"crypto"** to ensure proper spelling and maintain consistency.

# Changes:
- Corrected the typo **"cryto"** to **"crypto"** in the `getSupportedSDPString` function.

