### PR TITLE
fix typo Update swarm_dial.go

### DIFF
--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -383,7 +383,7 @@ func chainResolvers(ctx context.Context, addrs []ma.Multiaddr, outputLimit int, 
 }
 
 // resolveAddrs resolves DNS/DNSADDR components in the given peer's addresses.
-// We want to resolve the DNS components to IP addresses becase we want the
+// We want to resolve the DNS components to IP addresses because we want the
 // swarm to manage ranking and dialing multiple connections, and a single DNS
 // address can resolve to multiple IP addresses.
 func (s *Swarm) resolveAddrs(ctx context.Context, pi peer.AddrInfo) []ma.Multiaddr {


### PR DESCRIPTION
# Fix Typo in `swarm_dial.go`

**Author**: @MaxweLL22-22  
**Branch**: `MaxweLL22-22:Typo-fix`  
**Base**: `libp2p:master`  

## Description
This pull request fixes a typo in the `swarm_dial.go` file by correcting "becase" to "because" to improve code clarity and professionalism.

## Changes
- Corrected the typo: replaced "becase" with "because."

## Commit Details
- **Commit**: `fix typo Update swarm_dial.go`  
- **Contributor**: @MaxweLL22-22  
- **Date**: January 22, 2025  

## Additional Notes
- Maintainers are allowed to edit this pull request if needed.
- Contributions adhere to the repository’s security policy.
