### PR TITLE
Add support for network interfaces in mDNS configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66
 	github.com/raulk/go-watchdog v1.3.0
 	github.com/stretchr/testify v1.10.0
+	github.com/wlynxg/anet v0.0.5
 	go.uber.org/fx v1.23.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.5.0
@@ -127,7 +128,6 @@ require (
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
-	github.com/wlynxg/anet v0.0.5 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect

--- a/p2p/discovery/mdns/mdns.go
+++ b/p2p/discovery/mdns/mdns.go
@@ -3,6 +3,7 @@ package mdns
 import (
 	"context"
 	"errors"
+	"github.com/wlynxg/anet"
 	"io"
 	"math/rand"
 	"strings"
@@ -133,6 +134,11 @@ func (s *mdnsService) startServer() error {
 		return err
 	}
 
+	ifaces, err := anet.Interfaces()
+	if err != nil {
+		return err
+	}
+
 	server, err := zeroconf.RegisterProxy(
 		s.peerName,
 		s.serviceName,
@@ -141,7 +147,7 @@ func (s *mdnsService) startServer() error {
 		s.peerName,
 		ips,
 		txts,
-		nil,
+		ifaces,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit addresses an issue encountered on Android devices when using the [zeroconf] package, which results in the following error:

```
[zeroconf] no suitable IPv4 interface: udp4: failed to join any of these interfaces: []
```

The root cause of this issue is that the zeroconf package fails to properly detect network interfaces on Android. To resolve this, I have implementation with anet, which includes a fix specifically targeting Android compatibility.

Additionally, a similar issue exists in the package github.com/multiformats/go-multiaddr, where it fails to handle network interfaces correctly on Android. I worked around this issue with the following commit:

[8491a6c56a51cc4dec517388f4f044d939896984](https://github.com/cpeliciari/go-multiaddr/commit/8491a6c56a51cc4dec517388f4f044d939896984)