### PR TITLE
Add host with circuitv2 to integration test

### DIFF
--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -188,6 +188,22 @@ var transportsToTest = []TransportTestCase{
 			return h
 		},
 	},
+	{
+		Name: "Circuit V2",
+		HostGenerator: func(t *testing.T, opts TransportTestCaseOpts) host.Host {
+			libp2pOpts := transformOpts(opts)
+			libp2pOpts = append(libp2pOpts, libp2p.EnableRelay())
+			libp2pOpts = append(libp2pOpts, libp2p.EnableRelayService())
+			if opts.NoListen {
+				libp2pOpts = append(libp2pOpts, libp2p.NoListenAddrs)
+			} else {
+				libp2pOpts = append(libp2pOpts, libp2p.ListenAddrStrings(("/ip4/127.0.0.1/tcp/0/ws")))
+			}
+			h, err := libp2p.New(libp2pOpts...)
+			require.NoError(t, err)
+			return h
+		},
+	},
 }
 
 func TestPing(t *testing.T) {


### PR DESCRIPTION
### Description

- Resolve https://github.com/libp2p/go-libp2p/issues/3095
- Add host with `circuitv2` to transport integration test