### PR TITLE
test(p2p/protocol/identify): Fix user agent assertion in Go 1.24

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -19,6 +19,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/record"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	useragent "github.com/libp2p/go-libp2p/p2p/protocol/identify/internal/user-agent"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify/pb"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -53,8 +54,6 @@ const (
 	recentlyConnectedPeerMaxAddrs = 20
 	connectedPeerMaxAddrs         = 500
 )
-
-var defaultUserAgent = "github.com/libp2p/go-libp2p"
 
 type identifySnapshot struct {
 	seq       uint64
@@ -188,7 +187,7 @@ func NewIDService(h host.Host, opts ...Option) (*idService, error) {
 		opt(&cfg)
 	}
 
-	userAgent := defaultUserAgent
+	userAgent := useragent.DefaultUserAgent()
 	if cfg.userAgent != "" {
 		userAgent = cfg.userAgent
 	}

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	useragent "github.com/libp2p/go-libp2p/p2p/protocol/identify/internal/user-agent"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify/pb"
 
 	mockClock "github.com/benbjohnson/clock"
@@ -45,7 +46,7 @@ func testKnowsAddrs(t *testing.T, h host.Host, p peer.ID, expected []ma.Multiadd
 func testHasAgentVersion(t *testing.T, h host.Host, p peer.ID) {
 	v, err := h.Peerstore().Get(p, "AgentVersion")
 	require.NoError(t, err, "fetching agent version")
-	require.Equal(t, "github.com/libp2p/go-libp2p", v, "agent version")
+	require.Equal(t, useragent.DefaultUserAgent(), v, "agent version")
 }
 
 func testHasPublicKey(t *testing.T, h host.Host, p peer.ID, shouldBe ic.PubKey) {

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -104,7 +104,7 @@ func emitAddrChangeEvt(t *testing.T, h host.Host) {
 	}
 }
 
-// TestIDServiceWait gives the ID service 1s to finish after dialing
+// TestIDService gives the ID service 1s to finish after dialing
 // this is because it used to be concurrent. Now, Dial wait till the
 // id service is done.
 func TestIDService(t *testing.T) {

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -44,9 +44,8 @@ func testKnowsAddrs(t *testing.T, h host.Host, p peer.ID, expected []ma.Multiadd
 
 func testHasAgentVersion(t *testing.T, h host.Host, p peer.ID) {
 	v, err := h.Peerstore().Get(p, "AgentVersion")
-	if v.(string) != "github.com/libp2p/go-libp2p" { // this is the default user agent
-		t.Error("agent version mismatch", err)
-	}
+	require.NoError(t, err, "fetching agent version")
+	require.Equal(t, "github.com/libp2p/go-libp2p", v, "agent version")
 }
 
 func testHasPublicKey(t *testing.T, h host.Host, p peer.ID, shouldBe ic.PubKey) {

--- a/p2p/protocol/identify/internal/user-agent/user_agent.go
+++ b/p2p/protocol/identify/internal/user-agent/user_agent.go
@@ -1,9 +1,15 @@
-package identify
+package useragent
 
 import (
 	"fmt"
 	"runtime/debug"
 )
+
+func DefaultUserAgent() string {
+	return defaultUserAgent
+}
+
+var defaultUserAgent = "github.com/libp2p/go-libp2p"
 
 func init() {
 	bi, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
Fixes #3176