### PR TITLE
feat(swarm): logging waitForDirectConn return error

### DIFF
--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -510,6 +510,7 @@ func (s *Swarm) NewStream(ctx context.Context, p peer.ID) (network.Stream, error
 			var err error
 			c, err = s.waitForDirectConn(ctx, p)
 			if err != nil {
+				log.Debugf("[%s] waitForDirectConn error: %s", p, err)
 				return nil, err
 			}
 		}

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -510,7 +510,7 @@ func (s *Swarm) NewStream(ctx context.Context, p peer.ID) (network.Stream, error
 			var err error
 			c, err = s.waitForDirectConn(ctx, p)
 			if err != nil {
-				log.Debugf("[%s] waitForDirectConn error: %s", p, err)
+				log.Debugf("failed to get direct connection to a limited peer %s: %s", p, err)
 				return nil, err
 			}
 		}


### PR DESCRIPTION
When I tested the relay connection with the new version, I was able to successfully connect to the server peer, but a `context deadline exceeded` error occurred when calling `NewStream` because `WithAllowLimitedConn` was not used.

This error caused me trouble, and I finally found that it was a timeout in `waitForDirectConn` (because my environment could not successfully holepunch).

Logging the errors returned by waitForDirectConn can help more developers locate errors and know through code logic that WithAllowLimitedConn is needed.