### PR TITLE
chore(identify): move log to debug level

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -797,7 +797,7 @@ func (ids *idService) consumeMessage(mes *pb.Identify, c network.Conn, isPush bo
 	// otherwise use the unsigned addresses.
 	signedPeerRecord, err := signedPeerRecordFromMessage(mes)
 	if err != nil {
-		log.Errorf("error getting peer record from Identify message: %v", err)
+		log.Debugf("error getting peer record from Identify message: %v", err)
 	}
 
 	// Extend the TTLs on the known (probably) good addresses.


### PR DESCRIPTION
We've started seeing this ERROR in long-running Kubo nodes:

```
2025-02-23T23:15:04.924Z	ERROR	net/identify	identify/id.go:801	error getting peer record from Identify message: failed to validate envelope: invalid signature or incorrect domain
2025-02-24T03:14:47.091Z	ERROR	net/identify	identify/id.go:801	error getting peer record from Identify message: failed to validate envelope: invalid signature or incorrect domain
```

Seems to occur quite  often these days, likely due to some custom clients probing network.

This PR is moving this message to debug since (1) it is not a hard error (2) other errors of similar non-fatal category log to debug already