### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/p2p/host/blank/blank.go
+++ b/p2p/host/blank/blank.go
@@ -140,7 +140,7 @@ func (bh *BlankHost) Connect(ctx context.Context, ai peer.AddrInfo) error {
 	if err != nil {
 		return fmt.Errorf("failed to dial: %w", err)
 	}
-	return err
+	return nil
 }
 
 func (bh *BlankHost) Peerstore() peerstore.Peerstore {


### PR DESCRIPTION
The error here must be nil because a check for err != nil has already been performed earlier.

Use a more straightforward return value.