### PR TITLE
refactor: unify the error handling methods that are different from the project style

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ type Config struct {
 
 func (cfg *Config) makeSwarm(eventBus event.Bus, enableMetrics bool) (*swarm.Swarm, error) {
 	if cfg.Peerstore == nil {
-		return nil, fmt.Errorf("no peerstore specified")
+		return nil, errors.New("no peerstore specified")
 	}
 
 	// Check this early. Prevents us from even *starting* without verifying this.
@@ -166,7 +166,7 @@ func (cfg *Config) makeSwarm(eventBus event.Bus, enableMetrics bool) (*swarm.Swa
 	}
 
 	if cfg.PeerKey == nil {
-		return nil, fmt.Errorf("no peer key specified")
+		return nil, errors.New("no peer key specified")
 	}
 
 	// Obtain Peer ID from public key
@@ -448,7 +448,7 @@ func (cfg *Config) newBasicHost(swrm *swarm.Swarm, eventBus event.Bus) (*bhost.B
 
 func (cfg *Config) validate() error {
 	if cfg.EnableAutoRelay && !cfg.Relay {
-		return fmt.Errorf("cannot enable autorelay; relay is not enabled")
+		return errors.New("cannot enable autorelay; relay is not enabled")
 	}
 	// If possible check that the resource manager conn limit is higher than the
 	// limit set in the conn manager.

--- a/options.go
+++ b/options.go
@@ -73,7 +73,7 @@ func ListenAddrs(addrs ...ma.Multiaddr) Option {
 func Security(name string, constructor interface{}) Option {
 	return func(cfg *Config) error {
 		if cfg.Insecure {
-			return fmt.Errorf("cannot use security transports with an insecure libp2p configuration")
+			return errors.New("cannot use security transports with an insecure libp2p configuration")
 		}
 		cfg.SecurityTransports = append(cfg.SecurityTransports, config.Security{ID: protocol.ID(name), Constructor: constructor})
 		return nil
@@ -84,7 +84,7 @@ func Security(name string, constructor interface{}) Option {
 // It's incompatible with all other transport security protocols.
 var NoSecurity Option = func(cfg *Config) error {
 	if len(cfg.SecurityTransports) > 0 {
-		return fmt.Errorf("cannot use security transports with an insecure libp2p configuration")
+		return errors.New("cannot use security transports with an insecure libp2p configuration")
 	}
 	cfg.Insecure = true
 	return nil
@@ -198,7 +198,7 @@ func Transport(constructor interface{}, opts ...interface{}) Option {
 func Peerstore(ps peerstore.Peerstore) Option {
 	return func(cfg *Config) error {
 		if cfg.Peerstore != nil {
-			return fmt.Errorf("cannot specify multiple peerstore options")
+			return errors.New("cannot specify multiple peerstore options")
 		}
 
 		cfg.Peerstore = ps
@@ -210,7 +210,7 @@ func Peerstore(ps peerstore.Peerstore) Option {
 func PrivateNetwork(psk pnet.PSK) Option {
 	return func(cfg *Config) error {
 		if cfg.PSK != nil {
-			return fmt.Errorf("cannot specify multiple private network options")
+			return errors.New("cannot specify multiple private network options")
 		}
 
 		cfg.PSK = psk
@@ -222,7 +222,7 @@ func PrivateNetwork(psk pnet.PSK) Option {
 func BandwidthReporter(rep metrics.Reporter) Option {
 	return func(cfg *Config) error {
 		if cfg.Reporter != nil {
-			return fmt.Errorf("cannot specify multiple bandwidth reporter options")
+			return errors.New("cannot specify multiple bandwidth reporter options")
 		}
 
 		cfg.Reporter = rep
@@ -234,7 +234,7 @@ func BandwidthReporter(rep metrics.Reporter) Option {
 func Identity(sk crypto.PrivKey) Option {
 	return func(cfg *Config) error {
 		if cfg.PeerKey != nil {
-			return fmt.Errorf("cannot specify multiple identities")
+			return errors.New("cannot specify multiple identities")
 		}
 
 		cfg.PeerKey = sk
@@ -249,7 +249,7 @@ func Identity(sk crypto.PrivKey) Option {
 func ConnectionManager(connman connmgr.ConnManager) Option {
 	return func(cfg *Config) error {
 		if cfg.ConnManager != nil {
-			return fmt.Errorf("cannot specify multiple connection managers")
+			return errors.New("cannot specify multiple connection managers")
 		}
 		cfg.ConnManager = connman
 		return nil
@@ -260,7 +260,7 @@ func ConnectionManager(connman connmgr.ConnManager) Option {
 func AddrsFactory(factory config.AddrsFactory) Option {
 	return func(cfg *Config) error {
 		if cfg.AddrsFactory != nil {
-			return fmt.Errorf("cannot specify multiple address factories")
+			return errors.New("cannot specify multiple address factories")
 		}
 		cfg.AddrsFactory = factory
 		return nil
@@ -426,7 +426,7 @@ func NATPortMap() Option {
 func NATManager(nm config.NATManagerC) Option {
 	return func(cfg *Config) error {
 		if cfg.NATManager != nil {
-			return fmt.Errorf("cannot specify multiple NATManagers")
+			return errors.New("cannot specify multiple NATManagers")
 		}
 		cfg.NATManager = nm
 		return nil
@@ -445,7 +445,7 @@ func Ping(enable bool) Option {
 func Routing(rt config.RoutingC) Option {
 	return func(cfg *Config) error {
 		if cfg.Routing != nil {
-			return fmt.Errorf("cannot specify multiple routing options")
+			return errors.New("cannot specify multiple routing options")
 		}
 		cfg.Routing = rt
 		return nil

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -490,7 +490,7 @@ func (rf *relayFinder) handleNewNode(ctx context.Context, pi peer.AddrInfo) (add
 	supportsV2, err := rf.tryNode(ctx, pi)
 	if err != nil {
 		log.Debugf("node %s not accepted as a candidate: %s", pi.ID, err)
-		if err == errProtocolNotSupported {
+		if errors.Is(err, errProtocolNotSupported) {
 			rf.metricsTracer.CandidateChecked(false)
 		}
 		return false

--- a/p2p/host/eventbus/basic.go
+++ b/p2p/host/eventbus/basic.go
@@ -44,7 +44,7 @@ type emitter struct {
 
 func (e *emitter) Emit(evt interface{}) error {
 	if e.closed.Load() {
-		return fmt.Errorf("emitter is closed")
+		return errors.New("emitter is closed")
 	}
 
 	e.n.emit(evt)
@@ -58,7 +58,7 @@ func (e *emitter) Emit(evt interface{}) error {
 
 func (e *emitter) Close() error {
 	if !e.closed.CompareAndSwap(false, true) {
-		return fmt.Errorf("closed an emitter more than once")
+		return errors.New("closed an emitter more than once")
 	}
 	if e.n.nEmitters.Add(-1) == 0 {
 		e.dropper(e.typ)
@@ -238,7 +238,7 @@ func (b *basicBus) Subscribe(evtTypes interface{}, opts ...event.SubscriptionOpt
 	if len(types) > 1 {
 		for _, t := range types {
 			if t == event.WildcardSubscription {
-				return nil, fmt.Errorf("wildcard subscriptions must be started separately")
+				return nil, errors.New("wildcard subscriptions must be started separately")
 			}
 		}
 	}
@@ -293,7 +293,7 @@ func (b *basicBus) Subscribe(evtTypes interface{}, opts ...event.SubscriptionOpt
 // emit(EventT{})
 func (b *basicBus) Emitter(evtType interface{}, opts ...event.EmitterOpt) (e event.Emitter, err error) {
 	if evtType == event.WildcardSubscription {
-		return nil, fmt.Errorf("illegal emitter for wildcard subscription")
+		return nil, errors.New("illegal emitter for wildcard subscription")
 	}
 
 	var settings emitterSettings

--- a/p2p/host/peerstore/pstoreds/addr_book.go
+++ b/p2p/host/peerstore/pstoreds/addr_book.go
@@ -3,6 +3,7 @@ package pstoreds
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -290,10 +291,10 @@ func (ab *dsAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, ttl tim
 	}
 	rec, ok := r.(*peer.PeerRecord)
 	if !ok {
-		return false, fmt.Errorf("envelope did not contain PeerRecord")
+		return false, errors.New("envelope did not contain PeerRecord")
 	}
 	if !rec.PeerID.MatchesPublicKey(recordEnvelope.PublicKey) {
-		return false, fmt.Errorf("signing key does not match PeerID in PeerRecord")
+		return false, errors.New("signing key does not match PeerID in PeerRecord")
 	}
 
 	// ensure that the seq number from envelope is >= any previously received seq no

--- a/p2p/host/peerstore/pstoreds/keybook.go
+++ b/p2p/host/peerstore/pstoreds/keybook.go
@@ -40,7 +40,7 @@ func (kb *dsKeyBook) PubKey(p peer.ID) ic.PubKey {
 		if err != nil {
 			log.Errorf("error when unmarshalling pubkey from datastore for peer %s: %s\n", p, err)
 		}
-	} else if err == ds.ErrNotFound {
+	} else if errors.Is(err, ds.ErrNotFound) {
 		pk, err = p.ExtractPublicKey()
 		switch err {
 		case nil:

--- a/p2p/host/peerstore/pstoreds/metadata.go
+++ b/p2p/host/peerstore/pstoreds/metadata.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"errors"
 
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -45,7 +46,7 @@ func (pm *dsPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
 	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).ChildString(key)
 	value, err := pm.ds.Get(context.TODO(), k)
 	if err != nil {
-		if err == ds.ErrNotFound {
+		if errors.Is(err, ds.ErrNotFound) {
 			err = pstore.ErrNotFound
 		}
 		return nil, err

--- a/p2p/host/peerstore/pstoreds/protobook.go
+++ b/p2p/host/peerstore/pstoreds/protobook.go
@@ -2,7 +2,6 @@ package pstoreds
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -184,7 +183,7 @@ func (pb *dsProtoBook) getProtocolMap(p peer.ID) (map[protocol.ID]struct{}, erro
 	case nil:
 		cast, ok := iprotomap.(map[protocol.ID]struct{})
 		if !ok {
-			return nil, fmt.Errorf("stored protocol set was not a map")
+			return nil, errors.New("stored protocol set was not a map")
 		}
 
 		return cast, nil

--- a/p2p/host/peerstore/pstoremem/addr_book.go
+++ b/p2p/host/peerstore/pstoremem/addr_book.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -298,10 +297,10 @@ func (mab *memoryAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, tt
 	}
 	rec, ok := r.(*peer.PeerRecord)
 	if !ok {
-		return false, fmt.Errorf("unable to process envelope: not a PeerRecord")
+		return false, errors.New("unable to process envelope: not a PeerRecord")
 	}
 	if !rec.PeerID.MatchesPublicKey(recordEnvelope.PublicKey) {
-		return false, fmt.Errorf("signing key does not match PeerID in PeerRecord")
+		return false, errors.New("signing key does not match PeerID in PeerRecord")
 	}
 
 	mab.mu.Lock()

--- a/p2p/host/resource-manager/rcmgr.go
+++ b/p2p/host/resource-manager/rcmgr.go
@@ -2,6 +2,7 @@ package rcmgr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"strings"
@@ -352,7 +353,7 @@ func (r *resourceManager) OpenConnection(dir network.Direction, usefd bool, endp
 
 	ipAddr, ok := netip.AddrFromSlice(ip)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert ip to netip.Addr")
+		return nil, errors.New("failed to convert ip to netip.Addr")
 	}
 	return r.openConnection(dir, usefd, endpoint, ipAddr)
 }
@@ -757,7 +758,7 @@ func (s *connectionScope) SetPeer(p peer.ID) error {
 	defer s.Unlock()
 
 	if s.peer != nil {
-		return fmt.Errorf("connection scope already attached to a peer")
+		return errors.New("connection scope already attached to a peer")
 	}
 
 	system := s.rcmgr.system

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -2,7 +2,7 @@ package routedhost
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/connmgr"
@@ -151,7 +151,7 @@ func (rh *RoutedHost) findPeerAddrs(ctx context.Context, id peer.ID) ([]ma.Multi
 	}
 
 	if pi.ID != id {
-		err = fmt.Errorf("routing failure: provided addrs for different peer")
+		err = errors.New("routing failure: provided addrs for different peer")
 		log.Errorw("got wrong peer",
 			"error", err,
 			"wantedPeer", id,

--- a/p2p/http/auth/internal/handshake/handshake.go
+++ b/p2p/http/auth/internal/handshake/handshake.go
@@ -81,7 +81,7 @@ func (p *params) parsePeerIDAuthSchemeParams(headerVal []byte) error {
 			p.sigB64 = v
 		}
 	}
-	if err == bufio.ErrFinalToken {
+	if errors.Is(err, bufio.ErrFinalToken) {
 		err = nil
 	}
 	return err
@@ -169,7 +169,7 @@ type sigParam struct {
 
 func verifySig(publicKey crypto.PubKey, prefix string, signedParts []sigParam, sig []byte) error {
 	if publicKey == nil {
-		return fmt.Errorf("no public key to verify signature")
+		return errors.New("no public key to verify signature")
 	}
 
 	b := pool.Get(4096)
@@ -183,7 +183,7 @@ func verifySig(publicKey crypto.PubKey, prefix string, signedParts []sigParam, s
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("signature verification failed")
+		return errors.New("signature verification failed")
 	}
 
 	return nil

--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -3,6 +3,7 @@ package mocknet
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -277,11 +278,11 @@ func (mn *mocknet) LinkPeers(p1, p2 peer.ID) (Link, error) {
 	mn.Unlock()
 
 	if n1 == nil {
-		return nil, fmt.Errorf("network for p1 not in mocknet")
+		return nil, errors.New("network for p1 not in mocknet")
 	}
 
 	if n2 == nil {
-		return nil, fmt.Errorf("network for p2 not in mocknet")
+		return nil, errors.New("network for p2 not in mocknet")
 	}
 
 	return mn.LinkNets(n1, n2)
@@ -292,11 +293,11 @@ func (mn *mocknet) validate(n network.Network) (*peernet, error) {
 
 	nr, ok := n.(*peernet)
 	if !ok {
-		return nil, fmt.Errorf("network not supported (use mock package nets only)")
+		return nil, errors.New("network not supported (use mock package nets only)")
 	}
 
 	if _, found := mn.nets[nr.peer]; !found {
-		return nil, fmt.Errorf("network not on mocknet. is it from another mocknet?")
+		return nil, errors.New("network not on mocknet. is it from another mocknet?")
 	}
 
 	return nr, nil
@@ -326,7 +327,7 @@ func (mn *mocknet) Unlink(l2 Link) error {
 
 	l, ok := l2.(*link)
 	if !ok {
-		return fmt.Errorf("only links from mocknet are supported")
+		return errors.New("only links from mocknet are supported")
 	}
 
 	mn.removeLink(l)
@@ -336,7 +337,7 @@ func (mn *mocknet) Unlink(l2 Link) error {
 func (mn *mocknet) UnlinkPeers(p1, p2 peer.ID) error {
 	ls := mn.LinksBetweenPeers(p1, p2)
 	if ls == nil {
-		return fmt.Errorf("no link between p1 and p2")
+		return errors.New("no link between p1 and p2")
 	}
 
 	for _, l := range ls {

--- a/p2p/net/nat/internal/nat/upnp.go
+++ b/p2p/net/nat/internal/nat/upnp.go
@@ -2,7 +2,7 @@ package nat
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -109,7 +109,7 @@ func serviceVisitor(ctx context.Context, rootDevice *goupnp.RootDevice, outNats 
 
 		case internetgateway2.URN_WANIPConnection_2:
 			if rootDevice.Device.DeviceType == internetgateway2.URN_WANConnectionDevice_1 {
-				*outErrs = append(*outErrs, fmt.Errorf("found V2 service on V1 device"))
+				*outErrs = append(*outErrs, errors.New("found V2 service on V1 device"))
 				return
 			}
 			client := &internetgateway2.WANIPConnection2{ServiceClient: goupnp.ServiceClient{

--- a/p2p/net/swarm/dial_worker.go
+++ b/p2p/net/swarm/dial_worker.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"time"
@@ -414,7 +415,7 @@ func (w *dialWorker) dispatchError(ad *addrDial, err error) {
 	// this is necessary to support active listen scenarios, where a new dial comes in while
 	// another dial is in progress, and needs to do a direct connection without inhibitions from
 	// dial backoff.
-	if err == ErrDialBackoff {
+	if errors.Is(err, ErrDialBackoff) {
 		delete(w.trackedDials, string(ad.addr.Bytes()))
 	}
 }

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -933,7 +933,7 @@ func (r ResolverFromMaDNS) ResolveDNSAddr(ctx context.Context, expectedPeerID pe
 	if expectedPeerID != "" {
 		removeMismatchPeerID := func(a ma.Multiaddr) bool {
 			id, err := peer.IDFromP2PAddr(a)
-			if err == peer.ErrInvalidAddr {
+			if errors.Is(err, peer.ErrInvalidAddr) {
 				// This multiaddr didn't contain a peer id, assume it's for this peer.
 				// Handshake will fail later if it's not.
 				return false

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -270,7 +270,7 @@ func (s *Swarm) dialPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 		if conn.RemotePeer() != p {
 			conn.Close()
 			log.Errorw("Handshake failed to properly authenticate peer", "authenticated", conn.RemotePeer(), "expected", p)
-			return nil, fmt.Errorf("unexpected peer")
+			return nil, errors.New("unexpected peer")
 		}
 		return conn, nil
 	}

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -2,6 +2,7 @@ package upgrader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -63,7 +64,7 @@ func (l *listener) handleIncoming() {
 		// make sure we're closed
 		l.Listener.Close()
 		if l.err == nil {
-			l.err = fmt.Errorf("listener closed")
+			l.err = errors.New("listener closed")
 		}
 
 		wg.Wait()

--- a/p2p/net/upgrader/upgrader.go
+++ b/p2p/net/upgrader/upgrader.go
@@ -240,7 +240,7 @@ func (u *upgrader) negotiateMuxer(nc net.Conn, isServer bool) (*StreamMuxer, err
 	if m := u.getMuxerByID(proto); m != nil {
 		return m, nil
 	}
-	return nil, fmt.Errorf("selected protocol we don't have a transport for")
+	return nil, errors.New("selected protocol we don't have a transport for")
 }
 
 func (u *upgrader) getMuxerByID(id protocol.ID) *StreamMuxer {

--- a/p2p/test/resource-manager/echo.go
+++ b/p2p/test/resource-manager/echo.go
@@ -2,7 +2,7 @@ package itest
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"sync"
 	"time"
@@ -286,7 +286,7 @@ func (e *Echo) Echo(p peer.ID, what string) error {
 	}
 
 	if what != string(buf[:n]) {
-		return fmt.Errorf("echo output doesn't match input")
+		return errors.New("echo output doesn't match input")
 	}
 
 	return nil


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.