### PR TITLE
optimize: using t.TempDir() replace os.MkdirTemp in testfile

### DIFF
--- a/p2p/transport/quicreuse/tracer_test.go
+++ b/p2p/transport/quicreuse/tracer_test.go
@@ -13,13 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createLogDir(t *testing.T) string {
-	dir, err := os.MkdirTemp("", "libp2p-quic-transport-test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	return dir
-}
-
 func getFile(t *testing.T, dir string) os.FileInfo {
 	files, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -30,7 +23,7 @@ func getFile(t *testing.T, dir string) os.FileInfo {
 }
 
 func TestSaveQlog(t *testing.T) {
-	qlogDir := createLogDir(t)
+	qlogDir := t.TempDir()
 	logger := newQlogger(qlogDir, logging.PerspectiveServer, quic.ConnectionIDFromBytes([]byte{0xde, 0xad, 0xbe, 0xef}))
 	file := getFile(t, qlogDir)
 	require.Equal(t, ".", string(file.Name()[0]))
@@ -45,7 +38,7 @@ func TestSaveQlog(t *testing.T) {
 }
 
 func TestQlogBuffering(t *testing.T) {
-	qlogDir := createLogDir(t)
+	qlogDir := t.TempDir()
 	logger := newQlogger(qlogDir, logging.PerspectiveServer, quic.ConnectionIDFromBytes([]byte("connid")))
 	initialSize := getFile(t, qlogDir).Size()
 	// Do a small write.
@@ -60,7 +53,7 @@ func TestQlogBuffering(t *testing.T) {
 }
 
 func TestQlogCompression(t *testing.T) {
-	qlogDir := createLogDir(t)
+	qlogDir := t.TempDir()
 	logger := newQlogger(qlogDir, logging.PerspectiveServer, quic.ConnectionIDFromBytes([]byte("connid")))
 	logger.Write([]byte("foobar"))
 	require.NoError(t, logger.Close())


### PR DESCRIPTION
logs:
```
➜  go-libp2p git:(master) ✗ go test -v ./p2p/transport/quicreuse/  -run '' 

=== RUN   TestListenOnSameProto
=== RUN   TestListenOnSameProto/with_reuseport
=== RUN   TestListenOnSameProto/without_reuseport
--- PASS: TestListenOnSameProto (0.02s)
    --- PASS: TestListenOnSameProto/with_reuseport (0.01s)
    --- PASS: TestListenOnSameProto/without_reuseport (0.01s)
=== RUN   TestConnectionPassedToQUICForListening
--- PASS: TestConnectionPassedToQUICForListening (0.00s)
=== RUN   TestAcceptErrorGetCleanedUp
    connmgr_test.go:113: num goroutines: 7
    connmgr_test.go:127: num goroutines: 7
--- PASS: TestAcceptErrorGetCleanedUp (0.00s)
=== RUN   TestConnectionPassedToQUICForDialing
--- PASS: TestConnectionPassedToQUICForDialing (0.00s)
=== RUN   TestListener
=== RUN   TestListener/with_reuseport
=== RUN   TestListener/without_reuseport
--- PASS: TestListener (0.04s)
    --- PASS: TestListener/with_reuseport (0.02s)
    --- PASS: TestListener/without_reuseport (0.02s)
=== RUN   TestExternalTransport
--- PASS: TestExternalTransport (0.02s)
=== RUN   TestConvertToQuicMultiaddr
--- PASS: TestConvertToQuicMultiaddr (0.00s)
=== RUN   TestConvertToQuicV1Multiaddr
--- PASS: TestConvertToQuicV1Multiaddr (0.00s)
=== RUN   TestConvertFromQuicV1Multiaddr
--- PASS: TestConvertFromQuicV1Multiaddr (0.00s)
=== RUN   TestReuseListenOnAllIPv4
--- PASS: TestReuseListenOnAllIPv4 (0.05s)
=== RUN   TestReuseListenOnAllIPv6
--- PASS: TestReuseListenOnAllIPv6 (0.05s)
=== RUN   TestReuseCreateNewGlobalConnOnDial
--- PASS: TestReuseCreateNewGlobalConnOnDial (0.00s)
=== RUN   TestReuseConnectionWhenDialing
--- PASS: TestReuseConnectionWhenDialing (0.00s)
=== RUN   TestReuseConnectionWhenListening
--- PASS: TestReuseConnectionWhenListening (0.00s)
=== RUN   TestReuseConnectionWhenDialBeforeListen
--- PASS: TestReuseConnectionWhenDialBeforeListen (0.00s)
=== RUN   TestReuseListenOnSpecificInterface
    reuse_test.go:167: this test only works on platforms that support routing tables
--- SKIP: TestReuseListenOnSpecificInterface (0.00s)
=== RUN   TestReuseGarbageCollect
--- PASS: TestReuseGarbageCollect (0.15s)
=== RUN   TestSaveQlog
--- PASS: TestSaveQlog (0.00s)
=== RUN   TestQlogBuffering
    tracer_test.go:51: initial log file size: 0, final log file size: 19
--- PASS: TestQlogBuffering (0.00s)
=== RUN   TestQlogCompression
--- PASS: TestQlogCompression (0.00s)
PASS
ok      github.com/libp2p/go-libp2p/p2p/transport/quicreuse     0.356s
```