### PR TITLE
refactor(test): using `t.TempDir` to auto manage temp file in tests

### DIFF
--- a/p2p/host/peerstore/pstoreds/ds_test.go
+++ b/p2p/host/peerstore/pstoreds/ds_test.go
@@ -2,7 +2,6 @@ package pstoreds
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -104,17 +103,13 @@ func BenchmarkDsPeerstore(b *testing.B) {
 //
 //lint:ignore U1000 disabled for now
 func badgerStore(tb testing.TB) (ds.Batching, func()) {
-	dataPath, err := os.MkdirTemp(os.TempDir(), "badger")
-	if err != nil {
-		tb.Fatal(err)
-	}
+	dataPath := tb.TempDir()
 	store, err := badger.NewDatastore(dataPath, nil)
 	if err != nil {
 		tb.Fatal(err)
 	}
 	closer := func() {
 		store.Close()
-		os.RemoveAll(dataPath)
 	}
 	return store, closer
 }


### PR DESCRIPTION
Similar to #3222

BTW: I have checked the whole project and there is no more tests need to be replaced into `t.TempDir`.