### PR TITLE
Refactor `identify.proto`: Improve Field Order, Fix Comments

### DIFF
--- a/p2p/protocol/identify/pb/identify.proto
+++ b/p2p/protocol/identify/pb/identify.proto
@@ -6,13 +6,6 @@ option go_package = "github.com/libp2p/go-libp2p/p2p/protocol/identify/pb";
 
 message Identify {
 
-  // protocolVersion determines compatibility between peers
-  optional string protocolVersion = 5; // e.g. ipfs/1.0.0
-
-  // agentVersion is like a UserAgent string in browsers, or client version in bittorrent
-  // includes the client name and client.
-  optional string agentVersion = 6; // e.g. go-ipfs/0.1.0
-
   // publicKey is this node's public key (which also gives its node.ID)
   // - may not need to be sent, as secure channel implies it has been sent.
   // - then again, if we change / disable secure channel, may still want it.
@@ -21,13 +14,20 @@ message Identify {
   // listenAddrs are the multiaddrs the sender node listens for open connections on
   repeated bytes listenAddrs = 2;
 
-  // oservedAddr is the multiaddr of the remote endpoint that the sender node perceives
+  // protocols are the services this node is running
+  repeated string protocols = 3;
+
+  // observedAddr is the multiaddr of the remote endpoint that the sender node perceives
   // this is useful information to convey to the other side, as it helps the remote endpoint
   // determine whether its connection to the local peer goes through NAT.
   optional bytes observedAddr = 4;
 
-  // protocols are the services this node is running
-  repeated string protocols = 3;
+  // protocolVersion determines compatibility between peers
+  optional string protocolVersion = 5; // e.g. ipfs/1.0.0
+
+  // agentVersion is like a UserAgent string in browsers, or client version in bittorrent
+  // includes the client name and version.
+  optional string agentVersion = 6; // e.g. go-ipfs/0.1.0
 
   // signedPeerRecord contains a serialized SignedEnvelope containing a PeerRecord,
   // signed by the sending node. It contains the same addresses as the listenAddrs field, but


### PR DESCRIPTION
- Reordered fields for better logical grouping (without changing field numbers).  
- Ensured compatibility: No changes to field numbers to prevent breaking existing data. 
- Corrected a comment: `"client name and client"` → `"client name and version"`. 
- Fixed a typo: `oservedAddr` → `observedAddr`.  
