### PR TITLE
Fix Typographical and Spelling Errors in Documentation and Code Comments

### DIFF
--- a/core/network/rcmgr.go
+++ b/core/network/rcmgr.go
@@ -91,7 +91,7 @@ type ResourceManager interface {
 	// An unnegotiated stream will be initially unattached to any protocol scope
 	// and constrained by the transient scope.
 	// The caller owns the returned scope and is responsible for calling Done in order to signify
-	// the end of th scope's span.
+	// the end of the scope's span.
 	OpenStream(p peer.ID, dir Direction) (StreamManagementScope, error)
 
 	// Close closes the resource manager

--- a/options.go
+++ b/options.go
@@ -355,7 +355,7 @@ func ForceReachabilityPublic() Option {
 }
 
 // ForceReachabilityPrivate overrides automatic reachability detection in the AutoNAT subsystem,
-// forceing the local node to believe it is behind a NAT and not reachable externally.
+// forcing the local node to believe it is behind a NAT and not reachable externally.
 func ForceReachabilityPrivate() Option {
 	return func(cfg *Config) error {
 		private := network.ReachabilityPrivate


### PR DESCRIPTION
Change 1:

Old Text: "the end of th scope's span."
New Text: "the end of the scope's span."
File Affected: This change appears in a code or documentation file (likely related to span or scope management).
Reason: The word "th" was a typographical error. It was meant to be "the". Correcting the typo ensures that the sentence is grammatically correct and easy to read. Such minor errors can cause confusion or misinterpretation, particularly in technical documentation or code comments, which need to be precise.

Change 2:

Old Text: "forceing the local node to believe it is behind a NAT and not reachable externally."
New Text: "forcing the local node to believe it is behind a NAT and not reachable externally."
File Affected: This change likely occurs in documentation or code regarding network configurations or NAT handling.
Reason: The word "forceing" was misspelled. The correct form is "forcing". This is a simple typographical error. Correct spelling is crucial in professional technical documentation as it improves the clarity, professionalism, and overall quality of the content. This change also enhances readability and ensures that the content is easily understandable.