### PR TITLE
basichost: use autonatv2 to verify reachability

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@ linters:
     - revive
     - unused
     - prealloc
+  disable:
+    - errcheck
 
   settings:
     revive:

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ import (
 	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
+	"github.com/libp2p/go-libp2p/p2p/protocol/autonatv2"
 	circuitv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
 	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
@@ -413,15 +414,7 @@ func (cfg *Config) addTransports() ([]fx.Option, error) {
 	return fxopts, nil
 }
 
-func (cfg *Config) newBasicHost(swrm *swarm.Swarm, eventBus event.Bus) (*bhost.BasicHost, error) {
-	var autonatv2Dialer host.Host
-	if cfg.EnableAutoNATv2 {
-		ah, err := cfg.makeAutoNATV2Host()
-		if err != nil {
-			return nil, err
-		}
-		autonatv2Dialer = ah
-	}
+func (cfg *Config) newBasicHost(swrm *swarm.Swarm, eventBus event.Bus, an *autonatv2.AutoNAT) (*bhost.BasicHost, error) {
 	h, err := bhost.NewHost(swrm, &bhost.HostOpts{
 		EventBus:                        eventBus,
 		ConnManager:                     cfg.ConnManager,
@@ -437,8 +430,7 @@ func (cfg *Config) newBasicHost(swrm *swarm.Swarm, eventBus event.Bus) (*bhost.B
 		EnableMetrics:                   !cfg.DisableMetrics,
 		PrometheusRegisterer:            cfg.PrometheusRegisterer,
 		DisableIdentifyAddressDiscovery: cfg.DisableIdentifyAddressDiscovery,
-		EnableAutoNATv2:                 cfg.EnableAutoNATv2,
-		AutoNATv2Dialer:                 autonatv2Dialer,
+		AutoNATv2:                       an,
 	})
 	if err != nil {
 		return nil, err
@@ -516,6 +508,24 @@ func (cfg *Config) NewNode() (host.Host, error) {
 				},
 			})
 			return sw, nil
+		}),
+		fx.Provide(func() (*autonatv2.AutoNAT, error) {
+			if !cfg.EnableAutoNATv2 {
+				return nil, nil
+			}
+			ah, err := cfg.makeAutoNATV2Host()
+			if err != nil {
+				return nil, err
+			}
+			var mt autonatv2.MetricsTracer
+			if !cfg.DisableMetrics {
+				mt = autonatv2.NewMetricsTracer(cfg.PrometheusRegisterer)
+			}
+			autoNATv2, err := autonatv2.New(ah, autonatv2.WithMetricsTracer(mt))
+			if err != nil {
+				return nil, fmt.Errorf("failed to create autonatv2: %w", err)
+			}
+			return autoNATv2, nil
 		}),
 		fx.Provide(cfg.newBasicHost),
 		fx.Provide(func(bh *bhost.BasicHost) identify.IDService {

--- a/core/event/reachability.go
+++ b/core/event/reachability.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"github.com/libp2p/go-libp2p/core/network"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 // EvtLocalReachabilityChanged is an event struct to be emitted when the local's
@@ -10,4 +11,13 @@ import (
 // This event is usually emitted by the AutoNAT subsystem.
 type EvtLocalReachabilityChanged struct {
 	Reachability network.Reachability
+}
+
+// EvtHostReachableAddrsChanged is sent when host's reachable or unreachable addresses change
+// Reachable and Unreachable both contain only Public IP or DNS addresses
+//
+// Experimental: This API is unstable. Any changes to this event will be done without a deprecation notice.
+type EvtHostReachableAddrsChanged struct {
+	Reachable   []ma.Multiaddr
+	Unreachable []ma.Multiaddr
 }

--- a/p2p/host/basic/addrs_manager_test.go
+++ b/p2p/host/basic/addrs_manager_test.go
@@ -1,13 +1,17 @@
 package basichost
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	"github.com/libp2p/go-libp2p/p2p/protocol/autonatv2"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +34,7 @@ func TestAppendNATAddrs(t *testing.T) {
 			// nat mapping success, obsaddress ignored
 			Listen: ma.StringCast("/ip4/0.0.0.0/udp/1/quic-v1"),
 			Nat:    ma.StringCast("/ip4/1.1.1.1/udp/10/quic-v1"),
-			ObsAddrFunc: func(m ma.Multiaddr) []ma.Multiaddr {
+			ObsAddrFunc: func(_ ma.Multiaddr) []ma.Multiaddr {
 				return []ma.Multiaddr{ma.StringCast("/ip4/2.2.2.2/udp/100/quic-v1")}
 			},
 			Expected: []ma.Multiaddr{ma.StringCast("/ip4/1.1.1.1/udp/10/quic-v1")},
@@ -116,7 +120,7 @@ func TestAppendNATAddrs(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			as := &addrsManager{
 				natManager: &mockNatManager{
-					GetMappingFunc: func(addr ma.Multiaddr) ma.Multiaddr {
+					GetMappingFunc: func(_ ma.Multiaddr) ma.Multiaddr {
 						return tc.Nat
 					},
 				},
@@ -135,7 +139,7 @@ type mockNatManager struct {
 	GetMappingFunc func(addr ma.Multiaddr) ma.Multiaddr
 }
 
-func (m *mockNatManager) Close() error {
+func (*mockNatManager) Close() error {
 	return nil
 }
 
@@ -146,7 +150,7 @@ func (m *mockNatManager) GetMapping(addr ma.Multiaddr) ma.Multiaddr {
 	return m.GetMappingFunc(addr)
 }
 
-func (m *mockNatManager) HasDiscoveredNAT() bool {
+func (*mockNatManager) HasDiscoveredNAT() bool {
 	return true
 }
 
@@ -170,6 +174,8 @@ type addrsManagerArgs struct {
 	AddrsFactory         AddrsFactory
 	ObservedAddrsManager observedAddrsManager
 	ListenAddrs          func() []ma.Multiaddr
+	AutoNATClient        autonatv2Client
+	Bus                  event.Bus
 }
 
 type addrsManagerTestCase struct {
@@ -179,13 +185,16 @@ type addrsManagerTestCase struct {
 }
 
 func newAddrsManagerTestCase(t *testing.T, args addrsManagerArgs) addrsManagerTestCase {
-	eb := eventbus.NewBus()
+	eb := args.Bus
+	if eb == nil {
+		eb = eventbus.NewBus()
+	}
 	if args.AddrsFactory == nil {
 		args.AddrsFactory = func(addrs []ma.Multiaddr) []ma.Multiaddr { return addrs }
 	}
 	addrsUpdatedChan := make(chan struct{}, 1)
 	am, err := newAddrsManager(
-		eb, args.NATManager, args.AddrsFactory, args.ListenAddrs, nil, args.ObservedAddrsManager, addrsUpdatedChan,
+		eb, args.NATManager, args.AddrsFactory, args.ListenAddrs, nil, args.ObservedAddrsManager, addrsUpdatedChan, args.AutoNATClient,
 	)
 	require.NoError(t, err)
 
@@ -196,6 +205,7 @@ func newAddrsManagerTestCase(t *testing.T, args addrsManagerArgs) addrsManagerTe
 	rchEm, err := eb.Emitter(new(event.EvtLocalReachabilityChanged), eventbus.Stateful)
 	require.NoError(t, err)
 
+	t.Cleanup(am.Close)
 	return addrsManagerTestCase{
 		addrsManager: am,
 		PushRelay: func(relayAddrs []ma.Multiaddr) {
@@ -326,7 +336,7 @@ func TestAddrsManager(t *testing.T) {
 		}
 		am := newAddrsManagerTestCase(t, addrsManagerArgs{
 			ObservedAddrsManager: &mockObservedAddrs{
-				ObservedAddrsForFunc: func(addr ma.Multiaddr) []ma.Multiaddr {
+				ObservedAddrsForFunc: func(_ ma.Multiaddr) []ma.Multiaddr {
 					return quicAddrs
 				},
 			},
@@ -342,7 +352,7 @@ func TestAddrsManager(t *testing.T) {
 	t.Run("public addrs removed when private", func(t *testing.T) {
 		am := newAddrsManagerTestCase(t, addrsManagerArgs{
 			ObservedAddrsManager: &mockObservedAddrs{
-				ObservedAddrsForFunc: func(addr ma.Multiaddr) []ma.Multiaddr {
+				ObservedAddrsForFunc: func(_ ma.Multiaddr) []ma.Multiaddr {
 					return []ma.Multiaddr{publicQUIC}
 				},
 			},
@@ -384,7 +394,7 @@ func TestAddrsManager(t *testing.T) {
 				return nil
 			},
 			ObservedAddrsManager: &mockObservedAddrs{
-				ObservedAddrsForFunc: func(addr ma.Multiaddr) []ma.Multiaddr {
+				ObservedAddrsForFunc: func(_ ma.Multiaddr) []ma.Multiaddr {
 					return []ma.Multiaddr{publicQUIC}
 				},
 			},
@@ -404,7 +414,7 @@ func TestAddrsManager(t *testing.T) {
 	t.Run("updates addresses on signaling", func(t *testing.T) {
 		updateChan := make(chan struct{})
 		am := newAddrsManagerTestCase(t, addrsManagerArgs{
-			AddrsFactory: func(addrs []ma.Multiaddr) []ma.Multiaddr {
+			AddrsFactory: func(_ []ma.Multiaddr) []ma.Multiaddr {
 				select {
 				case <-updateChan:
 					return []ma.Multiaddr{publicQUIC}
@@ -425,17 +435,95 @@ func TestAddrsManager(t *testing.T) {
 	})
 }
 
+func TestAddrsManagerReachabilityEvent(t *testing.T) {
+	publicQUIC, _ := ma.NewMultiaddr("/ip4/1.2.3.4/udp/1234/quic-v1")
+	publicQUIC2, _ := ma.NewMultiaddr("/ip4/1.2.3.4/udp/1235/quic-v1")
+	publicTCP, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/1234")
+
+	bus := eventbus.NewBus()
+
+	sub, err := bus.Subscribe(new(event.EvtHostReachableAddrsChanged))
+	require.NoError(t, err)
+	defer sub.Close()
+
+	am := newAddrsManagerTestCase(t, addrsManagerArgs{
+		Bus: bus,
+		// currently they aren't being passed to the reachability tracker
+		ListenAddrs: func() []ma.Multiaddr { return []ma.Multiaddr{publicQUIC, publicQUIC2, publicTCP} },
+		AutoNATClient: mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				if reqs[0].Addr.Equal(publicQUIC) {
+					return autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: network.ReachabilityPublic}, nil
+				} else if reqs[0].Addr.Equal(publicTCP) || reqs[0].Addr.Equal(publicQUIC2) {
+					return autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: network.ReachabilityPrivate}, nil
+				}
+				return autonatv2.Result{}, errors.New("invalid")
+			},
+		},
+	})
+
+	reachableAddrs := []ma.Multiaddr{publicQUIC}
+	unreachableAddrs := []ma.Multiaddr{publicTCP, publicQUIC2}
+	select {
+	case e := <-sub.Out():
+		evt := e.(event.EvtHostReachableAddrsChanged)
+		require.ElementsMatch(t, reachableAddrs, evt.Reachable)
+		require.ElementsMatch(t, unreachableAddrs, evt.Unreachable)
+		require.ElementsMatch(t, reachableAddrs, am.ReachableAddrs())
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected event for reachability change")
+	}
+}
+
+func TestRemoveIfNotInSource(t *testing.T) {
+	var addrs []ma.Multiaddr
+	for i := 0; i < 10; i++ {
+		addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/1.2.3.4/tcp/%d", i)))
+	}
+	slices.SortFunc(addrs, func(a, b ma.Multiaddr) int { return a.Compare(b) })
+	cases := []struct {
+		addrs    []ma.Multiaddr
+		source   []ma.Multiaddr
+		expected []ma.Multiaddr
+	}{
+		{},
+		{addrs: slices.Clone(addrs[:5]), source: nil, expected: nil},
+		{addrs: nil, source: addrs, expected: nil},
+		{addrs: []ma.Multiaddr{addrs[0]}, source: []ma.Multiaddr{addrs[0]}, expected: []ma.Multiaddr{addrs[0]}},
+		{addrs: slices.Clone(addrs), source: []ma.Multiaddr{addrs[0]}, expected: []ma.Multiaddr{addrs[0]}},
+		{addrs: slices.Clone(addrs), source: slices.Clone(addrs[5:]), expected: slices.Clone(addrs[5:])},
+		{addrs: slices.Clone(addrs[:5]), source: []ma.Multiaddr{addrs[0], addrs[2], addrs[8]}, expected: []ma.Multiaddr{addrs[0], addrs[2]}},
+	}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			addrs := removeNotInSource(tc.addrs, tc.source)
+			require.ElementsMatch(t, tc.expected, addrs, "%s\n%s", tc.expected, tc.addrs)
+		})
+	}
+}
+
 func BenchmarkAreAddrsDifferent(b *testing.B) {
 	var addrs [10]ma.Multiaddr
 	for i := 0; i < len(addrs); i++ {
 		addrs[i] = ma.StringCast(fmt.Sprintf("/ip4/1.1.1.%d/tcp/1", i))
 	}
-	am := &addrsManager{}
 	b.Run("areAddrsDifferent", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			am.areAddrsDifferent(addrs[:], addrs[:])
+			areAddrsDifferent(addrs[:], addrs[:])
 		}
 	})
+}
+
+func BenchmarkRemoveIfNotInSource(b *testing.B) {
+	var addrs [10]ma.Multiaddr
+	for i := 0; i < len(addrs); i++ {
+		addrs[i] = ma.StringCast(fmt.Sprintf("/ip4/1.1.1.%d/tcp/1", i))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		removeNotInSource(slices.Clone(addrs[:5]), addrs[:])
+	}
 }

--- a/p2p/host/basic/addrs_reachability_tracker.go
+++ b/p2p/host/basic/addrs_reachability_tracker.go
@@ -1,0 +1,666 @@
+package basichost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/protocol/autonatv2"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+type autonatv2Client interface {
+	GetReachability(ctx context.Context, reqs []autonatv2.Request) (autonatv2.Result, error)
+}
+
+const (
+
+	// maxAddrsPerRequest is the maximum number of addresses to probe in a single request
+	maxAddrsPerRequest = 10
+	// maxTrackedAddrs is the maximum number of addresses to track
+	// 10 addrs per transport for 5 transports
+	maxTrackedAddrs = 50
+	// defaultMaxConcurrency is the default number of concurrent workers for reachability checks
+	defaultMaxConcurrency = 5
+	// newAddrsProbeDelay is the delay before probing new addr's reachability.
+	newAddrsProbeDelay = 1 * time.Second
+)
+
+// addrsReachabilityTracker tracks reachability for addresses.
+// Use UpdateAddrs to provide addresses for tracking reachability.
+// reachabilityUpdateCh is notified when reachability for any of the tracked address changes.
+type addrsReachabilityTracker struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	client autonatv2Client
+	// reachabilityUpdateCh is used to notify when reachability may have changed
+	reachabilityUpdateCh chan struct{}
+	maxConcurrency       int
+	newAddrsProbeDelay   time.Duration
+	probeManager         *probeManager
+	newAddrs             chan []ma.Multiaddr
+	clock                clock.Clock
+
+	mx               sync.Mutex
+	reachableAddrs   []ma.Multiaddr
+	unreachableAddrs []ma.Multiaddr
+}
+
+// newAddrsReachabilityTracker returns a new addrsReachabilityTracker.
+// reachabilityUpdateCh is notified when reachability for any of the tracked address changes.
+func newAddrsReachabilityTracker(client autonatv2Client, reachabilityUpdateCh chan struct{}, cl clock.Clock) *addrsReachabilityTracker {
+	ctx, cancel := context.WithCancel(context.Background())
+	if cl == nil {
+		cl = clock.New()
+	}
+	return &addrsReachabilityTracker{
+		ctx:                  ctx,
+		cancel:               cancel,
+		client:               client,
+		reachabilityUpdateCh: reachabilityUpdateCh,
+		probeManager:         newProbeManager(cl.Now),
+		newAddrsProbeDelay:   newAddrsProbeDelay,
+		maxConcurrency:       defaultMaxConcurrency,
+		newAddrs:             make(chan []ma.Multiaddr, 1),
+		clock:                cl,
+	}
+}
+
+func (r *addrsReachabilityTracker) UpdateAddrs(addrs []ma.Multiaddr) {
+	select {
+	case r.newAddrs <- slices.Clone(addrs):
+	case <-r.ctx.Done():
+	}
+}
+
+func (r *addrsReachabilityTracker) ConfirmedAddrs() (reachableAddrs, unreachableAddrs []ma.Multiaddr) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	return slices.Clone(r.reachableAddrs), slices.Clone(r.unreachableAddrs)
+}
+
+func (r *addrsReachabilityTracker) Start() error {
+	r.wg.Add(1)
+	go r.background()
+	return nil
+}
+
+func (r *addrsReachabilityTracker) Close() error {
+	r.cancel()
+	r.wg.Wait()
+	return nil
+}
+
+const (
+	// defaultReachabilityRefreshInterval is the default interval to refresh reachability.
+	// In steady state, we check for any required probes every refresh interval.
+	// This doesn't mean we'll probe for any particular address, only that we'll check
+	// if any address needs to be probed.
+	defaultReachabilityRefreshInterval = 5 * time.Minute
+	// maxBackoffInterval is the maximum back off in case we're unable to probe for reachability.
+	// We may be unable to confirm addresses in case there are no valid peers with autonatv2
+	// or the autonatv2 subsystem is consistently erroring.
+	maxBackoffInterval = 5 * time.Minute
+	// backoffStartInterval is the initial back off in case we're unable to probe for reachability.
+	backoffStartInterval = 5 * time.Second
+)
+
+func (r *addrsReachabilityTracker) background() {
+	defer r.wg.Done()
+
+	// probeTicker is used to trigger probes at regular intervals
+	probeTicker := r.clock.Ticker(defaultReachabilityRefreshInterval)
+	defer probeTicker.Stop()
+
+	// probeTimer is used to trigger probes at specific times
+	probeTimer := r.clock.Timer(time.Duration(math.MaxInt64))
+	defer probeTimer.Stop()
+	nextProbeTime := time.Time{}
+
+	var task reachabilityTask
+	var backoffInterval time.Duration
+	var currReachable, currUnreachable, prevReachable, prevUnreachable []ma.Multiaddr
+	for {
+		select {
+		case <-probeTicker.C:
+			// don't start a probe if we have a scheduled probe
+			if task.BackoffCh == nil && nextProbeTime.IsZero() {
+				task = r.refreshReachability()
+			}
+		case <-probeTimer.C:
+			if task.BackoffCh == nil {
+				task = r.refreshReachability()
+			}
+			nextProbeTime = time.Time{}
+		case backoff := <-task.BackoffCh:
+			task = reachabilityTask{}
+			// On completion, start the next probe immediately, or wait for backoff.
+			// In case there are no further probes, the reachability tracker will return an empty task,
+			// which hangs forever. Eventually, we'll refresh again when the ticker fires.
+			if backoff {
+				backoffInterval = newBackoffInterval(backoffInterval)
+			} else {
+				backoffInterval = -1 * time.Second // negative to trigger next probe immediately
+			}
+			nextProbeTime = r.clock.Now().Add(backoffInterval)
+		case addrs := <-r.newAddrs:
+			if task.BackoffCh != nil { // cancel running task.
+				task.Cancel()
+				<-task.BackoffCh // ignore backoff from cancelled task
+				task = reachabilityTask{}
+			}
+			r.updateTrackedAddrs(addrs)
+			newAddrsNextTime := r.clock.Now().Add(r.newAddrsProbeDelay)
+			if nextProbeTime.Before(newAddrsNextTime) {
+				nextProbeTime = newAddrsNextTime
+			}
+		case <-r.ctx.Done():
+			if task.BackoffCh != nil {
+				task.Cancel()
+				<-task.BackoffCh
+				task = reachabilityTask{}
+			}
+			return
+		}
+
+		currReachable, currUnreachable = r.appendConfirmedAddrs(currReachable[:0], currUnreachable[:0])
+		if areAddrsDifferent(prevReachable, currReachable) || areAddrsDifferent(prevUnreachable, currUnreachable) {
+			r.notify()
+		}
+		prevReachable = append(prevReachable[:0], currReachable...)
+		prevUnreachable = append(prevUnreachable[:0], currUnreachable...)
+		if !nextProbeTime.IsZero() {
+			probeTimer.Reset(nextProbeTime.Sub(r.clock.Now()))
+		}
+	}
+}
+
+func newBackoffInterval(current time.Duration) time.Duration {
+	if current <= 0 {
+		return backoffStartInterval
+	}
+	current *= 2
+	if current > maxBackoffInterval {
+		return maxBackoffInterval
+	}
+	return current
+}
+
+func (r *addrsReachabilityTracker) appendConfirmedAddrs(reachable, unreachable []ma.Multiaddr) (reachableAddrs, unreachableAddrs []ma.Multiaddr) {
+	reachable, unreachable = r.probeManager.AppendConfirmedAddrs(reachable, unreachable)
+	r.mx.Lock()
+	r.reachableAddrs = append(r.reachableAddrs[:0], reachable...)
+	r.unreachableAddrs = append(r.unreachableAddrs[:0], unreachable...)
+	r.mx.Unlock()
+	return reachable, unreachable
+}
+
+func (r *addrsReachabilityTracker) notify() {
+	select {
+	case r.reachabilityUpdateCh <- struct{}{}:
+	default:
+	}
+}
+
+func (r *addrsReachabilityTracker) updateTrackedAddrs(addrs []ma.Multiaddr) {
+	addrs = slices.DeleteFunc(addrs, func(a ma.Multiaddr) bool {
+		return !manet.IsPublicAddr(a)
+	})
+	if len(addrs) > maxTrackedAddrs {
+		log.Errorf("too many addresses (%d) for addrs reachability tracker; dropping %d", len(addrs), len(addrs)-maxTrackedAddrs)
+		addrs = addrs[:maxTrackedAddrs]
+	}
+	r.probeManager.UpdateAddrs(addrs)
+}
+
+type probe = []autonatv2.Request
+
+const probeTimeout = 30 * time.Second
+
+// reachabilityTask is a task to refresh reachability.
+// Waiting on the zero value blocks forever.
+type reachabilityTask struct {
+	Cancel context.CancelFunc
+	// BackoffCh returns whether the caller should backoff before
+	// refreshing reachability
+	BackoffCh chan bool
+}
+
+func (r *addrsReachabilityTracker) refreshReachability() reachabilityTask {
+	if len(r.probeManager.GetProbe()) == 0 {
+		return reachabilityTask{}
+	}
+	resCh := make(chan bool, 1)
+	ctx, cancel := context.WithTimeout(r.ctx, 5*time.Minute)
+	r.wg.Add(1)
+	// We run probes provided by addrsTracker. It stops probing when any
+	// of the following happens:
+	// - there are no more probes to run
+	// - context is completed
+	// - there are too many consecutive failures from the client
+	// - the client has no valid peers to probe
+	go func() {
+		defer r.wg.Done()
+		defer cancel()
+		client := &errCountingClient{autonatv2Client: r.client, MaxConsecutiveErrors: maxConsecutiveErrors}
+		var backoff atomic.Bool
+		var wg sync.WaitGroup
+		wg.Add(r.maxConcurrency)
+		for range r.maxConcurrency {
+			go func() {
+				defer wg.Done()
+				for {
+					if ctx.Err() != nil {
+						return
+					}
+					reqs := r.probeManager.GetProbe()
+					if len(reqs) == 0 {
+						return
+					}
+					r.probeManager.MarkProbeInProgress(reqs)
+					rctx, cancel := context.WithTimeout(ctx, probeTimeout)
+					res, err := client.GetReachability(rctx, reqs)
+					cancel()
+					r.probeManager.CompleteProbe(reqs, res, err)
+					if isErrorPersistent(err) {
+						backoff.Store(true)
+						return
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		resCh <- backoff.Load()
+	}()
+	return reachabilityTask{Cancel: cancel, BackoffCh: resCh}
+}
+
+var errTooManyConsecutiveFailures = errors.New("too many consecutive failures")
+
+// errCountingClient counts errors from autonatv2Client and wraps the errors in response with a
+// errTooManyConsecutiveFailures in case of persistent failures from autonatv2 module.
+type errCountingClient struct {
+	autonatv2Client
+	MaxConsecutiveErrors int
+	mx                   sync.Mutex
+	consecutiveErrors    int
+}
+
+func (c *errCountingClient) GetReachability(ctx context.Context, reqs probe) (autonatv2.Result, error) {
+	res, err := c.autonatv2Client.GetReachability(ctx, reqs)
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	if err != nil && !errors.Is(err, context.Canceled) { // ignore canceled errors, they're not errors from autonatv2
+		c.consecutiveErrors++
+		if c.consecutiveErrors > c.MaxConsecutiveErrors {
+			err = fmt.Errorf("%w:%w", errTooManyConsecutiveFailures, err)
+		}
+		if errors.Is(err, autonatv2.ErrPrivateAddrs) {
+			log.Errorf("private IP addr in autonatv2 request: %s", err)
+		}
+	} else {
+		c.consecutiveErrors = 0
+	}
+	return res, err
+}
+
+const maxConsecutiveErrors = 20
+
+// isErrorPersistent returns whether the error will repeat on future probes for a while
+func isErrorPersistent(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, autonatv2.ErrPrivateAddrs) || errors.Is(err, autonatv2.ErrNoPeers) ||
+		errors.Is(err, errTooManyConsecutiveFailures)
+}
+
+const (
+	// recentProbeInterval is the interval to probe addresses that have been refused
+	// these are generally addresses with newer transports for which we don't have many peers
+	// capable of dialing the transport
+	recentProbeInterval = 10 * time.Minute
+	// maxConsecutiveRefusals is the maximum number of consecutive refusals for an address after which
+	// we wait for `recentProbeInterval` before probing again
+	maxConsecutiveRefusals = 5
+	// maxRecentDialsPerAddr is the maximum number of dials on an address before we stop probing for the address.
+	// This is used to prevent infinite probing of an address whose status is indeterminate for any reason.
+	maxRecentDialsPerAddr = 10
+	// confidence is the absolute difference between the number of successes and failures for an address
+	// targetConfidence is the confidence threshold for an address after which we wait for `maxProbeInterval`
+	// before probing again.
+	targetConfidence = 3
+	// minConfidence is the confidence threshold for an address to be considered reachable or unreachable
+	// confidence is the absolute difference between the number of successes and failures for an address
+	minConfidence = 2
+	// maxRecentDialsWindow is the maximum number of recent probe results to consider for a single address
+	//
+	// +2 allows for 1 invalid probe result. Consider a string of successes, after which we have a single failure
+	// and then a success(...S S S S F S). The confidence in the targetConfidence window  will be equal to
+	// targetConfidence, the last F and S cancel each other, and we won't probe again for maxProbeInterval.
+	maxRecentDialsWindow = targetConfidence + 2
+	// highConfidenceAddrProbeInterval is the maximum interval between probes for an address
+	highConfidenceAddrProbeInterval = 1 * time.Hour
+	// maxProbeResultTTL is the maximum time to keep probe results for an address
+	maxProbeResultTTL = maxRecentDialsWindow * highConfidenceAddrProbeInterval
+)
+
+// probeManager tracks reachability for a set of addresses by periodically probing reachability with autonatv2.
+// A Probe is a list of addresses which can be tested for reachability with autonatv2.
+// This struct decides the priority order of addresses for testing reachability, and throttles in case there have
+// been too many probes for an address in the `ProbeInterval`.
+//
+// Use the `runProbes` function to execute the probes with an autonatv2 client.
+type probeManager struct {
+	now func() time.Time
+
+	mx                    sync.Mutex
+	inProgressProbes      map[string]int // addr -> count
+	inProgressProbesTotal int
+	statuses              map[string]*addrStatus
+	addrs                 []ma.Multiaddr
+}
+
+// newProbeManager creates a new probe manager.
+func newProbeManager(now func() time.Time) *probeManager {
+	return &probeManager{
+		statuses:         make(map[string]*addrStatus),
+		inProgressProbes: make(map[string]int),
+		now:              now,
+	}
+}
+
+// AppendConfirmedAddrs appends the current confirmed reachable and unreachable addresses.
+func (m *probeManager) AppendConfirmedAddrs(reachable, unreachable []ma.Multiaddr) (reachableAddrs, unreachableAddrs []ma.Multiaddr) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	for _, a := range m.addrs {
+		s := m.statuses[string(a.Bytes())]
+		s.RemoveBefore(m.now().Add(-maxProbeResultTTL)) // cleanup stale results
+		switch s.Reachability() {
+		case network.ReachabilityPublic:
+			reachable = append(reachable, a)
+		case network.ReachabilityPrivate:
+			unreachable = append(unreachable, a)
+		}
+	}
+	return reachable, unreachable
+}
+
+// UpdateAddrs updates the tracked addrs
+func (m *probeManager) UpdateAddrs(addrs []ma.Multiaddr) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	slices.SortFunc(addrs, func(a, b ma.Multiaddr) int { return a.Compare(b) })
+	statuses := make(map[string]*addrStatus, len(addrs))
+	for _, addr := range addrs {
+		k := string(addr.Bytes())
+		if _, ok := m.statuses[k]; !ok {
+			statuses[k] = &addrStatus{Addr: addr}
+		} else {
+			statuses[k] = m.statuses[k]
+		}
+	}
+	m.addrs = addrs
+	m.statuses = statuses
+}
+
+// GetProbe returns the next probe. Returns zero value in case there are no more probes.
+// Probes that are run against an autonatv2 client should be marked in progress with
+// `MarkProbeInProgress` before running.
+func (m *probeManager) GetProbe() probe {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	now := m.now()
+	for i, a := range m.addrs {
+		ab := a.Bytes()
+		pc := m.statuses[string(ab)].RequiredProbeCount(now)
+		if m.inProgressProbes[string(ab)] >= pc {
+			continue
+		}
+		reqs := make(probe, 0, maxAddrsPerRequest)
+		reqs = append(reqs, autonatv2.Request{Addr: a, SendDialData: true})
+		// We have the first(primary) address. Append other addresses, ignoring inprogress probes
+		// on secondary addresses. The expectation is that the primary address will
+		// be dialed.
+		for j := 1; j < len(m.addrs); j++ {
+			k := (i + j) % len(m.addrs)
+			ab := m.addrs[k].Bytes()
+			pc := m.statuses[string(ab)].RequiredProbeCount(now)
+			if pc == 0 {
+				continue
+			}
+			reqs = append(reqs, autonatv2.Request{Addr: m.addrs[k], SendDialData: true})
+			if len(reqs) >= maxAddrsPerRequest {
+				break
+			}
+		}
+		return reqs
+	}
+	return nil
+}
+
+// MarkProbeInProgress should be called when a probe is started.
+// All in progress probes *MUST* be completed with `CompleteProbe`
+func (m *probeManager) MarkProbeInProgress(reqs probe) {
+	if len(reqs) == 0 {
+		return
+	}
+	m.mx.Lock()
+	defer m.mx.Unlock()
+	m.inProgressProbes[string(reqs[0].Addr.Bytes())]++
+	m.inProgressProbesTotal++
+}
+
+// InProgressProbes returns the number of probes that are currently in progress.
+func (m *probeManager) InProgressProbes() int {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+	return m.inProgressProbesTotal
+}
+
+// CompleteProbe should be called when a probe completes.
+func (m *probeManager) CompleteProbe(reqs probe, res autonatv2.Result, err error) {
+	now := m.now()
+
+	if len(reqs) == 0 {
+		// should never happen
+		return
+	}
+
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	// decrement in-progress count for the first address
+	primaryAddrKey := string(reqs[0].Addr.Bytes())
+	m.inProgressProbes[primaryAddrKey]--
+	if m.inProgressProbes[primaryAddrKey] <= 0 {
+		delete(m.inProgressProbes, primaryAddrKey)
+	}
+	m.inProgressProbesTotal--
+
+	// nothing to do if the request errored.
+	if err != nil {
+		return
+	}
+
+	// Consider only primary address as refused. This increases the number of
+	// refused probes, but refused probes are cheap for a server as no dials are made.
+	if res.AllAddrsRefused {
+		if s, ok := m.statuses[primaryAddrKey]; ok {
+			s.AddRefusal(now)
+		}
+		return
+	}
+	dialAddrKey := string(res.Addr.Bytes())
+	if dialAddrKey != primaryAddrKey {
+		if s, ok := m.statuses[primaryAddrKey]; ok {
+			s.AddRefusal(now)
+		}
+	}
+
+	// record the result for the dialed address
+	if s, ok := m.statuses[dialAddrKey]; ok {
+		s.AddOutcome(now, res.Reachability, maxRecentDialsWindow)
+	}
+}
+
+type dialOutcome struct {
+	Success bool
+	At      time.Time
+}
+
+type addrStatus struct {
+	Addr                ma.Multiaddr
+	lastRefusalTime     time.Time
+	consecutiveRefusals int
+	dialTimes           []time.Time
+	outcomes            []dialOutcome
+}
+
+func (s *addrStatus) Reachability() network.Reachability {
+	rch, _, _ := s.reachabilityAndCounts()
+	return rch
+}
+
+func (s *addrStatus) RequiredProbeCount(now time.Time) int {
+	if s.consecutiveRefusals >= maxConsecutiveRefusals {
+		if now.Sub(s.lastRefusalTime) < recentProbeInterval {
+			return 0
+		}
+		// reset every `recentProbeInterval`
+		s.lastRefusalTime = time.Time{}
+		s.consecutiveRefusals = 0
+	}
+
+	// Don't probe if we have probed too many times recently
+	rd := s.recentDialCount(now)
+	if rd >= maxRecentDialsPerAddr {
+		return 0
+	}
+
+	return s.requiredProbeCountForConfirmation(now)
+}
+
+func (s *addrStatus) requiredProbeCountForConfirmation(now time.Time) int {
+	reachability, successes, failures := s.reachabilityAndCounts()
+	confidence := successes - failures
+	if confidence < 0 {
+		confidence = -confidence
+	}
+	cnt := targetConfidence - confidence
+	if cnt > 0 {
+		return cnt
+	}
+	// we have enough confirmations; check if we should refresh
+
+	// Should never happen. The confidence logic above should require a few probes.
+	if len(s.outcomes) == 0 {
+		return 0
+	}
+	lastOutcome := s.outcomes[len(s.outcomes)-1]
+	// If the last probe result is old, we need to retest
+	if now.Sub(lastOutcome.At) > highConfidenceAddrProbeInterval {
+		return 1
+	}
+	// if the last probe result was different from reachability, probe again.
+	switch reachability {
+	case network.ReachabilityPublic:
+		if !lastOutcome.Success {
+			return 1
+		}
+	case network.ReachabilityPrivate:
+		if lastOutcome.Success {
+			return 1
+		}
+	default:
+		// this should never happen
+		return 1
+	}
+	return 0
+}
+
+func (s *addrStatus) AddRefusal(now time.Time) {
+	s.lastRefusalTime = now
+	s.consecutiveRefusals++
+}
+
+func (s *addrStatus) AddOutcome(at time.Time, rch network.Reachability, windowSize int) {
+	s.lastRefusalTime = time.Time{}
+	s.consecutiveRefusals = 0
+
+	s.dialTimes = append(s.dialTimes, at)
+	for i, t := range s.dialTimes {
+		if at.Sub(t) < recentProbeInterval {
+			s.dialTimes = slices.Delete(s.dialTimes, 0, i)
+			break
+		}
+	}
+
+	s.RemoveBefore(at.Add(-maxProbeResultTTL)) // remove old outcomes
+	success := false
+	switch rch {
+	case network.ReachabilityPublic:
+		success = true
+	case network.ReachabilityPrivate:
+		success = false
+	default:
+		return // don't store the outcome if reachability is unknown
+	}
+	s.outcomes = append(s.outcomes, dialOutcome{At: at, Success: success})
+	if len(s.outcomes) > windowSize {
+		s.outcomes = slices.Delete(s.outcomes, 0, len(s.outcomes)-windowSize)
+	}
+}
+
+// RemoveBefore removes outcomes before t
+func (s *addrStatus) RemoveBefore(t time.Time) {
+	end := 0
+	for ; end < len(s.outcomes); end++ {
+		if !s.outcomes[end].At.Before(t) {
+			break
+		}
+	}
+	s.outcomes = slices.Delete(s.outcomes, 0, end)
+}
+
+func (s *addrStatus) recentDialCount(now time.Time) int {
+	cnt := 0
+	for _, t := range slices.Backward(s.dialTimes) {
+		if now.Sub(t) > recentProbeInterval {
+			break
+		}
+		cnt++
+	}
+	return cnt
+}
+
+func (s *addrStatus) reachabilityAndCounts() (rch network.Reachability, successes int, failures int) {
+	for _, r := range s.outcomes {
+		if r.Success {
+			successes++
+		} else {
+			failures++
+		}
+	}
+	if successes-failures >= minConfidence {
+		return network.ReachabilityPublic, successes, failures
+	}
+	if failures-successes >= minConfidence {
+		return network.ReachabilityPrivate, successes, failures
+	}
+	return network.ReachabilityUnknown, successes, failures
+}

--- a/p2p/host/basic/addrs_reachability_tracker_test.go
+++ b/p2p/host/basic/addrs_reachability_tracker_test.go
@@ -1,0 +1,919 @@
+package basichost
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/netip"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/protocol/autonatv2"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeManager(t *testing.T) {
+	pub1 := ma.StringCast("/ip4/1.1.1.1/tcp/1")
+	pub2 := ma.StringCast("/ip4/1.1.1.2/tcp/1")
+	pub3 := ma.StringCast("/ip4/1.1.1.3/tcp/1")
+
+	cl := clock.NewMock()
+
+	nextProbe := func(pm *probeManager) []autonatv2.Request {
+		reqs := pm.GetProbe()
+		if len(reqs) != 0 {
+			pm.MarkProbeInProgress(reqs)
+		}
+		return reqs
+	}
+
+	makeNewProbeManager := func(addrs []ma.Multiaddr) *probeManager {
+		pm := newProbeManager(cl.Now)
+		pm.UpdateAddrs(addrs)
+		return pm
+	}
+
+	t.Run("addrs updates", func(t *testing.T) {
+		pm := newProbeManager(cl.Now)
+		pm.UpdateAddrs([]ma.Multiaddr{pub1, pub2})
+		for {
+			reqs := nextProbe(pm)
+			if len(reqs) == 0 {
+				break
+			}
+			pm.CompleteProbe(reqs, autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: network.ReachabilityPublic}, nil)
+		}
+		reachable, _ := pm.AppendConfirmedAddrs(nil, nil)
+		require.Equal(t, reachable, []ma.Multiaddr{pub1, pub2})
+		pm.UpdateAddrs([]ma.Multiaddr{pub3})
+
+		reachable, _ = pm.AppendConfirmedAddrs(nil, nil)
+		require.Empty(t, reachable)
+		require.Len(t, pm.statuses, 1)
+	})
+
+	t.Run("inprogress", func(t *testing.T) {
+		pm := makeNewProbeManager([]ma.Multiaddr{pub1, pub2})
+		reqs1 := pm.GetProbe()
+		reqs2 := pm.GetProbe()
+		require.Equal(t, reqs1, reqs2)
+		for range targetConfidence {
+			reqs := nextProbe(pm)
+			require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}, {Addr: pub2, SendDialData: true}})
+		}
+		for range targetConfidence {
+			reqs := nextProbe(pm)
+			require.Equal(t, reqs, []autonatv2.Request{{Addr: pub2, SendDialData: true}, {Addr: pub1, SendDialData: true}})
+		}
+		reqs := pm.GetProbe()
+		require.Empty(t, reqs)
+	})
+
+	t.Run("refusals", func(t *testing.T) {
+		pm := makeNewProbeManager([]ma.Multiaddr{pub1, pub2})
+		var probes [][]autonatv2.Request
+		for range targetConfidence {
+			reqs := nextProbe(pm)
+			require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}, {Addr: pub2, SendDialData: true}})
+			probes = append(probes, reqs)
+		}
+		// first one refused second one successful
+		for _, p := range probes {
+			pm.CompleteProbe(p, autonatv2.Result{Addr: pub2, Idx: 1, Reachability: network.ReachabilityPublic}, nil)
+		}
+		// the second address is validated!
+		probes = nil
+		for range targetConfidence {
+			reqs := nextProbe(pm)
+			require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}})
+			probes = append(probes, reqs)
+		}
+		reqs := pm.GetProbe()
+		require.Empty(t, reqs)
+		for _, p := range probes {
+			pm.CompleteProbe(p, autonatv2.Result{AllAddrsRefused: true}, nil)
+		}
+		// all requests refused; no more probes for too many refusals
+		reqs = pm.GetProbe()
+		require.Empty(t, reqs)
+
+		cl.Add(recentProbeInterval)
+		reqs = pm.GetProbe()
+		require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}})
+	})
+
+	t.Run("successes", func(t *testing.T) {
+		pm := makeNewProbeManager([]ma.Multiaddr{pub1, pub2})
+		for j := 0; j < 2; j++ {
+			for i := 0; i < targetConfidence; i++ {
+				reqs := nextProbe(pm)
+				pm.CompleteProbe(reqs, autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: network.ReachabilityPublic}, nil)
+			}
+		}
+		// all addrs confirmed
+		reqs := pm.GetProbe()
+		require.Empty(t, reqs)
+
+		cl.Add(highConfidenceAddrProbeInterval + time.Millisecond)
+		reqs = nextProbe(pm)
+		require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}, {Addr: pub2, SendDialData: true}})
+		reqs = nextProbe(pm)
+		require.Equal(t, reqs, []autonatv2.Request{{Addr: pub2, SendDialData: true}, {Addr: pub1, SendDialData: true}})
+	})
+
+	t.Run("throttling on indeterminate reachability", func(t *testing.T) {
+		pm := makeNewProbeManager([]ma.Multiaddr{pub1, pub2})
+		reachability := network.ReachabilityPublic
+		nextReachability := func() network.Reachability {
+			if reachability == network.ReachabilityPublic {
+				reachability = network.ReachabilityPrivate
+			} else {
+				reachability = network.ReachabilityPublic
+			}
+			return reachability
+		}
+		// both addresses are indeterminate
+		for range 2 * maxRecentDialsPerAddr {
+			reqs := nextProbe(pm)
+			pm.CompleteProbe(reqs, autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: nextReachability()}, nil)
+		}
+		reqs := pm.GetProbe()
+		require.Empty(t, reqs)
+
+		cl.Add(recentProbeInterval + time.Millisecond)
+		reqs = pm.GetProbe()
+		require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}, {Addr: pub2, SendDialData: true}})
+		for range 2 * maxRecentDialsPerAddr {
+			reqs := nextProbe(pm)
+			pm.CompleteProbe(reqs, autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: nextReachability()}, nil)
+		}
+		reqs = pm.GetProbe()
+		require.Empty(t, reqs)
+	})
+
+	t.Run("reachabilityUpdate", func(t *testing.T) {
+		pm := makeNewProbeManager([]ma.Multiaddr{pub1, pub2})
+		for range 2 * targetConfidence {
+			reqs := nextProbe(pm)
+			if reqs[0].Addr.Equal(pub1) {
+				pm.CompleteProbe(reqs, autonatv2.Result{Addr: pub1, Idx: 0, Reachability: network.ReachabilityPublic}, nil)
+			} else {
+				pm.CompleteProbe(reqs, autonatv2.Result{Addr: pub2, Idx: 0, Reachability: network.ReachabilityPrivate}, nil)
+			}
+		}
+
+		reachable, unreachable := pm.AppendConfirmedAddrs(nil, nil)
+		require.Equal(t, reachable, []ma.Multiaddr{pub1})
+		require.Equal(t, unreachable, []ma.Multiaddr{pub2})
+	})
+	t.Run("expiry", func(t *testing.T) {
+		pm := makeNewProbeManager([]ma.Multiaddr{pub1})
+		for range 2 * targetConfidence {
+			reqs := nextProbe(pm)
+			pm.CompleteProbe(reqs, autonatv2.Result{Addr: pub1, Idx: 0, Reachability: network.ReachabilityPublic}, nil)
+		}
+
+		reachable, unreachable := pm.AppendConfirmedAddrs(nil, nil)
+		require.Equal(t, reachable, []ma.Multiaddr{pub1})
+		require.Empty(t, unreachable)
+
+		cl.Add(maxProbeResultTTL + 1*time.Second)
+		reachable, unreachable = pm.AppendConfirmedAddrs(nil, nil)
+		require.Empty(t, reachable)
+		require.Empty(t, unreachable)
+	})
+}
+
+type mockAutoNATClient struct {
+	F func(context.Context, []autonatv2.Request) (autonatv2.Result, error)
+}
+
+func (m mockAutoNATClient) GetReachability(ctx context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+	return m.F(ctx, reqs)
+}
+
+var _ autonatv2Client = mockAutoNATClient{}
+
+func TestAddrsReachabilityTracker(t *testing.T) {
+	pub1 := ma.StringCast("/ip4/1.1.1.1/tcp/1")
+	pub2 := ma.StringCast("/ip4/1.1.1.2/tcp/1")
+	pub3 := ma.StringCast("/ip4/1.1.1.3/tcp/1")
+	pri := ma.StringCast("/ip4/192.168.1.1/tcp/1")
+
+	newTracker := func(cli mockAutoNATClient, cl clock.Clock) *addrsReachabilityTracker {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if cl == nil {
+			cl = clock.New()
+		}
+		tr := &addrsReachabilityTracker{
+			ctx:                  ctx,
+			cancel:               cancel,
+			client:               cli,
+			newAddrs:             make(chan []ma.Multiaddr, 1),
+			reachabilityUpdateCh: make(chan struct{}, 1),
+			maxConcurrency:       3,
+			newAddrsProbeDelay:   0 * time.Second,
+			probeManager:         newProbeManager(cl.Now),
+			clock:                cl,
+		}
+		err := tr.Start()
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := tr.Close()
+			assert.NoError(t, err)
+		})
+		return tr
+	}
+
+	t.Run("simple", func(t *testing.T) {
+		// pub1 reachable, pub2 unreachable, pub3 ignored
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				for i, req := range reqs {
+					if req.Addr.Equal(pub1) {
+						return autonatv2.Result{Addr: pub1, Idx: i, Reachability: network.ReachabilityPublic}, nil
+					} else if req.Addr.Equal(pub2) {
+						return autonatv2.Result{Addr: pub2, Idx: i, Reachability: network.ReachabilityPrivate}, nil
+					}
+				}
+				return autonatv2.Result{}, autonatv2.ErrNoPeers
+			},
+		}
+		tr := newTracker(mockClient, nil)
+		tr.UpdateAddrs([]ma.Multiaddr{pub2, pub1, pri})
+		select {
+		case <-tr.reachabilityUpdateCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected reachability update")
+		}
+		reachable, unreachable := tr.ConfirmedAddrs()
+		require.Equal(t, reachable, []ma.Multiaddr{pub1}, "%s %s", reachable, pub1)
+		require.Equal(t, unreachable, []ma.Multiaddr{pub2}, "%s %s", unreachable, pub2)
+
+		tr.UpdateAddrs([]ma.Multiaddr{pub3, pub1, pri})
+		select {
+		case <-tr.reachabilityUpdateCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected reachability update")
+		}
+		reachable, unreachable = tr.ConfirmedAddrs()
+		require.Equal(t, reachable, []ma.Multiaddr{pub1}, "%s %s", reachable, pub1)
+		require.Empty(t, unreachable)
+	})
+
+	t.Run("confirmed addrs ordering", func(t *testing.T) {
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				return autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: network.ReachabilityPublic}, nil
+			},
+		}
+		tr := newTracker(mockClient, nil)
+		var addrs []ma.Multiaddr
+		for i := 0; i < 10; i++ {
+			addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/1.1.1.1/tcp/%d", i)))
+		}
+		slices.SortFunc(addrs, func(a, b ma.Multiaddr) int { return -a.Compare(b) }) // sort in reverse order
+		tr.UpdateAddrs(addrs)
+		select {
+		case <-tr.reachabilityUpdateCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected reachability update")
+		}
+		reachable, unreachable := tr.ConfirmedAddrs()
+		require.Empty(t, unreachable)
+
+		orderedAddrs := slices.Clone(addrs)
+		slices.Reverse(orderedAddrs)
+		require.Equal(t, reachable, orderedAddrs, "%s %s", reachable, addrs)
+	})
+
+	t.Run("backoff", func(t *testing.T) {
+		notify := make(chan struct{}, 1)
+		drainNotify := func() bool {
+			found := false
+			for {
+				select {
+				case <-notify:
+					found = true
+				default:
+					return found
+				}
+			}
+		}
+
+		var allow atomic.Bool
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				select {
+				case notify <- struct{}{}:
+				default:
+				}
+				if !allow.Load() {
+					return autonatv2.Result{}, autonatv2.ErrNoPeers
+				}
+				if reqs[0].Addr.Equal(pub1) {
+					return autonatv2.Result{Addr: pub1, Idx: 0, Reachability: network.ReachabilityPublic}, nil
+				}
+				return autonatv2.Result{AllAddrsRefused: true}, nil
+			},
+		}
+
+		cl := clock.NewMock()
+		tr := newTracker(mockClient, cl)
+
+		// update addrs and wait for initial checks
+		tr.UpdateAddrs([]ma.Multiaddr{pub1})
+		// need to update clock after the background goroutine processes the new addrs
+		time.Sleep(100 * time.Millisecond)
+		cl.Add(1)
+		time.Sleep(100 * time.Millisecond)
+		require.True(t, drainNotify()) // check that we did receive probes
+
+		backoffInterval := backoffStartInterval
+		for i := 0; i < 4; i++ {
+			drainNotify()
+			cl.Add(backoffInterval / 2)
+			select {
+			case <-notify:
+				t.Fatal("unexpected call")
+			case <-time.After(50 * time.Millisecond):
+			}
+			cl.Add(backoffInterval/2 + 1) // +1 to push it slightly over the backoff interval
+			backoffInterval *= 2
+			select {
+			case <-notify:
+			case <-time.After(1 * time.Second):
+				t.Fatal("expected probe")
+			}
+			reachable, unreachable := tr.ConfirmedAddrs()
+			require.Empty(t, reachable)
+			require.Empty(t, unreachable)
+		}
+		allow.Store(true)
+		drainNotify()
+		cl.Add(backoffInterval + 1)
+		select {
+		case <-tr.reachabilityUpdateCh:
+		case <-time.After(1 * time.Second):
+			t.Fatal("unexpected reachability update")
+		}
+		reachable, unreachable := tr.ConfirmedAddrs()
+		require.Equal(t, reachable, []ma.Multiaddr{pub1})
+		require.Empty(t, unreachable)
+	})
+
+	t.Run("event update", func(t *testing.T) {
+		// allow minConfidence probes to pass
+		called := make(chan struct{}, minConfidence)
+		notify := make(chan struct{})
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, _ []autonatv2.Request) (autonatv2.Result, error) {
+				select {
+				case called <- struct{}{}:
+					notify <- struct{}{}
+					return autonatv2.Result{Addr: pub1, Idx: 0, Reachability: network.ReachabilityPublic}, nil
+				default:
+					return autonatv2.Result{AllAddrsRefused: true}, nil
+				}
+			},
+		}
+
+		tr := newTracker(mockClient, nil)
+		tr.UpdateAddrs([]ma.Multiaddr{pub1})
+		for i := 0; i < minConfidence; i++ {
+			select {
+			case <-notify:
+			case <-time.After(1 * time.Second):
+				t.Fatal("expected call to autonat client")
+			}
+		}
+		select {
+		case <-tr.reachabilityUpdateCh:
+			reachable, unreachable := tr.ConfirmedAddrs()
+			require.Equal(t, reachable, []ma.Multiaddr{pub1})
+			require.Empty(t, unreachable)
+		case <-time.After(1 * time.Second):
+			t.Fatal("expected reachability update")
+		}
+		tr.UpdateAddrs([]ma.Multiaddr{pub1}) // same addrs shouldn't get update
+		select {
+		case <-tr.reachabilityUpdateCh:
+			t.Fatal("didn't expect reachability update")
+		case <-time.After(100 * time.Millisecond):
+		}
+		tr.UpdateAddrs([]ma.Multiaddr{pub2})
+		select {
+		case <-tr.reachabilityUpdateCh:
+			reachable, unreachable := tr.ConfirmedAddrs()
+			require.Empty(t, reachable)
+			require.Empty(t, unreachable)
+		case <-time.After(1 * time.Second):
+			t.Fatal("expected reachability update")
+		}
+	})
+
+	t.Run("refresh after reset interval", func(t *testing.T) {
+		notify := make(chan struct{}, 1)
+		drainNotify := func() bool {
+			found := false
+			for {
+				select {
+				case <-notify:
+					found = true
+				default:
+					return found
+				}
+			}
+		}
+
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				select {
+				case notify <- struct{}{}:
+				default:
+				}
+				if reqs[0].Addr.Equal(pub1) {
+					return autonatv2.Result{Addr: pub1, Idx: 0, Reachability: network.ReachabilityPublic}, nil
+				}
+				return autonatv2.Result{AllAddrsRefused: true}, nil
+			},
+		}
+
+		cl := clock.NewMock()
+		tr := newTracker(mockClient, cl)
+
+		// update addrs and wait for initial checks
+		tr.UpdateAddrs([]ma.Multiaddr{pub1})
+		// need to update clock after the background goroutine processes the new addrs
+		time.Sleep(100 * time.Millisecond)
+		cl.Add(1)
+		time.Sleep(100 * time.Millisecond)
+		require.True(t, drainNotify()) // check that we did receive probes
+		cl.Add(highConfidenceAddrProbeInterval / 2)
+		select {
+		case <-notify:
+			t.Fatal("unexpected call")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		cl.Add(highConfidenceAddrProbeInterval/2 + defaultReachabilityRefreshInterval) // defaultResetInterval for the next probe time
+		select {
+		case <-notify:
+		case <-time.After(1 * time.Second):
+			t.Fatal("expected probe")
+		}
+	})
+}
+
+func TestRefreshReachability(t *testing.T) {
+	pub1 := ma.StringCast("/ip4/1.1.1.1/tcp/1")
+	pub2 := ma.StringCast("/ip4/1.1.1.1/tcp/2")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	newTracker := func(client autonatv2Client, pm *probeManager) *addrsReachabilityTracker {
+		return &addrsReachabilityTracker{
+			probeManager:   pm,
+			client:         client,
+			clock:          clock.New(),
+			maxConcurrency: 3,
+			ctx:            ctx,
+			cancel:         cancel,
+		}
+	}
+	t.Run("backoff on ErrNoValidPeers", func(t *testing.T) {
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, _ []autonatv2.Request) (autonatv2.Result, error) {
+				return autonatv2.Result{}, autonatv2.ErrNoPeers
+			},
+		}
+
+		addrTracker := newProbeManager(time.Now)
+		addrTracker.UpdateAddrs([]ma.Multiaddr{pub1})
+		r := newTracker(mockClient, addrTracker)
+		res := r.refreshReachability()
+		require.True(t, <-res.BackoffCh)
+		require.Equal(t, addrTracker.InProgressProbes(), 0)
+	})
+
+	t.Run("returns backoff on errTooManyConsecutiveFailures", func(t *testing.T) {
+		// Create a client that always returns ErrDialRefused
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, _ []autonatv2.Request) (autonatv2.Result, error) {
+				return autonatv2.Result{}, errors.New("test error")
+			},
+		}
+
+		pm := newProbeManager(time.Now)
+		pm.UpdateAddrs([]ma.Multiaddr{pub1})
+		r := newTracker(mockClient, pm)
+		result := r.refreshReachability()
+		require.True(t, <-result.BackoffCh)
+		require.Equal(t, pm.InProgressProbes(), 0)
+	})
+
+	t.Run("quits on cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		block := make(chan struct{})
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, _ []autonatv2.Request) (autonatv2.Result, error) {
+				block <- struct{}{}
+				return autonatv2.Result{}, nil
+			},
+		}
+
+		pm := newProbeManager(time.Now)
+		pm.UpdateAddrs([]ma.Multiaddr{pub1})
+		r := &addrsReachabilityTracker{
+			ctx:          ctx,
+			cancel:       cancel,
+			client:       mockClient,
+			probeManager: pm,
+			clock:        clock.New(),
+		}
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result := r.refreshReachability()
+			assert.False(t, <-result.BackoffCh)
+			assert.Equal(t, pm.InProgressProbes(), 0)
+		}()
+
+		cancel()
+		time.Sleep(50 * time.Millisecond) // wait for the cancellation to be processed
+
+	outer:
+		for i := 0; i < defaultMaxConcurrency; i++ {
+			select {
+			case <-block:
+			default:
+				break outer
+			}
+		}
+		select {
+		case <-block:
+			t.Fatal("expected no more requests")
+		case <-time.After(50 * time.Millisecond):
+		}
+		wg.Wait()
+	})
+
+	t.Run("handles refusals", func(t *testing.T) {
+		pub1, _ := ma.NewMultiaddr("/ip4/1.1.1.1/tcp/1")
+
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				for i, req := range reqs {
+					if req.Addr.Equal(pub1) {
+						return autonatv2.Result{Addr: pub1, Idx: i, Reachability: network.ReachabilityPublic}, nil
+					}
+				}
+				return autonatv2.Result{AllAddrsRefused: true}, nil
+			},
+		}
+
+		pm := newProbeManager(time.Now)
+		pm.UpdateAddrs([]ma.Multiaddr{pub2, pub1})
+		r := newTracker(mockClient, pm)
+
+		result := r.refreshReachability()
+		require.False(t, <-result.BackoffCh)
+
+		reachable, unreachable := pm.AppendConfirmedAddrs(nil, nil)
+		require.Equal(t, reachable, []ma.Multiaddr{pub1})
+		require.Empty(t, unreachable)
+		require.Equal(t, pm.InProgressProbes(), 0)
+	})
+
+	t.Run("handles completions", func(t *testing.T) {
+		mockClient := mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				for i, req := range reqs {
+					if req.Addr.Equal(pub1) {
+						return autonatv2.Result{Addr: pub1, Idx: i, Reachability: network.ReachabilityPublic}, nil
+					}
+					if req.Addr.Equal(pub2) {
+						return autonatv2.Result{Addr: pub2, Idx: i, Reachability: network.ReachabilityPrivate}, nil
+					}
+				}
+				return autonatv2.Result{AllAddrsRefused: true}, nil
+			},
+		}
+		pm := newProbeManager(time.Now)
+		pm.UpdateAddrs([]ma.Multiaddr{pub2, pub1})
+		r := newTracker(mockClient, pm)
+		result := r.refreshReachability()
+		require.False(t, <-result.BackoffCh)
+
+		reachable, unreachable := pm.AppendConfirmedAddrs(nil, nil)
+		require.Equal(t, reachable, []ma.Multiaddr{pub1})
+		require.Equal(t, unreachable, []ma.Multiaddr{pub2})
+		require.Equal(t, pm.InProgressProbes(), 0)
+	})
+}
+
+func TestAddrStatusProbeCount(t *testing.T) {
+	cases := []struct {
+		inputs             string
+		wantRequiredProbes int
+		wantReachability   network.Reachability
+	}{
+		{
+			inputs:             "",
+			wantRequiredProbes: 3,
+			wantReachability:   network.ReachabilityUnknown,
+		},
+		{
+			inputs:             "S",
+			wantRequiredProbes: 2,
+			wantReachability:   network.ReachabilityUnknown,
+		},
+		{
+			inputs:             "SS",
+			wantRequiredProbes: 1,
+			wantReachability:   network.ReachabilityPublic,
+		},
+		{
+			inputs:             "SSS",
+			wantRequiredProbes: 0,
+			wantReachability:   network.ReachabilityPublic,
+		},
+		{
+			inputs:             "SSSSSSSF",
+			wantRequiredProbes: 1,
+			wantReachability:   network.ReachabilityPublic,
+		},
+		{
+			inputs:             "SFSFSSSS",
+			wantRequiredProbes: 0,
+			wantReachability:   network.ReachabilityPublic,
+		},
+		{
+			inputs:             "SSSSSFSF",
+			wantRequiredProbes: 2,
+			wantReachability:   network.ReachabilityUnknown,
+		},
+		{
+			inputs:             "FF",
+			wantRequiredProbes: 1,
+			wantReachability:   network.ReachabilityPrivate,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.inputs, func(t *testing.T) {
+			now := time.Time{}.Add(1 * time.Second)
+			ao := addrStatus{}
+			for _, r := range c.inputs {
+				if r == 'S' {
+					ao.AddOutcome(now, network.ReachabilityPublic, 5)
+				} else {
+					ao.AddOutcome(now, network.ReachabilityPrivate, 5)
+				}
+				now = now.Add(1 * time.Second)
+			}
+			require.Equal(t, ao.RequiredProbeCount(now), c.wantRequiredProbes)
+			require.Equal(t, ao.Reachability(), c.wantReachability)
+			if c.wantRequiredProbes == 0 {
+				now = now.Add(highConfidenceAddrProbeInterval + 10*time.Microsecond)
+				require.Equal(t, ao.RequiredProbeCount(now), 1)
+			}
+
+			now = now.Add(1 * time.Second)
+			ao.RemoveBefore(now)
+			require.Len(t, ao.outcomes, 0)
+		})
+	}
+}
+
+func BenchmarkAddrTracker(b *testing.B) {
+	cl := clock.NewMock()
+	t := newProbeManager(cl.Now)
+
+	addrs := make([]ma.Multiaddr, 20)
+	for i := range addrs {
+		addrs[i] = ma.StringCast(fmt.Sprintf("/ip4/1.1.1.1/tcp/%d", rand.Intn(1000)))
+	}
+	t.UpdateAddrs(addrs)
+	b.ReportAllocs()
+	b.ResetTimer()
+	p := t.GetProbe()
+	for i := 0; i < b.N; i++ {
+		pp := t.GetProbe()
+		if len(pp) == 0 {
+			pp = p
+		}
+		t.MarkProbeInProgress(pp)
+		t.CompleteProbe(pp, autonatv2.Result{Addr: pp[0].Addr, Idx: 0, Reachability: network.ReachabilityPublic}, nil)
+	}
+}
+
+func FuzzAddrsReachabilityTracker(f *testing.F) {
+	type autonatv2Response struct {
+		Result autonatv2.Result
+		Err    error
+	}
+
+	newMockClient := func(b []byte) mockAutoNATClient {
+		count := 0
+		return mockAutoNATClient{
+			F: func(_ context.Context, reqs []autonatv2.Request) (autonatv2.Result, error) {
+				if len(b) == 0 {
+					return autonatv2.Result{}, nil
+				}
+				count = (count + 1) % len(b)
+				if b[count]%3 == 0 {
+					// some address confirmed
+					c1 := (count + 1) % len(b)
+					c2 := (count + 2) % len(b)
+					rch := network.Reachability(b[c1] % 3)
+					n := int(b[c2]) % len(reqs)
+					return autonatv2.Result{
+						Addr:         reqs[n].Addr,
+						Idx:          n,
+						Reachability: rch,
+					}, nil
+				}
+				outcomes := []autonatv2Response{
+					{Result: autonatv2.Result{AllAddrsRefused: true}},
+					{Err: errors.New("test error")},
+					{Err: autonatv2.ErrPrivateAddrs},
+					{Err: autonatv2.ErrNoPeers},
+					{Result: autonatv2.Result{}, Err: nil},
+					{Result: autonatv2.Result{Addr: reqs[0].Addr, Idx: 0, Reachability: network.ReachabilityPublic}},
+					{Result: autonatv2.Result{
+						Addr:            reqs[0].Addr,
+						Idx:             0,
+						Reachability:    network.ReachabilityPublic,
+						AllAddrsRefused: true,
+					}},
+					{Result: autonatv2.Result{
+						Addr:            reqs[0].Addr,
+						Idx:             len(reqs) - 1, // invalid idx
+						Reachability:    network.ReachabilityPublic,
+						AllAddrsRefused: false,
+					}},
+				}
+				outcome := outcomes[int(b[count])%len(outcomes)]
+				return outcome.Result, outcome.Err
+			},
+		}
+	}
+
+	// TODO: Move this to go-multiaddrs
+	getProto := func(protos []byte) ma.Multiaddr {
+		protoType := 0
+		if len(protos) > 0 {
+			protoType = int(protos[0])
+		}
+
+		port1, port2 := 0, 0
+		if len(protos) > 1 {
+			port1 = int(protos[1])
+		}
+		if len(protos) > 2 {
+			port2 = int(protos[2])
+		}
+		protoTemplates := []string{
+			"/tcp/%d/",
+			"/udp/%d/",
+			"/udp/%d/quic-v1/",
+			"/udp/%d/quic-v1/tcp/%d",
+			"/udp/%d/quic-v1/webtransport/",
+			"/udp/%d/webrtc/",
+			"/udp/%d/webrtc-direct/",
+			"/unix/hello/",
+		}
+		s := protoTemplates[protoType%len(protoTemplates)]
+		port1 %= (1 << 16)
+		if strings.Count(s, "%d") == 1 {
+			return ma.StringCast(fmt.Sprintf(s, port1))
+		}
+		port2 %= (1 << 16)
+		return ma.StringCast(fmt.Sprintf(s, port1, port2))
+	}
+
+	getIP := func(ips []byte) ma.Multiaddr {
+		ipType := 0
+		if len(ips) > 0 {
+			ipType = int(ips[0])
+		}
+		ips = ips[1:]
+		var x, y int64
+		split := 128 / 8
+		if len(ips) < split {
+			split = len(ips)
+		}
+		var b [8]byte
+		copy(b[:], ips[:split])
+		x = int64(binary.LittleEndian.Uint64(b[:]))
+		clear(b[:])
+		copy(b[:], ips[split:])
+		y = int64(binary.LittleEndian.Uint64(b[:]))
+
+		var ip netip.Addr
+		switch ipType % 3 {
+		case 0:
+			ip = netip.AddrFrom4([4]byte{byte(x), byte(x >> 8), byte(x >> 16), byte(x >> 24)})
+			return ma.StringCast(fmt.Sprintf("/ip4/%s/", ip))
+		case 1:
+			pubIP := net.ParseIP("2005::") // Public IP address
+			x := int64(binary.LittleEndian.Uint64(pubIP[0:8]))
+			ip = netip.AddrFrom16([16]byte{
+				byte(x), byte(x >> 8), byte(x >> 16), byte(x >> 24),
+				byte(x >> 32), byte(x >> 40), byte(x >> 48), byte(x >> 56),
+				byte(y), byte(y >> 8), byte(y >> 16), byte(y >> 24),
+				byte(y >> 32), byte(y >> 40), byte(y >> 48), byte(y >> 56),
+			})
+			return ma.StringCast(fmt.Sprintf("/ip6/%s/", ip))
+		default:
+			ip := netip.AddrFrom16([16]byte{
+				byte(x), byte(x >> 8), byte(x >> 16), byte(x >> 24),
+				byte(x >> 32), byte(x >> 40), byte(x >> 48), byte(x >> 56),
+				byte(y), byte(y >> 8), byte(y >> 16), byte(y >> 24),
+				byte(y >> 32), byte(y >> 40), byte(y >> 48), byte(y >> 56),
+			})
+			return ma.StringCast(fmt.Sprintf("/ip6/%s/", ip))
+		}
+	}
+
+	getAddr := func(addrType int, ips, protos []byte) ma.Multiaddr {
+		switch addrType % 4 {
+		case 0:
+			return getIP(ips).Encapsulate(getProto(protos))
+		case 1:
+			return getProto(protos)
+		case 2:
+			return nil
+		default:
+			return getIP(ips).Encapsulate(getProto(protos))
+		}
+	}
+
+	getDNSAddr := func(hostNameBytes, protos []byte) ma.Multiaddr {
+		hostName := strings.ReplaceAll(string(hostNameBytes), "\\", "")
+		hostName = strings.ReplaceAll(hostName, "/", "")
+		if hostName == "" {
+			hostName = "localhost"
+		}
+		dnsType := 0
+		if len(hostNameBytes) > 0 {
+			dnsType = int(hostNameBytes[0])
+		}
+		dnsProtos := []string{"dns", "dns4", "dns6", "dnsaddr"}
+		da := ma.StringCast(fmt.Sprintf("/%s/%s/", dnsProtos[dnsType%len(dnsProtos)], hostName))
+		return da.Encapsulate(getProto(protos))
+	}
+
+	const maxAddrs = 1000
+	getAddrs := func(numAddrs int, ips, protos, hostNames []byte) []ma.Multiaddr {
+		if len(ips) == 0 || len(protos) == 0 || len(hostNames) == 0 {
+			return nil
+		}
+		numAddrs = ((numAddrs % maxAddrs) + maxAddrs) % maxAddrs
+		addrs := make([]ma.Multiaddr, numAddrs)
+		ipIdx := 0
+		protoIdx := 0
+		for i := range numAddrs {
+			addrs[i] = getAddr(i, ips[ipIdx:], protos[protoIdx:])
+			ipIdx = (ipIdx + 1) % len(ips)
+			protoIdx = (protoIdx + 1) % len(protos)
+		}
+		maxDNSAddrs := 10
+		protoIdx = 0
+		for i := 0; i < len(hostNames) && i < maxDNSAddrs; i += 2 {
+			ed := min(i+2, len(hostNames))
+			addrs = append(addrs, getDNSAddr(hostNames[i:ed], protos[protoIdx:]))
+			protoIdx = (protoIdx + 1) % len(protos)
+		}
+		return addrs
+	}
+
+	cl := clock.NewMock()
+	f.Fuzz(func(t *testing.T, numAddrs int, ips, protos, hostNames, autonatResponses []byte) {
+		tr := newAddrsReachabilityTracker(newMockClient(autonatResponses), nil, cl)
+		require.NoError(t, tr.Start())
+		tr.UpdateAddrs(getAddrs(numAddrs, ips, protos, hostNames))
+
+		// fuzz tests need to finish in 10 seconds for some reason
+		// https://github.com/golang/go/issues/48157
+		// https://github.com/golang/go/commit/5d24203c394e6b64c42a9f69b990d94cb6c8aad4#diff-4e3b9481b8794eb058998e2bec389d3db7a23c54e67ac0f7259a3a5d2c79fd04R474-R483
+		const maxIters = 20
+		for range maxIters {
+			cl.Add(5 * time.Minute)
+			time.Sleep(100 * time.Millisecond)
+		}
+		require.NoError(t, tr.Close())
+	})
+}

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -47,6 +47,7 @@ func TestHostSimple(t *testing.T) {
 	h1.Start()
 	h2, err := NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
+
 	defer h2.Close()
 	h2.Start()
 
@@ -211,6 +212,7 @@ func TestAllAddrs(t *testing.T) {
 	// no listen addrs
 	h, err := NewHost(swarmt.GenSwarm(t, swarmt.OptDialOnly), nil)
 	require.NoError(t, err)
+	h.Start()
 	defer h.Close()
 	require.Nil(t, h.AllAddrs())
 

--- a/p2p/protocol/autonatv2/autonat.go
+++ b/p2p/protocol/autonatv2/autonat.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
+	"math/rand/v2"
 	"slices"
 	"sync"
 	"time"
-
-	"math/rand/v2"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/p2p/protocol/autonatv2/pb"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
@@ -35,11 +34,15 @@ const (
 	// maxPeerAddresses is the number of addresses in a dial request the server
 	// will inspect, rest are ignored.
 	maxPeerAddresses = 50
+
+	defaultThrottlePeerDuration = 2 * time.Minute
 )
 
 var (
-	ErrNoValidPeers = errors.New("no valid peers for autonat v2")
-	ErrDialRefused  = errors.New("dial refused")
+	// ErrNoPeers is returned when the client knows no autonatv2 servers.
+	ErrNoPeers = errors.New("no peers for autonat v2")
+	// ErrPrivateAddrs is returned when the request has private IP addresses.
+	ErrPrivateAddrs = errors.New("private addresses cannot be verified with autonatv2")
 
 	log = logging.Logger("autonatv2")
 )
@@ -56,10 +59,12 @@ type Request struct {
 type Result struct {
 	// Addr is the dialed address
 	Addr ma.Multiaddr
-	// Reachability of the dialed address
+	// Idx is the index of the address that was dialed
+	Idx int
+	// Reachability is the reachability for `Addr`
 	Reachability network.Reachability
-	// Status is the outcome of the dialback
-	Status pb.DialStatus
+	// AllAddrsRefused is true when the server refused to dial all the addresses in the request.
+	AllAddrsRefused bool
 }
 
 // AutoNAT implements the AutoNAT v2 client and server.
@@ -76,8 +81,12 @@ type AutoNAT struct {
 	srv *server
 	cli *client
 
-	mx    sync.Mutex
-	peers *peersMap
+	mx           sync.Mutex
+	peers        *peersMap
+	throttlePeer map[peer.ID]time.Time
+	// throttlePeerDuration is the duration to wait before making another dial request to the
+	// same server.
+	throttlePeerDuration time.Duration
 	// allowPrivateAddrs enables using private and localhost addresses for reachability checks.
 	// This is only useful for testing.
 	allowPrivateAddrs bool
@@ -86,7 +95,7 @@ type AutoNAT struct {
 // New returns a new AutoNAT instance.
 // host and dialerHost should have the same dialing capabilities. In case the host doesn't support
 // a transport, dial back requests for address for that transport will be ignored.
-func New(host host.Host, dialerHost host.Host, opts ...AutoNATOption) (*AutoNAT, error) {
+func New(dialerHost host.Host, opts ...AutoNATOption) (*AutoNAT, error) {
 	s := defaultSettings()
 	for _, o := range opts {
 		if err := o(s); err != nil {
@@ -96,18 +105,20 @@ func New(host host.Host, dialerHost host.Host, opts ...AutoNATOption) (*AutoNAT,
 
 	ctx, cancel := context.WithCancel(context.Background())
 	an := &AutoNAT{
-		host:              host,
-		ctx:               ctx,
-		cancel:            cancel,
-		srv:               newServer(host, dialerHost, s),
-		cli:               newClient(host),
-		allowPrivateAddrs: s.allowPrivateAddrs,
-		peers:             newPeersMap(),
+		ctx:                  ctx,
+		cancel:               cancel,
+		srv:                  newServer(dialerHost, s),
+		cli:                  newClient(),
+		allowPrivateAddrs:    s.allowPrivateAddrs,
+		peers:                newPeersMap(),
+		throttlePeer:         make(map[peer.ID]time.Time),
+		throttlePeerDuration: s.throttlePeerDuration,
 	}
 	return an, nil
 }
 
 func (an *AutoNAT) background(sub event.Subscription) {
+	ticker := time.NewTicker(10 * time.Minute)
 	for {
 		select {
 		case <-an.ctx.Done():
@@ -122,12 +133,24 @@ func (an *AutoNAT) background(sub event.Subscription) {
 				an.updatePeer(evt.Peer)
 			case event.EvtPeerIdentificationCompleted:
 				an.updatePeer(evt.Peer)
+			default:
+				log.Errorf("unexpected event: %T", e)
 			}
+		case <-ticker.C:
+			now := time.Now()
+			an.mx.Lock()
+			for p, t := range an.throttlePeer {
+				if t.Before(now) {
+					delete(an.throttlePeer, p)
+				}
+			}
+			an.mx.Unlock()
 		}
 	}
 }
 
-func (an *AutoNAT) Start() error {
+func (an *AutoNAT) Start(h host.Host) error {
+	an.host = h
 	// Listen on event.EvtPeerProtocolsUpdated, event.EvtPeerConnectednessChanged
 	// event.EvtPeerIdentificationCompleted to maintain our set of autonat supporting peers.
 	sub, err := an.host.EventBus().Subscribe([]interface{}{
@@ -138,8 +161,8 @@ func (an *AutoNAT) Start() error {
 	if err != nil {
 		return fmt.Errorf("event subscription failed: %w", err)
 	}
-	an.cli.Start()
-	an.srv.Start()
+	an.cli.Start(h)
+	an.srv.Start(h)
 
 	an.wg.Add(1)
 	go an.background(sub)
@@ -156,24 +179,48 @@ func (an *AutoNAT) Close() {
 
 // GetReachability makes a single dial request for checking reachability for requested addresses
 func (an *AutoNAT) GetReachability(ctx context.Context, reqs []Request) (Result, error) {
+	var filteredReqs []Request
 	if !an.allowPrivateAddrs {
+		filteredReqs = make([]Request, 0, len(reqs))
 		for _, r := range reqs {
-			if !manet.IsPublicAddr(r.Addr) {
-				return Result{}, fmt.Errorf("private address cannot be verified by autonatv2: %s", r.Addr)
+			if manet.IsPublicAddr(r.Addr) {
+				filteredReqs = append(filteredReqs, r)
+			} else {
+				log.Errorf("private address in reachability check: %s", r.Addr)
 			}
 		}
+		if len(filteredReqs) == 0 {
+			return Result{}, ErrPrivateAddrs
+		}
+	} else {
+		filteredReqs = reqs
 	}
 	an.mx.Lock()
-	p := an.peers.GetRand()
+	now := time.Now()
+	var p peer.ID
+	for pr := range an.peers.Shuffled() {
+		if t := an.throttlePeer[pr]; t.After(now) {
+			continue
+		}
+		p = pr
+		an.throttlePeer[p] = time.Now().Add(an.throttlePeerDuration)
+		break
+	}
 	an.mx.Unlock()
 	if p == "" {
-		return Result{}, ErrNoValidPeers
+		return Result{}, ErrNoPeers
 	}
-
-	res, err := an.cli.GetReachability(ctx, p, reqs)
+	res, err := an.cli.GetReachability(ctx, p, filteredReqs)
 	if err != nil {
 		log.Debugf("reachability check with %s failed, err: %s", p, err)
-		return Result{}, fmt.Errorf("reachability check with %s failed: %w", p, err)
+		return res, fmt.Errorf("reachability check with %s failed: %w", p, err)
+	}
+	// restore the correct index in case we'd filtered private addresses
+	for i, r := range reqs {
+		if r.Addr.Equal(res.Addr) {
+			res.Idx = i
+			break
+		}
 	}
 	log.Debugf("reachability check with %s successful", p)
 	return res, nil
@@ -187,7 +234,7 @@ func (an *AutoNAT) updatePeer(p peer.ID) {
 	// and swarm for the current state
 	protos, err := an.host.Peerstore().SupportsProtocols(p, DialProtocol)
 	connectedness := an.host.Network().Connectedness(p)
-	if err == nil && slices.Contains(protos, DialProtocol) && connectedness == network.Connected {
+	if err == nil && connectedness == network.Connected && slices.Contains(protos, DialProtocol) {
 		an.peers.Put(p)
 	} else {
 		an.peers.Delete(p)
@@ -208,28 +255,40 @@ func newPeersMap() *peersMap {
 	}
 }
 
-func (p *peersMap) GetRand() peer.ID {
-	if len(p.peers) == 0 {
-		return ""
+// Shuffled iterates over the map in random order
+func (p *peersMap) Shuffled() iter.Seq[peer.ID] {
+	n := len(p.peers)
+	start := 0
+	if n > 0 {
+		start = rand.IntN(n)
 	}
-	return p.peers[rand.IntN(len(p.peers))]
+	return func(yield func(peer.ID) bool) {
+		for i := range n {
+			if !yield(p.peers[(i+start)%n]) {
+				return
+			}
+		}
+	}
 }
 
-func (p *peersMap) Put(pid peer.ID) {
-	if _, ok := p.peerIdx[pid]; ok {
+func (p *peersMap) Put(id peer.ID) {
+	if _, ok := p.peerIdx[id]; ok {
 		return
 	}
-	p.peers = append(p.peers, pid)
-	p.peerIdx[pid] = len(p.peers) - 1
+	p.peers = append(p.peers, id)
+	p.peerIdx[id] = len(p.peers) - 1
 }
 
-func (p *peersMap) Delete(pid peer.ID) {
-	idx, ok := p.peerIdx[pid]
+func (p *peersMap) Delete(id peer.ID) {
+	idx, ok := p.peerIdx[id]
 	if !ok {
 		return
 	}
-	p.peers[idx] = p.peers[len(p.peers)-1]
-	p.peerIdx[p.peers[idx]] = idx
-	p.peers = p.peers[:len(p.peers)-1]
-	delete(p.peerIdx, pid)
+	n := len(p.peers)
+	lastPeer := p.peers[n-1]
+	p.peers[idx] = lastPeer
+	p.peerIdx[lastPeer] = idx
+	p.peers[n-1] = ""
+	p.peers = p.peers[:n-1]
+	delete(p.peerIdx, id)
 }

--- a/p2p/protocol/autonatv2/options.go
+++ b/p2p/protocol/autonatv2/options.go
@@ -13,6 +13,7 @@ type autoNATSettings struct {
 	now                                  func() time.Time
 	amplificatonAttackPreventionDialWait time.Duration
 	metricsTracer                        MetricsTracer
+	throttlePeerDuration                 time.Duration
 }
 
 func defaultSettings() *autoNATSettings {
@@ -25,6 +26,7 @@ func defaultSettings() *autoNATSettings {
 		dataRequestPolicy:                    amplificationAttackPrevention,
 		amplificatonAttackPreventionDialWait: 3 * time.Second,
 		now:                                  time.Now,
+		throttlePeerDuration:                 defaultThrottlePeerDuration,
 	}
 }
 
@@ -62,6 +64,13 @@ func allowPrivateAddrs(s *autoNATSettings) error {
 func withAmplificationAttackPreventionDialWait(d time.Duration) AutoNATOption {
 	return func(s *autoNATSettings) error {
 		s.amplificatonAttackPreventionDialWait = d
+		return nil
+	}
+}
+
+func withThrottlePeerDuration(d time.Duration) AutoNATOption {
+	return func(s *autoNATSettings) error {
+		s.throttlePeerDuration = d
 		return nil
 	}
 }

--- a/p2p/protocol/autonatv2/server.go
+++ b/p2p/protocol/autonatv2/server.go
@@ -59,10 +59,9 @@ type server struct {
 	allowPrivateAddrs bool
 }
 
-func newServer(host, dialer host.Host, s *autoNATSettings) *server {
+func newServer(dialer host.Host, s *autoNATSettings) *server {
 	return &server{
 		dialerHost:                           dialer,
-		host:                                 host,
 		dialDataRequestPolicy:                s.dataRequestPolicy,
 		amplificatonAttackPreventionDialWait: s.amplificatonAttackPreventionDialWait,
 		allowPrivateAddrs:                    s.allowPrivateAddrs,
@@ -79,7 +78,8 @@ func newServer(host, dialer host.Host, s *autoNATSettings) *server {
 }
 
 // Enable attaches the stream handler to the host.
-func (as *server) Start() {
+func (as *server) Start(h host.Host) {
+	as.host = h
 	as.host.SetStreamHandler(DialProtocol, as.handleDialRequest)
 }
 


### PR DESCRIPTION
This introduces `addrsReachabilityTracker` that tracks reachability on
a set of addresses. It probes reachability for addresses periodically
and has an exponential backoff in case there are too many errors
or we don't have any valid autonatv2 peer. 

There's no smartness in the address selection logic currently. We just
test all provided addresses. It also doesn't use the addresses provided
by `AddrsFactory`, so currently there's no way to get a user provided
address tested for reachability, something that would be a problem for 
dns addresses. I intend to introduce an alternative to 
`AddrsFactory`, something like, `AnnounceAddrs(addrs []ma.Multiaddr)`
that's just appended to the set of addresses that we have, and check
reachability for those addresses. 

There's only one method exposed in the BasicHost right now that's 
`ReachableAddrs() []ma.Multiaddr` that returns the host's reachable
addrs. Users can also use the event `EvtHostReachableAddrsChanged`
to be notified when any addrs reachability changes.