### PR TITLE
wip: feat: support forwarded headers for websocket

### DIFF
--- a/p2p/transport/websocket/conn.go
+++ b/p2p/transport/websocket/conn.go
@@ -39,7 +39,7 @@ var _ manet.Conn = (*Conn)(nil)
 // NewConn creates a Conn given a regular gorilla/websocket Conn.
 //
 // Deprecated: There's no reason to use this method externally. It'll be unexported in a future release.
-func NewConn(raw *ws.Conn, secure bool) *Conn {
+func NewConn(raw *ws.Conn, secure bool, remoteAddr string) *Conn {
 	lna := NewAddrWithScheme(raw.LocalAddr().String(), secure)
 	laddr, err := manet.FromNetAddr(lna)
 	if err != nil {
@@ -47,7 +47,10 @@ func NewConn(raw *ws.Conn, secure bool) *Conn {
 		return nil
 	}
 
-	rna := NewAddrWithScheme(raw.RemoteAddr().String(), secure)
+	if remoteAddr == "" {
+		remoteAddr = raw.RemoteAddr().String()
+	}
+	rna := NewAddrWithScheme(remoteAddr, secure)
 	raddr, err := manet.FromNetAddr(rna)
 	if err != nil {
 		log.Errorf("BUG: invalid remoteaddr on websocket conn", raw.RemoteAddr())

--- a/p2p/transport/websocket/real_ip.go
+++ b/p2p/transport/websocket/real_ip.go
@@ -1,0 +1,82 @@
+package websocket
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func GetRealIP(addr net.Addr, h http.Header) string {
+	remoteAddr := addr.String()
+	remoteIp := GetRealIPFromHeader(h)
+	if remoteIp != nil {
+		remoteTcpAddr, ok := addr.(*net.TCPAddr)
+		if ok {
+			remoteAddr = IpPort(remoteIp, remoteTcpAddr.Port)
+		} else {
+			p := strings.LastIndex(remoteAddr, ":")
+			if p > 0 {
+				port, err := strconv.ParseInt(remoteAddr[p+1:], 10, 16)
+				if err == nil {
+					remoteAddr = IpPort(remoteIp, int(port))
+				}
+			}
+		}
+	}
+	return remoteAddr
+}
+
+// GetRealIPFromHeader extracts the client's real IP address from HTTP request header.
+// It checks various proxy header to find the actual IP.
+func GetRealIPFromHeader(h http.Header) net.IP {
+	// Check X-Real-IP header (used by Nginx and others)
+	ipStr := h.Get("X-Real-IP")
+	if ip := validateIp(ipStr); ip != nil {
+		return ip
+	}
+
+	// Check X-Forwarded-For header (used by most proxies)
+	// Format: client, proxy1, proxy2, ...
+	ipStr = h.Get("X-Forwarded-For")
+	if ipStr != "" {
+		// Extract the first IP from the comma-separated list
+		ips := strings.Split(ipStr, ",")
+		for _, ipItem := range ips {
+			ipItem = strings.TrimSpace(ipItem)
+			if ip := validateIp(ipItem); ip != nil {
+				return ip
+			}
+		}
+	}
+
+	// Check CF-Connecting-IP header (used by Cloudflare)
+	ipStr = h.Get("CF-Connecting-IP")
+	if ip := validateIp(ipStr); ip != nil {
+		return ip
+	}
+
+	// Check True-Client-IP header (used by Akamai, Cloudflare, etc.)
+	ipStr = h.Get("True-Client-IP")
+	if ip := validateIp(ipStr); ip != nil {
+		return ip
+	}
+
+	return nil
+}
+
+// validateIp checks if a string is a valid IP address
+func validateIp(ip string) net.IP {
+	if ip == "" {
+		return nil
+	}
+	return net.ParseIP(ip)
+}
+
+func IpPort(ip net.IP, port int) string {
+	if ip.To4() == nil {
+		return fmt.Sprintf("[%s]:%d", ip.String(), port)
+	}
+	return fmt.Sprintf("%s:%d", ip.String(), port)
+}

--- a/p2p/transport/websocket/real_ip_test.go
+++ b/p2p/transport/websocket/real_ip_test.go
@@ -1,0 +1,208 @@
+package websocket
+
+import (
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestGetRealIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		addr     net.Addr
+		header   map[string]string
+		expected string
+	}{
+		{
+			name:     "No header, simple IP",
+			addr:     &net.TCPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 8080},
+			header:   map[string]string{},
+			expected: "192.168.1.1:8080",
+		},
+		{
+			name: "With X-Real-IP header",
+			addr: &net.TCPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 8080},
+			header: map[string]string{
+				"X-Real-IP": "203.0.113.1",
+			},
+			expected: "203.0.113.1:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			for key, value := range tt.header {
+				header.Set(key, value)
+			}
+
+			result := GetRealIP(tt.addr, header)
+			if result != tt.expected {
+				t.Errorf("GetRealIP() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetRealIPFromHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   map[string]string
+		expected string
+	}{
+		{
+			name: "X-Real-IP header",
+			header: map[string]string{
+				"X-Real-IP": "192.168.1.1",
+			},
+			expected: "192.168.1.1",
+		},
+		{
+			name: "X-Forwarded-For header single IP",
+			header: map[string]string{
+				"X-Forwarded-For": "203.0.113.1",
+			},
+			expected: "203.0.113.1",
+		},
+		{
+			name: "X-Forwarded-For header multiple IPs",
+			header: map[string]string{
+				"X-Forwarded-For": "203.0.113.1,192.168.1.1,10.0.0.1",
+			},
+			expected: "203.0.113.1",
+		},
+		{
+			name: "CF-Connecting-IP header",
+			header: map[string]string{
+				"CF-Connecting-IP": "2001:db8::1",
+			},
+			expected: "2001:db8::1",
+		},
+		{
+			name: "True-Client-IP header",
+			header: map[string]string{
+				"True-Client-IP": "192.0.2.1",
+			},
+			expected: "192.0.2.1",
+		},
+		{
+			name: "Invalid IP in X-Real-IP",
+			header: map[string]string{
+				"X-Real-IP": "invalid-ip",
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty header",
+			header:   map[string]string{},
+			expected: "",
+		},
+		{
+			name: "Multiple header with priority",
+			header: map[string]string{
+				"X-Real-IP":        "192.168.1.1",
+				"X-Forwarded-For":  "203.0.113.1",
+				"CF-Connecting-IP": "2001:db8::1",
+			},
+			expected: "192.168.1.1", // X-Real-IP should take precedence
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			for key, value := range tt.header {
+				header.Set(key, value)
+			}
+
+			got := GetRealIPFromHeader(header)
+
+			if tt.expected == "" {
+				if got != nil {
+					t.Errorf("GetRealIPFromHeader() = %v, want nil", got)
+				}
+				return
+			}
+
+			expected := net.ParseIP(tt.expected)
+			if !got.Equal(expected) {
+				t.Errorf("GetRealIPFromHeader() = %v, want %v", got, expected)
+			}
+		})
+	}
+}
+
+func TestValidateIp(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "Valid IPv4",
+			input:    "192.168.1.1",
+			expected: true,
+		},
+		{
+			name:     "Valid IPv6",
+			input:    "2001:db8::1",
+			expected: true,
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "Invalid IP",
+			input:    "invalid-ip",
+			expected: false,
+		},
+		{
+			name:     "Partial IP",
+			input:    "192.168",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateIp(tt.input)
+			if (got != nil) != tt.expected {
+				t.Errorf("validateIp(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIpPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		port     int
+		expected string
+	}{
+		{
+			name:     "IPv4 address",
+			ip:       "192.168.1.1",
+			port:     8080,
+			expected: "192.168.1.1:8080",
+		},
+		{
+			name:     "IPv6 address",
+			ip:       "2001:db8::1",
+			port:     8080,
+			expected: "[2001:db8::1]:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			got := IpPort(ip, tt.port)
+			if got != tt.expected {
+				t.Errorf("IpPort() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p/issues/1437
Also https://github.com/ipfs/kubo/issues/8193

Kubo Log:
```
DEBUG   upgrader        upgrader/listener.go:99 resource manager blocked accept of new connection       {"error": "connections per ip limit exceeded for /ip4/10.42.111.111/tcp/38108/ws"}
```
