### PR TITLE
feat: support overriding net interface methods

### DIFF
--- a/core/network/net_provider.go
+++ b/core/network/net_provider.go
@@ -1,0 +1,32 @@
+package network
+
+import "net"
+
+type NetProvider interface {
+	Interfaces() ([]net.Interface, error)
+	InterfaceAddrs() ([]net.Addr, error)
+}
+
+type defaultNetProvider struct{}
+
+func (defaultNetProvider) Interfaces() ([]net.Interface, error) {
+	return net.Interfaces()
+}
+
+func (defaultNetProvider) InterfaceAddrs() ([]net.Addr, error) {
+	return net.InterfaceAddrs()
+}
+
+var netProvider NetProvider = defaultNetProvider{}
+
+func Interfaces() ([]net.Interface, error) {
+	return netProvider.Interfaces()
+}
+
+func InterfaceAddrs() ([]net.Addr, error) {
+	return netProvider.InterfaceAddrs()
+}
+
+func SetNetProvider(provider NetProvider) {
+	netProvider = provider
+}

--- a/p2p/discovery/mdns/mdns.go
+++ b/p2p/discovery/mdns/mdns.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/libp2p/zeroconf/v2"
@@ -133,6 +134,11 @@ func (s *mdnsService) startServer() error {
 		return err
 	}
 
+	interfaces, err := network.Interfaces()
+	if err != nil {
+		return err
+	}
+
 	server, err := zeroconf.RegisterProxy(
 		s.peerName,
 		s.serviceName,
@@ -141,7 +147,7 @@ func (s *mdnsService) startServer() error {
 		s.peerName,
 		ips,
 		txts,
-		nil,
+		interfaces,
 	)
 	if err != nil {
 		return err

--- a/p2p/host/basic/addrs_manager.go
+++ b/p2p/host/basic/addrs_manager.go
@@ -516,7 +516,13 @@ func (i *interfaceAddrsCache) updateUnlocked() {
 	}
 
 	// Resolve the interface addresses
-	ifaceAddrs, err := manet.InterfaceMultiaddrs()
+	var ifaceAddrs []ma.Multiaddr
+	var err error
+	var addrs []net.Addr
+	if addrs, err = network.InterfaceAddrs(); err != nil {
+		ifaceAddrs, err = manet.InterfaceMultiaddrsFor(addrs)
+	}
+
 	if err != nil {
 		// This usually shouldn't happen, but we could be in some kind
 		// of funky restricted environment.

--- a/p2p/net/nat/internal/nat/natpmp.go
+++ b/p2p/net/nat/internal/nat/natpmp.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	natpmp "github.com/jackpal/go-nat-pmp"
+	"github.com/libp2p/go-libp2p/core/network"
 )
 
 var (
@@ -67,7 +68,7 @@ func (n *natpmpNAT) GetDeviceAddress() (addr net.IP, err error) {
 }
 
 func (n *natpmpNAT) GetInternalAddress() (addr net.IP, err error) {
-	ifaces, err := net.Interfaces()
+	ifaces, err := network.Interfaces()
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/net/nat/internal/nat/upnp.go
+++ b/p2p/net/nat/internal/nat/upnp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/huin/goupnp"
 	"github.com/huin/goupnp/dcps/internetgateway1"
 	"github.com/huin/goupnp/dcps/internetgateway2"
+	"github.com/libp2p/go-libp2p/core/network"
 
 	"github.com/koron/go-ssdp"
 )
@@ -229,7 +230,7 @@ func (u *upnp_NAT) GetInternalAddress() (net.IP, error) {
 		return nil, err
 	}
 
-	ifaces, err := net.Interfaces()
+	ifaces, err := network.Interfaces()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The builtin methods are broken on android (see https://github.com/golang/go/issues/40569). This patch allows users to provide their own implementation of these methods, such as [anet](https://github.com/wlynxg/anet).

This depends on a change in go-multiaddr to be merged first: https://github.com/multiformats/go-multiaddr/pull/275

As suggested in: https://github.com/libp2p/go-libp2p/pull/3159#issuecomment-2622609540.
