### PR TITLE
chore: the copy of the 'for' variable "tc" can be deleted (Go 1.22+)

### DIFF
--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -686,7 +686,6 @@ func (rf *relayFinder) refreshReservations(ctx context.Context, now time.Time) b
 			continue
 		}
 
-		p := p
 		g.Go(func() error {
 			err := rf.refreshRelayReservation(ctx, p)
 			rf.metricsTracer.ReservationRequestFinished(true, err)

--- a/p2p/test/negotiation/muxer_test.go
+++ b/p2p/test/negotiation/muxer_test.go
@@ -84,11 +84,7 @@ func TestMuxerNegotiation(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
-
 		for _, sec := range securities {
-			sec := sec
-
 			t.Run(fmt.Sprintf("%s: %s", sec.Name, tc.Name), func(t *testing.T) {
 				server, err := libp2p.New(
 					libp2p.Identity(serverID),

--- a/p2p/test/negotiation/security_test.go
+++ b/p2p/test/negotiation/security_test.go
@@ -54,8 +54,6 @@ func TestSecurityNegotiation(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range testcases {
-		tc := tc
-
 		t.Run(tc.Name, func(t *testing.T) {
 			server, err := libp2p.New(
 				libp2p.Identity(serverID),

--- a/p2p/transport/webtransport/crypto_test.go
+++ b/p2p/transport/webtransport/crypto_test.go
@@ -93,7 +93,6 @@ func TestCertificateVerification(t *testing.T) {
 			errStr: "cert not valid",
 		},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("rejecting invalid certificates: %s", tc.name), func(t *testing.T) {
 			err := verifyRawCerts([][]byte{tc.cert.Raw}, []multihash.DecodedMultihash{sha256Multihash(t, tc.cert.Raw)})
 			require.Error(t, err)
@@ -125,7 +124,6 @@ func TestCertificateVerification(t *testing.T) {
 			errStr: "cert hash not found",
 		},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("rejecting invalid certificates: %s", tc.name), func(t *testing.T) {
 			err := verifyRawCerts(tc.certs, tc.hashes)
 			require.Error(t, err)


### PR DESCRIPTION
close: https://github.com/libp2p/go-libp2p/issues/3240