### PR TITLE
autonatv2: explicitly handle dns addrs

### DIFF
--- a/p2p/protocol/autonatv2/server.go
+++ b/p2p/protocol/autonatv2/server.go
@@ -522,6 +522,9 @@ func amplificationAttackPrevention(observedAddr, dialAddr ma.Multiaddr) bool {
 	if err != nil {
 		return true
 	}
-	dialIP, _ := manet.ToIP(dialAddr) // must be an IP multiaddr
+	dialIP, err := manet.ToIP(dialAddr) // can be dns addr
+	if err != nil {
+		return true
+	}
 	return !observedIP.Equal(dialIP)
 }

--- a/p2p/protocol/autonatv2/server_test.go
+++ b/p2p/protocol/autonatv2/server_test.go
@@ -588,6 +588,13 @@ func TestDefaultAmplificationAttackPrevention(t *testing.T) {
 
 	t2 := ma.StringCast("/ip4/1.1.1.1/tcp/1235") // different IP
 	require.True(t, amplificationAttackPrevention(q2, t2))
+
+	// always ask dial data for dns addrs
+	d1 := ma.StringCast("/dns/localhost/udp/1/quic-v1")
+	d2 := ma.StringCast("/dnsaddr/libp2p.io/tcp/1")
+	require.True(t, amplificationAttackPrevention(d1, t1))
+	require.True(t, amplificationAttackPrevention(d2, t1))
+
 }
 
 func FuzzServerDialRequest(f *testing.F) {


### PR DESCRIPTION
We do allow dns addrs for autonatv2. This function handles them correcly, but the comment is wrong, and the handling is accidental.  Make it explicity.