### PR TITLE
fix(relay): fix data-race in relayFinder

### DIFF
--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -251,6 +251,9 @@ func (rf *relayFinder) updateAddrs() {
 // This function returns the p2p-circuit addrs for the host.
 // The returned addresses are of the form <relay's-addr>/p2p/<relay's-id>/p2p-circuit.
 func (rf *relayFinder) getCircuitAddrs() []ma.Multiaddr {
+	rf.relayMx.Lock()
+	defer rf.relayMx.Unlock()
+
 	raddrs := make([]ma.Multiaddr, 0, 4*len(rf.relays)+4)
 	for p := range rf.relays {
 		addrs := cleanupAddressSet(rf.host.Peerstore().Addrs(p))


### PR DESCRIPTION
# Description  

This PR fixes a data race condition in the relay finder. It was observed [here](https://github.com/pactus-project/pactus/actions/runs/14100227555/job/39494949146?pr=1713#step:4:511).  

The `cleanupDisconnectedPeers` function deletes `rf.relays` while, at the same time, `getCircuitAddrs` iterates over the map.  

This PR adds a lock in `getCircuitAddrs` to ensure it iterates over the map only when it is unlocked.  
