### PR TITLE
identify: reduce timeout to 5 seconds

### DIFF
--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -817,12 +817,6 @@ func TestLargePushMessage(t *testing.T) {
 }
 
 func TestIdentifyResponseReadTimeout(t *testing.T) {
-	timeout := identify.Timeout
-	identify.Timeout = 100 * time.Millisecond
-	defer func() {
-		identify.Timeout = timeout
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -832,12 +826,12 @@ func TestIdentifyResponseReadTimeout(t *testing.T) {
 	defer h2.Close()
 
 	h2p := h2.ID()
-	ids1, err := identify.NewIDService(h1)
+	ids1, err := identify.NewIDService(h1, identify.WithTimeout(100*time.Millisecond))
 	require.NoError(t, err)
 	defer ids1.Close()
 	ids1.Start()
 
-	ids2, err := identify.NewIDService(h2)
+	ids2, err := identify.NewIDService(h2, identify.WithTimeout(100*time.Millisecond))
 	require.NoError(t, err)
 	defer ids2.Close()
 	ids2.Start()
@@ -863,12 +857,6 @@ func TestIdentifyResponseReadTimeout(t *testing.T) {
 }
 
 func TestIncomingIDStreamsTimeout(t *testing.T) {
-	timeout := identify.Timeout
-	identify.Timeout = 100 * time.Millisecond
-	defer func() {
-		identify.Timeout = timeout
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -880,12 +868,12 @@ func TestIncomingIDStreamsTimeout(t *testing.T) {
 		defer h1.Close()
 		defer h2.Close()
 
-		ids1, err := identify.NewIDService(h1)
+		ids1, err := identify.NewIDService(h1, identify.WithTimeout(100*time.Millisecond))
 		require.NoError(t, err)
 		defer ids1.Close()
 		ids1.Start()
 
-		ids2, err := identify.NewIDService(h2)
+		ids2, err := identify.NewIDService(h2, identify.WithTimeout(100*time.Millisecond))
 		require.NoError(t, err)
 		defer ids2.Close()
 		ids2.Start()

--- a/p2p/protocol/identify/opts.go
+++ b/p2p/protocol/identify/opts.go
@@ -1,11 +1,14 @@
 package identify
 
+import "time"
+
 type config struct {
 	protocolVersion            string
 	userAgent                  string
 	disableSignedPeerRecord    bool
 	metricsTracer              MetricsTracer
 	disableObservedAddrManager bool
+	timeout                    time.Duration
 }
 
 // Option is an option function for identify.
@@ -45,5 +48,12 @@ func WithMetricsTracer(tr MetricsTracer) Option {
 func DisableObservedAddrManager() Option {
 	return func(cfg *config) {
 		cfg.disableObservedAddrManager = true
+	}
+}
+
+// WithTimeout sets the timeout for identify interactions.
+func WithTimeout(timeout time.Duration) Option {
+	return func(cfg *config) {
+		cfg.timeout = timeout
 	}
 }


### PR DESCRIPTION
The max message size is about 100kB. 5 seconds are enough to transfer this.