### PR TITLE
Fix: Clean up transport associations when QUIC listener is closed

### DIFF
--- a/p2p/transport/quicreuse/connmgr.go
+++ b/p2p/transport/quicreuse/connmgr.go
@@ -224,6 +224,9 @@ func (c *ConnManager) onListenerClosed(key string) {
 	entry.refCount = entry.refCount - 1
 	if entry.refCount <= 0 {
 		delete(c.quicListeners, key)
+		if tr, ok := entry.ln.transport.(*refcountedTransport); ok {
+			tr.disassociate()
+		}
 		entry.ln.Close()
 	} else {
 		c.quicListeners[key] = entry

--- a/p2p/transport/quicreuse/reuse.go
+++ b/p2p/transport/quicreuse/reuse.go
@@ -118,6 +118,13 @@ func (c *refcountedTransport) hasAssociation(a any) bool {
 	return ok
 }
 
+// disassociate removes all associations from this transport.
+func (c *refcountedTransport) disassociate() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.assocations = nil
+}
+
 func (c *refcountedTransport) IncreaseCount() {
 	c.mutex.Lock()
 	c.refCount++


### PR DESCRIPTION
This PR resolves #3246  by ensuring that associated transports are properly cleaned up when a QUIC listener is closed.