### PR TITLE
rcmgr: use netip.Prefix as map key instead of string

### DIFF
--- a/p2p/host/resource-manager/conn_limiter_test.go
+++ b/p2p/host/resource-manager/conn_limiter_test.go
@@ -24,6 +24,22 @@ func TestItLimits(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, cl.addConn(otherIP))
 	})
+
+	t.Run("IPv4 removal", func(t *testing.T) {
+		ip, err := netip.ParseAddr("1.2.3.4")
+		require.NoError(t, err)
+		cl := newConnLimiter()
+		cl.connLimitPerSubnetV4[0].ConnCount = 1
+		require.True(t, cl.addConn(ip))
+
+		// should fail the second time
+		require.False(t, cl.addConn(ip))
+		// remove the connection
+		cl.rmConn(ip)
+		// should succeed now
+		require.True(t, cl.addConn(ip))
+	})
+
 	t.Run("IPv6", func(t *testing.T) {
 		ip, err := netip.ParseAddr("1:2:3:4::1")
 		require.NoError(t, err)


### PR DESCRIPTION
We're converting this prefix to string for storing in maps. There's no need to, as netip.prefix is a value type that can be used as a key. 

No functional change expected.