### PR TITLE
ci: add golangci-lint for linting

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -19,3 +19,42 @@ jobs:
     with:
       go-version: "1.24.x"
       go-generate-ignore-protoc-version-comments: true
+  
+  golangci-lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [  "1.23.x", "1.24.x" ]
+    env:
+      GOLANGCI_LINT_VERSION: v2.0.2
+    name: golangci-lint (Go ${{ matrix.go }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: golangci-lint (Linux)
+        uses: golangci/golangci-lint-action@v7
+        with:
+          args: --timeout=5m
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          only-new-issues: true
+      - name: golangci-lint (Windows)
+        if: success() || failure() # run this step even if the previous one failed
+        uses: golangci/golangci-lint-action@v7
+        env:
+          GOOS: "windows"
+        with:
+          args: --timeout=5m
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          only-new-issues: true
+      - name: golangci-lint (OSX)
+        if: success() || failure() # run this step even if the previous one failed
+        uses: golangci/golangci-lint-action@v7
+        env:
+          GOOS: "darwin"
+        with:
+          args: --timeout=5m
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - revive
+    - unused
+    - prealloc
+
+  settings:
+    revive:
+      severity: warning
+      rules:
+        - name: unused-parameter
+          severity: warning
+
+severity:
+    default: warning
+

--- a/p2p/protocol/autonatv2/server.go
+++ b/p2p/protocol/autonatv2/server.go
@@ -213,7 +213,7 @@ func (as *server) serveDialRequest(s network.Stream) EventDialRequestCompleted {
 	nonce := msg.GetDialRequest().Nonce
 
 	isDialDataRequired := as.dialDataRequestPolicy(s.Conn().RemoteMultiaddr(), dialAddr)
-	if isDialDataRequired && !as.limiter.AcceptDialDataRequest(p) {
+	if isDialDataRequired && !as.limiter.AcceptDialDataRequest() {
 		msg = pb.Message{
 			Msg: &pb.Message_DialResponse{
 				DialResponse: &pb.DialResponse{
@@ -442,7 +442,7 @@ func (r *rateLimiter) Accept(p peer.ID) bool {
 	return true
 }
 
-func (r *rateLimiter) AcceptDialDataRequest(p peer.ID) bool {
+func (r *rateLimiter) AcceptDialDataRequest() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {

--- a/p2p/protocol/autonatv2/server_test.go
+++ b/p2p/protocol/autonatv2/server_test.go
@@ -445,7 +445,7 @@ func TestRateLimiterStress(t *testing.T) {
 							success.Add(1)
 							peerSuccesses[j].Add(1)
 						}
-						if r.AcceptDialDataRequest(p) {
+						if r.AcceptDialDataRequest() {
 							dialDataSuccesses.Add(1)
 						}
 						r.CompleteRequest(p)


### PR DESCRIPTION
Configures ci to use golang-ci for linting. 

The workflow is copied from quic-go. The os specific checks don't add too much value, I guess. I am fine with keeping only linux. 

I couldn't get the unparam linter to detect unused parameters in functions. I guess it is aggressive about not raising failse positives. Using revive for unparam check. 

I fear errcheck may be too much some times. We can disable / configure that one when we come across a change that warrants it. 

See: https://github.com/libp2p/go-libp2p/actions/runs/14307422981/job/40094362132?pr=3269
for a failure. 

See: #1843 for past discussion on this.  

Fixes: #3248 