### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/p2p/security/tls/crypto.go
+++ b/p2p/security/tls/crypto.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"os"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
@@ -165,7 +166,7 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (ic.PubKey, error) {
 	var keyExt pkix.Extension
 	// find the libp2p key extension, skipping all unknown extensions
 	for _, ext := range cert.Extensions {
-		if extensionIDEqual(ext.Id, extensionID) {
+		if slices.Equal(ext.Id, extensionID) {
 			keyExt = ext
 			found = true
 			for i, oident := range cert.UnhandledCriticalExtensions {

--- a/p2p/security/tls/extension.go
+++ b/p2p/security/tls/extension.go
@@ -7,16 +7,3 @@ var extensionPrefix = []int{1, 3, 6, 1, 4, 1, 53594}
 func getPrefixedExtensionID(suffix []int) []int {
 	return append(extensionPrefix, suffix...)
 }
-
-// extensionIDEqual compares two extension IDs.
-func extensionIDEqual(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/p2p/security/tls/extension_test.go
+++ b/p2p/security/tls/extension_test.go
@@ -1,6 +1,7 @@
 package libp2ptls
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,8 +12,8 @@ func TestExtensionGenerating(t *testing.T) {
 }
 
 func TestExtensionComparison(t *testing.T) {
-	require.True(t, extensionIDEqual([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}))
-	require.False(t, extensionIDEqual([]int{1, 2, 3, 4}, []int{1, 2, 3}))
-	require.False(t, extensionIDEqual([]int{1, 2, 3}, []int{1, 2, 3, 4}))
-	require.False(t, extensionIDEqual([]int{1, 2, 3, 4}, []int{4, 3, 2, 1}))
+	require.True(t, slices.Equal([]int{1, 2, 3, 4}, []int{1, 2, 3, 4}))
+	require.False(t, slices.Equal([]int{1, 2, 3, 4}, []int{1, 2, 3}))
+	require.False(t, slices.Equal([]int{1, 2, 3}, []int{1, 2, 3, 4}))
+	require.False(t, slices.Equal([]int{1, 2, 3, 4}, []int{4, 3, 2, 1}))
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.1#Equal) added in the go1.21 standard library, which can make the code more concise and easy to read.