### PR TITLE
Add missing log for failed GC record unmarshalling in `purgeStore()`

### DIFF
--- a/p2p/host/peerstore/pstoreds/addr_book_gc.go
+++ b/p2p/host/peerstore/pstoreds/addr_book_gc.go
@@ -278,7 +278,7 @@ func (gc *dsAddrBookGc) purgeStore() {
 	for result := range results.Next() {
 		record.Reset()
 		if err = proto.Unmarshal(result.Value, record); err != nil {
-			// TODO log
+			log.Warnf("failed to unmarshal record during GC purge: key=%s, err=%v", result.Key, err)
 			continue
 		}
 


### PR DESCRIPTION
This PR replaces a `// TODO` comment with an actual log statement in the `purgeStore()` method of the `dsAddrBookGc`:

#### Change summary:
- Added a `log.Warnf` when `proto.Unmarshal` fails during garbage collection:
  ```go
  log.Warnf("failed to unmarshal record during GC purge: key=%s, err=%v", result.Key, err)
  ```

