### PR TITLE
fix(pstoreds): Correct cyclic batch threshold and handle peer ID decoding errors

### DIFF
--- a/p2p/host/peerstore/pstoreds/cyclic_batch.go
+++ b/p2p/host/peerstore/pstoreds/cyclic_batch.go
@@ -28,7 +28,7 @@ func newCyclicBatch(ds ds.Batching, threshold int) (ds.Batch, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &cyclicBatch{Batch: batch, ds: ds}, nil
+	return &cyclicBatch{Batch: batch, ds: ds, threshold: threshold}, nil
 }
 
 func (cb *cyclicBatch) cycle() (err error) {

--- a/p2p/host/peerstore/pstoreds/peerstore.go
+++ b/p2p/host/peerstore/pstoreds/peerstore.go
@@ -127,9 +127,17 @@ func uniquePeerIds(ds ds.Datastore, prefix ds.Key, extractor func(result query.R
 
 	ids := make(peer.IDSlice, 0, len(idset))
 	for id := range idset {
-		pid, _ := base32.RawStdEncoding.DecodeString(id)
-		id, _ := peer.IDFromBytes(pid)
-		ids = append(ids, id)
+		pid, err := base32.RawStdEncoding.DecodeString(id)
+		if err != nil {
+			log.Debugf("failed to decode peer id %s from base32: %v; skipping", id, err)
+		        continue
+		}
+		peerID, err := peer.IDFromBytes(pid)
+		if err != nil {
+			log.Debugf("failed to create peer id from bytes for %s: %v; skipping", id, err)
+			continue
+		}
+		ids = append(ids, peerID)
 	}
 	return ids, nil
 }


### PR DESCRIPTION
1.  **Fix cyclic batch threshold initialization:** 
In `newCyclicBatch`, the provided `threshold` parameter was not being assigned to the struct field, causing the batch to potentially commit on every operation instead of respecting the threshold. This change correctly assigns the `threshold`.


2.  **Handle errors during peer ID decoding:** 
In `uniquePeerIds`, errors returned by `base32.RawStdEncoding.DecodeString` and `peer.IDFromBytes` were ignored using `_`. This could lead to panics or inclusion of invalid peer IDs if corrupted data is encountered in the datastore. This change adds proper error checking and skips invalid entries, logging a debug message.