### PR TITLE
eventbus: change slow consumer event from error to warn

### DIFF
--- a/p2p/host/eventbus/basic.go
+++ b/p2p/host/eventbus/basic.go
@@ -14,6 +14,7 @@ import (
 
 type logInterface interface {
 	Errorf(string, ...interface{})
+	Warnf(string, ...interface{})
 }
 
 var log logInterface = logging.Logger("eventbus")
@@ -464,7 +465,7 @@ func emitAndLogError(timer *time.Timer, typ reflect.Type, evt interface{}, sink 
 			<-timer.C
 		}
 	case <-timer.C:
-		log.Errorf("subscriber named \"%s\" is a slow consumer of %s. This can lead to libp2p stalling and hard to debug issues.", sink.name, typ)
+		log.Warnf("subscriber named \"%s\" is a slow consumer of %s. This can lead to libp2p stalling and hard to debug issues.", sink.name, typ)
 		// Continue to stall since there's nothing else we can do.
 		sink.ch <- evt
 	}

--- a/p2p/host/eventbus/basic_test.go
+++ b/p2p/host/eventbus/basic_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type EventA struct{}
-type EventB int
+type (
+	EventA struct{}
+	EventB int
+)
 
 func getN() int {
 	n := 50000
@@ -142,6 +144,10 @@ func (m *mockLogger) Errorf(format string, args ...interface{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.logs = append(m.logs, fmt.Sprintf(format, args...))
+}
+
+func (m *mockLogger) Warnf(format string, args ...interface{}) {
+	m.Errorf(format, args...)
 }
 
 func (m *mockLogger) Logs() []string {


### PR DESCRIPTION
Change event bus slow consumer event logging from `ERROR` to `WARN`.

`WARN` seems more appropriate since this isn't an error.

Closes https://github.com/ipfs/kubo/issues/10778