### PR TITLE
chore: use tcort/github-action-markdown-link-check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'   # show only broken links
           use-verbose-mode: 'yes'


### PR DESCRIPTION
The existing checker is consistently failing