### PR TITLE
autonatv2: add Unknown addrs to event

### DIFF
--- a/core/event/reachability.go
+++ b/core/event/reachability.go
@@ -14,10 +14,11 @@ type EvtLocalReachabilityChanged struct {
 }
 
 // EvtHostReachableAddrsChanged is sent when host's reachable or unreachable addresses change
-// Reachable and Unreachable both contain only Public IP or DNS addresses
+// Reachable, Unreachable, and Unknown only contain Public IP or DNS addresses
 //
 // Experimental: This API is unstable. Any changes to this event will be done without a deprecation notice.
 type EvtHostReachableAddrsChanged struct {
 	Reachable   []ma.Multiaddr
 	Unreachable []ma.Multiaddr
+	Unknown     []ma.Multiaddr
 }

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -752,14 +752,14 @@ func (h *BasicHost) AllAddrs() []ma.Multiaddr {
 	return h.addressManager.DirectAddrs()
 }
 
-// ReachableAddrs returns all addresses of the host that are reachable from the internet
+// ConfirmedAddrs returns all addresses of the host grouped by their reachability
 // as verified by autonatv2.
 //
 // Experimental: This API may change in the future without deprecation.
 //
 // Requires AutoNATv2 to be enabled.
-func (h *BasicHost) ReachableAddrs() []ma.Multiaddr {
-	return h.addressManager.ReachableAddrs()
+func (h *BasicHost) ConfirmedAddrs() (reachable []ma.Multiaddr, unreachable []ma.Multiaddr, unknown []ma.Multiaddr) {
+	return h.addressManager.ConfirmedAddrs()
 }
 
 func trimHostAddrList(addrs []ma.Multiaddr, maxSize int) []ma.Multiaddr {


### PR DESCRIPTION
Providing unknown addresses to the user, helps them infer whether autonatv2 has any more addresses it might confirm.

There's no upside to not sending this information.

This also changes `host.ConfirmedAddrs` to return all the three categories, Reachable, Unreachable, and Unknown addrs. 