### PR TITLE
mocknet: notify listeners on listen

### DIFF
--- a/p2p/net/mock/mock_peernet.go
+++ b/p2p/net/mock/mock_peernet.go
@@ -361,6 +361,11 @@ func (pn *peernet) BandwidthTotals() (in uint64, out uint64) {
 // Listen tells the network to start listening on given multiaddrs.
 func (pn *peernet) Listen(addrs ...ma.Multiaddr) error {
 	pn.Peerstore().AddAddrs(pn.LocalPeer(), addrs, peerstore.PermanentAddrTTL)
+	for _, a := range addrs {
+		pn.notifyAll(func(n network.Notifiee) {
+			n.Listen(pn, a)
+		})
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is causing a regression in kubo(https://github.com/ipfs/kubo/pull/10835#pullrequestreview-2914948501) with the new addrs manager which depends on being notified of new listen addresses instead of recomputing all the host's addresses every time on every `host.Addrs` call. 

