### PR TITLE
chore: fix the format of the deprecated comment

### DIFF
--- a/p2p/transport/websocket/addrs.go
+++ b/p2p/transport/websocket/addrs.go
@@ -24,7 +24,7 @@ func (addr *Addr) Network() string {
 
 // NewAddr creates an Addr with `ws` scheme (insecure).
 //
-// Deprecated. Use NewAddrWithScheme.
+// Deprecated: Use NewAddrWithScheme.
 func NewAddr(host string) *Addr {
 	// Older versions of the transport only supported insecure connections (i.e.
 	// WS instead of WSS). Assume that is the case here.


### PR DESCRIPTION
deprecatedComment: the proper format is `Deprecated: <text>`