### PR TITLE
Minor Typo Fixes in Comments and Test Names

### DIFF
--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -902,7 +902,7 @@ func TestTrimHostAddrList(t *testing.T) {
 			out:       []ma.Multiaddr{tcpPublic},
 		},
 		{
-			name:      "Public and private preffered over local",
+			name:      "Public and private preferred over local",
 			in:        []ma.Multiaddr{tcpPublic, tcpPrivate, quicLocal},
 			threshold: len(tcpPublic.Bytes()) + len(tcpPrivate.Bytes()),
 			out:       []ma.Multiaddr{tcpPublic, tcpPrivate},

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -908,7 +908,7 @@ func TestOutOfOrderConnectedNotifs(t *testing.T) {
 	doneCh := make(chan struct{})
 	errCh := make(chan error)
 
-	// This callback may be called before identify's Connnected callback completes. If it does, the IdentifyWait should still finish successfully.
+	// This callback may be called before identify's Connected callback completes. If it does, the IdentifyWait should still finish successfully.
 	h1.Network().Notify(&network.NotifyBundle{
 		ConnectedF: func(_ network.Network, c network.Conn) {
 			idChan := h1.(interface{ IDService() identify.IDService }).IDService().IdentifyWait(c)

--- a/p2p/security/tls/transport.go
+++ b/p2p/security/tls/transport.go
@@ -157,7 +157,7 @@ func (t *Transport) setupConn(tlsConn *tls.Conn, remotePubKey ci.PubKey) (sec.Se
 
 	nextProto := tlsConn.ConnectionState().NegotiatedProtocol
 	// The special ALPN extension value "libp2p" is used by libp2p versions
-	// that don't support early muxer negotiation. If we see this sepcial
+	// that don't support early muxer negotiation. If we see this special
 	// value selected, that means we are handshaking with a version that does
 	// not support early muxer negotiation. In this case return empty nextProto
 	// to indicate no muxer is selected.


### PR DESCRIPTION


---


**Description:**  
This pull request addresses minor typographical errors in comments and test case names across several files:
- Corrected spelling mistakes in comments for clarity.



---