### PR TITLE
fix: remove duplicate listen addresses to avoid muxer panic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -475,6 +475,19 @@ func (cfg *Config) validate() error {
 		return errors.New("cannot use shared TCP listener with PSK")
 	}
 
+	// check for duplicate listen addresses and remove them
+	listenAddresses := cfg.ListenAddrs
+	// Remove duplicates while keeping the first occurrence of each address
+	seen := make(map[string]bool)
+	listenAddresses = slices.DeleteFunc(listenAddresses, func(addr ma.Multiaddr) bool {
+		addrStr := addr.String()
+		if seen[addrStr] {
+			return true // Remove this duplicate
+		}
+		seen[addrStr] = true
+		return false // Keep this first occurrence
+	})
+	cfg.ListenAddrs = listenAddresses
 	return nil
 }
 
@@ -482,7 +495,6 @@ func (cfg *Config) validate() error {
 //
 // This function consumes the config. Do not reuse it (really!).
 func (cfg *Config) NewNode() (host.Host, error) {
-
 	validateErr := cfg.validate()
 	if validateErr != nil {
 		if cfg.ResourceManager != nil {


### PR DESCRIPTION
Fixes this part of the issue: https://github.com/libp2p/go-libp2p/issues/3340#issuecomment-3103612088