### PR TITLE
fix: self-healing NAT mappings with request deduplication

### DIFF
--- a/p2p/discovery/mdns/mdns_test.go
+++ b/p2p/discovery/mdns/mdns_test.go
@@ -1,6 +1,8 @@
 package mdns
 
 import (
+	"os"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -47,6 +49,10 @@ func (n *notif) GetPeers() []peer.AddrInfo {
 }
 
 func TestOtherDiscovery(t *testing.T) {
+	if runtime.GOOS != "linux" && os.Getenv("CI") != "" {
+		t.Skip("this test is flaky on CI outside of linux")
+	}
+
 	const n = 4
 
 	notifs := make([]*notif, n)
@@ -91,8 +97,8 @@ func TestOtherDiscovery(t *testing.T) {
 			}
 			return true
 		},
-		25*time.Second,
-		5*time.Millisecond,
+		5*time.Second,
+		100*time.Millisecond,
 		"expected peers to find each other",
 	)
 }

--- a/p2p/host/basic/natmgr.go
+++ b/p2p/host/basic/natmgr.go
@@ -7,7 +7,6 @@ import (
 	"net/netip"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	inat "github.com/libp2p/go-libp2p/p2p/net/nat"
@@ -105,7 +104,7 @@ func (nmgr *natManager) background(ctx context.Context) {
 		}
 	}()
 
-	discoverCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	discoverCtx, cancel := context.WithTimeout(ctx, inat.DiscoveryTimeout)
 	defer cancel()
 	natInstance, err := discoverNAT(discoverCtx)
 	if err != nil {

--- a/p2p/net/nat/nat.go
+++ b/p2p/net/nat/nat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -26,6 +27,21 @@ const MappingDuration = time.Minute
 // CacheTime is the time a mapping will cache an external address for
 const CacheTime = 15 * time.Second
 
+// DiscoveryTimeout is the maximum time to wait for NAT discovery.
+// This is based on the underlying UPnP and NAT-PMP/PCP protocols:
+//   - SSDP (UPnP discovery) waits 5 seconds for responses
+//   - NAT-PMP uses exponential backoff starting at 250ms, up to 9 retries
+//     (total ~32 seconds if exhausted, but typically responds in 1-2 seconds)
+//   - PCP follows similar timing to NAT-PMP
+//   - 10 seconds covers common cases while failing fast when no NAT exists
+const DiscoveryTimeout = 10 * time.Second
+
+// rediscoveryThreshold is the number of consecutive connection failures
+// before triggering NAT rediscovery. We ignore first few failures to
+// distinguish between transient network issues and persistent router
+// problems like restarts or port changes that require finding the NAT device again.
+const rediscoveryThreshold = 3
+
 type entry struct {
 	protocol string
 	port     int
@@ -40,18 +56,15 @@ func DiscoverNAT(ctx context.Context) (*NAT, error) {
 	if err != nil {
 		return nil, err
 	}
-	var extAddr netip.Addr
-	extIP, err := natInstance.GetExternalAddress()
-	if err == nil {
-		extAddr, _ = netip.AddrFromSlice(extIP)
-	}
+
+	extAddr := getExternalAddress(natInstance)
 
 	// Log the device addr.
 	addr, err := natInstance.GetDeviceAddress()
 	if err != nil {
-		log.Debug("DiscoverGateway address error", "err", err)
+		log.Warn("DiscoverGateway address error", "err", err)
 	} else {
-		log.Debug("DiscoverGateway address", "address", addr)
+		log.Info("DiscoverGateway address", "address", addr)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -74,9 +87,24 @@ func DiscoverNAT(ctx context.Context) (*NAT, error) {
 // NATs (Network Address Translators). It is a long-running
 // service that will periodically renew port mappings,
 // and keep an up-to-date list of all the external addresses.
+//
+// Locking strategy:
+//   - natmu: Protects nat instance and rediscovery state (nat, consecutiveFailures, rediscovering)
+//   - mappingmu: Protects port mappings table and closed flag (mappings, closed)
+//   - Lock ordering: When both locks are needed, always acquire mappingmu before natmu
+//     to prevent deadlocks
+//   - We use separate mutexes because the NAT instance may change (e.g., when router
+//     restarts and UPnP port changes), but the port mappings must persist and be
+//     re-applied across all instances. This separation allows the mappings table to
+//     remain stable while the underlying NAT device changes.
 type NAT struct {
 	natmu sync.Mutex
 	nat   nat.NAT
+
+	// Track connection failures for auto-rediscovery
+	consecutiveFailures int  // protected by natmu
+	rediscovering       bool // protected by natmu
+
 	// External IP of the NAT. Will be renewed periodically (every CacheTime).
 	extAddr atomic.Pointer[netip.Addr]
 
@@ -84,9 +112,10 @@ type NAT struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	mappingmu sync.RWMutex // guards mappings
-	closed    bool
-	mappings  map[entry]int
+	// Port mappings that should persist across NAT instance changes
+	mappingmu sync.RWMutex
+	closed    bool          // protected by mappingmu
+	mappings  map[entry]int // protected by mappingmu
 }
 
 // Close shuts down all port mappings. NAT can no longer be used.
@@ -149,11 +178,14 @@ func (nat *NAT) AddMapping(ctx context.Context, protocol string, port int) error
 func (nat *NAT) RemoveMapping(ctx context.Context, protocol string, port int) error {
 	nat.mappingmu.Lock()
 	defer nat.mappingmu.Unlock()
+	nat.natmu.Lock()
+	defer nat.natmu.Unlock()
 
 	switch protocol {
 	case "tcp", "udp":
 		e := entry{protocol: protocol, port: port}
 		if _, ok := nat.mappings[e]; ok {
+			log.Info("Stopping maintenance of port mapping", "protocol", protocol, "port", port)
 			delete(nat.mappings, e)
 			return nat.nat.DeletePortMapping(ctx, protocol, port)
 		}
@@ -164,6 +196,12 @@ func (nat *NAT) RemoveMapping(ctx context.Context, protocol string, port int) er
 }
 
 func (nat *NAT) background() {
+	// Renew port mappings every 20 seconds (1/3 of 60s lifetime).
+	// - NAT-PMP RFC 6886 recommends renewing at 50% of lifetime
+	// - We use 33% for added safety against silent lifetime reductions
+	// NOTE: This aggressive 60s/20s pattern may be outdated for modern routers
+	// but provides quick cleanup and fast failure detection for our rediscovery.
+	// TODO: Research longer durations (e.g. 30min/10min) to reduce router load
 	const mappingUpdate = MappingDuration / 3
 
 	now := time.Now()
@@ -202,8 +240,11 @@ func (nat *NAT) background() {
 				nextMappingUpdate = time.Now().Add(mappingUpdate)
 			}
 			if now.After(nextAddrUpdate) {
-				var extAddr netip.Addr
+				nat.natmu.Lock()
 				extIP, err := nat.nat.GetExternalAddress()
+				nat.natmu.Unlock()
+
+				var extAddr netip.Addr
 				if err == nil {
 					extAddr, _ = netip.AddrFromSlice(extIP)
 				}
@@ -213,13 +254,16 @@ func (nat *NAT) background() {
 			t.Reset(time.Until(minTime(nextAddrUpdate, nextMappingUpdate)))
 		case <-nat.ctx.Done():
 			nat.mappingmu.Lock()
+			defer nat.mappingmu.Unlock()
+			nat.natmu.Lock()
+			defer nat.natmu.Unlock()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			for e := range nat.mappings {
-				delete(nat.mappings, e)
 				nat.nat.DeletePortMapping(ctx, e.protocol, e.port)
 			}
-			nat.mappingmu.Unlock()
+			clear(nat.mappings)
 			return
 		}
 	}
@@ -229,28 +273,95 @@ func (nat *NAT) establishMapping(ctx context.Context, protocol string, internalP
 	log.Debug("Attempting port map", "protocol", protocol, "internal_port", internalPort)
 	const comment = "libp2p"
 
+	// Try to establish the mapping with both NAT calls under the same lock
 	nat.natmu.Lock()
+	defer nat.natmu.Unlock()
+
 	var err error
 	externalPort, err = nat.nat.AddPortMapping(ctx, protocol, internalPort, comment, MappingDuration)
 	if err != nil {
 		// Some hardware does not support mappings with timeout, so try that
 		externalPort, err = nat.nat.AddPortMapping(ctx, protocol, internalPort, comment, 0)
 	}
-	nat.natmu.Unlock()
 
-	if err != nil || externalPort == 0 {
-		if err != nil {
-			log.Warn("NAT port mapping failed", "protocol", protocol, "internal_port", internalPort, "err", err)
+	// Handle success
+	if err == nil && externalPort != 0 {
+		nat.consecutiveFailures = 0
+		log.Debug("NAT port mapping established", "protocol", protocol, "internal_port", internalPort, "external_port", externalPort)
+		return externalPort
+	}
+
+	// Handle failures
+	if err != nil {
+		log.Warn("NAT port mapping failed", "protocol", protocol, "internal_port", internalPort, "err", err)
+
+		// Check if this is a connection error that might indicate router restart
+		// See: https://github.com/libp2p/go-libp2p/issues/3224#issuecomment-2866844723
+		// Note: We use string matching because goupnp doesn't preserve error chains (uses %v instead of %w)
+		if strings.Contains(err.Error(), "connection refused") {
+			nat.consecutiveFailures++
+			if nat.consecutiveFailures >= rediscoveryThreshold && !nat.rediscovering {
+				nat.rediscovering = true
+				// Spawn in goroutine to avoid blocking the caller while we
+				// perform network discovery, which can take up to 30 seconds.
+				// The rediscovering flag prevents multiple concurrent attempts.
+				go nat.rediscoverNAT()
+			}
 		} else {
-			log.Warn("NAT port mapping failed", "protocol", protocol, "internal_port", internalPort, "external_port", 0)
+			// Reset counter for non-connection errors (transient failures)
+			nat.consecutiveFailures = 0
 		}
-		// we do not close if the mapping failed,
-		// because it may work again next time.
 		return 0
 	}
 
-	log.Debug("NAT Mapping", "external_port", externalPort, "internal_port", internalPort, "protocol", protocol)
-	return externalPort
+	// externalPort is 0 but no error was returned
+	log.Warn("NAT port mapping failed", "protocol", protocol, "internal_port", internalPort, "external_port", 0)
+	return 0
+}
+
+// rediscoverNAT attempts to rediscover the NAT device after connection failures
+func (nat *NAT) rediscoverNAT() {
+	log.Info("NAT rediscovery triggered due to repeated connection failures")
+
+	ctx, cancel := context.WithTimeout(nat.ctx, DiscoveryTimeout)
+	defer cancel()
+
+	newNATInstance, err := discoverGateway(ctx)
+	if err != nil {
+		log.Warn("NAT rediscovery failed", "err", err)
+		nat.natmu.Lock()
+		defer nat.natmu.Unlock()
+		nat.rediscovering = false
+		return
+	}
+
+	extAddr := getExternalAddress(newNATInstance)
+
+	// Replace the NAT instance
+	// No cleanup of the old instance needed because:
+	// - Router restart has already wiped all mappings
+	// - Old UPnP endpoint is dead (connection refused)
+	// - If router didn't actually restart (false positive), any stale mappings
+	//   on the router expire naturally (60 second UPnP timeout)
+	nat.natmu.Lock()
+	nat.nat = newNATInstance
+	nat.extAddr.Store(&extAddr)
+	nat.consecutiveFailures = 0
+	nat.rediscovering = false
+	nat.natmu.Unlock()
+
+	// Re-establish all existing mappings on the new NAT instance
+	nat.mappingmu.Lock()
+	for e := range nat.mappings {
+		extPort := nat.establishMapping(nat.ctx, e.protocol, e.port)
+		nat.mappings[e] = extPort
+		if extPort != 0 {
+			log.Info("NAT mapping restored after rediscovery", "protocol", e.protocol, "internal_port", e.port, "external_port", extPort)
+		}
+	}
+	nat.mappingmu.Unlock()
+
+	log.Info("NAT rediscovery successful")
 }
 
 func minTime(a, b time.Time) time.Time {
@@ -258,4 +369,19 @@ func minTime(a, b time.Time) time.Time {
 		return a
 	}
 	return b
+}
+
+// getExternalAddress retrieves and parses the external address from a NAT instance
+func getExternalAddress(natInstance nat.NAT) netip.Addr {
+	extIP, err := natInstance.GetExternalAddress()
+	if err != nil {
+		log.Debug("Failed to get external address", "err", err)
+		return netip.Addr{}
+	}
+	extAddr, ok := netip.AddrFromSlice(extIP)
+	if !ok {
+		log.Debug("Failed to parse external address", "ip", extIP)
+		return netip.Addr{}
+	}
+	return extAddr
 }

--- a/p2p/net/nat/nat_test.go
+++ b/p2p/net/nat/nat_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"net"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p/p2p/net/nat/internal/nat"
 	"github.com/stretchr/testify/require"
@@ -13,6 +16,27 @@ import (
 )
 
 //go:generate sh -c "go run go.uber.org/mock/mockgen -package nat -destination mock_nat_test.go github.com/libp2p/go-libp2p/p2p/net/nat/internal/nat NAT"
+
+// Helper functions for test setup
+
+// expectPortMappingFailure sets up mock expectations for a port mapping failure
+func expectPortMappingFailure(mockNAT *MockNAT, protocol string, port int, err error) {
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), protocol, port, gomock.Any(), MappingDuration).Return(0, err).Times(1)
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), protocol, port, gomock.Any(), time.Duration(0)).Return(0, err).Times(1)
+}
+
+// expectPortMappingSuccess sets up mock expectations for a successful port mapping
+func expectPortMappingSuccess(mockNAT *MockNAT, protocol string, internalPort, externalPort int) {
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), protocol, internalPort, gomock.Any(), MappingDuration).Return(externalPort, nil).Times(1)
+}
+
+// setupMockNATWithAddress creates a mock NAT with the given external address
+func setupMockNATWithAddress(ctrl *gomock.Controller, addr net.IP) *MockNAT {
+	mockNAT := NewMockNAT(ctrl)
+	mockNAT.EXPECT().GetDeviceAddress().Return(nil, errors.New("nope")).AnyTimes()
+	mockNAT.EXPECT().GetExternalAddress().Return(addr, nil).AnyTimes()
+	return mockNAT
+}
 
 func setupMockNAT(t *testing.T) (mockNAT *MockNAT, reset func()) {
 	t.Helper()
@@ -27,6 +51,7 @@ func setupMockNAT(t *testing.T) (mockNAT *MockNAT, reset func()) {
 	}
 }
 
+// TestAddMapping tests basic port mapping creation and retrieval to ensure mappings are stored correctly.
 func TestAddMapping(t *testing.T) {
 	mockNAT, reset := setupMockNAT(t)
 	defer reset()
@@ -35,7 +60,7 @@ func TestAddMapping(t *testing.T) {
 	nat, err := DiscoverNAT(context.Background())
 	require.NoError(t, err)
 
-	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000, gomock.Any(), MappingDuration).Return(1234, nil)
+	expectPortMappingSuccess(mockNAT, "tcp", 10000, 1234)
 	require.NoError(t, nat.AddMapping(context.Background(), "tcp", 10000))
 
 	_, found := nat.GetMapping("tcp", 9999)
@@ -48,6 +73,7 @@ func TestAddMapping(t *testing.T) {
 	require.Equal(t, netip.AddrPortFrom(addr, 1234), mapped)
 }
 
+// TestRemoveMapping tests deletion of port mappings to ensure cleanup works and unknown mappings error.
 func TestRemoveMapping(t *testing.T) {
 	mockNAT, reset := setupMockNAT(t)
 	defer reset()
@@ -55,7 +81,7 @@ func TestRemoveMapping(t *testing.T) {
 	mockNAT.EXPECT().GetExternalAddress().Return(net.IPv4(1, 2, 3, 4), nil)
 	nat, err := DiscoverNAT(context.Background())
 	require.NoError(t, err)
-	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000, gomock.Any(), MappingDuration).Return(1234, nil)
+	expectPortMappingSuccess(mockNAT, "tcp", 10000, 1234)
 	require.NoError(t, nat.AddMapping(context.Background(), "tcp", 10000))
 	_, found := nat.GetMapping("tcp", 10000)
 	require.True(t, found, "expected port mapping")
@@ -68,6 +94,7 @@ func TestRemoveMapping(t *testing.T) {
 	require.False(t, found, "didn't expect port mapping for deleted mapping")
 }
 
+// TestAddMappingInvalidPort tests NAT returning port 0 to ensure invalid mappings are not stored.
 func TestAddMappingInvalidPort(t *testing.T) {
 	mockNAT, reset := setupMockNAT(t)
 	defer reset()
@@ -76,9 +103,305 @@ func TestAddMappingInvalidPort(t *testing.T) {
 	nat, err := DiscoverNAT(context.Background())
 	require.NoError(t, err)
 
-	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000, gomock.Any(), MappingDuration).Return(0, nil)
+	expectPortMappingSuccess(mockNAT, "tcp", 10000, 0)
 	require.NoError(t, nat.AddMapping(context.Background(), "tcp", 10000))
 
 	_, found := nat.GetMapping("tcp", 10000)
 	require.False(t, found, "didn't expect a port mapping for invalid nat-ed port")
+}
+
+// TestNATRediscoveryOnConnectionError tests automatic NAT rediscovery after router restart
+// to ensure mappings are restored when router's NAT service (e.g. miniupnpd) changes its listening port
+// (a regression test for https://github.com/libp2p/go-libp2p/issues/3224#issuecomment-2866844723).
+func TestNATRediscoveryOnConnectionError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Setup initial mock NAT
+	mockNAT := NewMockNAT(ctrl)
+	mockNAT.EXPECT().GetDeviceAddress().Return(nil, errors.New("nope")).AnyTimes()
+	mockNAT.EXPECT().GetExternalAddress().Return(net.IPv4(1, 2, 3, 4), nil).Times(1)
+
+	// Setup new mock NAT for rediscovery
+	newMockNAT := setupMockNATWithAddress(ctrl, net.IPv4(5, 6, 7, 8))
+
+	// Track discovery calls with atomic counter
+	var discoveryCalls atomic.Int32
+	origDiscoverGateway := discoverGateway
+	discoverGateway = func(_ context.Context) (nat.NAT, error) {
+		count := discoveryCalls.Add(1)
+		if count == 1 {
+			return mockNAT, nil
+		}
+		return newMockNAT, nil
+	}
+	defer func() {
+		discoverGateway = origDiscoverGateway
+	}()
+
+	// Create NAT instance
+	n, err := DiscoverNAT(context.Background())
+	require.NoError(t, err)
+
+	// Expect cleanup on close
+	defer func() {
+		// The final NAT instance is newMockNAT, which will have these mappings
+		newMockNAT.EXPECT().DeletePortMapping(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		n.Close()
+	}()
+
+	// Add some existing mappings that should be restored after rediscovery
+	expectPortMappingSuccess(mockNAT, "tcp", 4001, 4001)
+	require.NoError(t, n.AddMapping(context.Background(), "tcp", 4001))
+	expectPortMappingSuccess(mockNAT, "udp", 4002, 4002)
+	require.NoError(t, n.AddMapping(context.Background(), "udp", 4002))
+
+	// Simulate connection refused error that happens when router's UPnP port changes
+	errConnectionRefused := errors.New("goupnp: error performing SOAP HTTP request: Post \"http://192.168.1.1:1234/ctl/IPConn\": dial tcp 192.168.1.1:1234: connect: connection refused")
+
+	// Set up expectations for the failures that will trigger rediscovery
+	for i := 0; i < 3; i++ {
+		expectPortMappingFailure(mockNAT, "tcp", 10000+i, errConnectionRefused)
+	}
+
+	// Expect the existing mappings to be restored on the new NAT instance
+	expectPortMappingSuccess(newMockNAT, "tcp", 4001, 4001)
+	expectPortMappingSuccess(newMockNAT, "udp", 4002, 4002)
+
+	// Now trigger the failures
+	for i := 0; i < 3; i++ {
+		externalPort := n.establishMapping(context.Background(), "tcp", 10000+i)
+		require.Equal(t, 0, externalPort)
+	}
+
+	// Give time for async rediscovery and mapping restoration
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify mappings were restored
+	mapped, found := n.GetMapping("tcp", 4001)
+	require.True(t, found, "expected tcp/4001 mapping to be restored")
+	addr, _ := netip.AddrFromSlice(net.IPv4(5, 6, 7, 8)) // new NAT's external IP
+	require.Equal(t, netip.AddrPortFrom(addr, 4001), mapped)
+
+	mapped, found = n.GetMapping("udp", 4002)
+	require.True(t, found, "expected udp/4002 mapping to be restored")
+	require.Equal(t, netip.AddrPortFrom(addr, 4002), mapped)
+
+	// Next mapping should use the new NAT
+	expectPortMappingSuccess(newMockNAT, "tcp", 10003, 12345)
+
+	externalPort := n.establishMapping(context.Background(), "tcp", 10003)
+	require.Equal(t, 12345, externalPort)
+	require.Equal(t, int32(2), discoveryCalls.Load()) // Initial + rediscovery
+}
+
+// TestNATRediscoveryOldRouterReturns tests rediscovery when router comes back on same IP/port
+// to ensure we handle transient failures without losing the NAT instance.
+func TestNATRediscoveryOldRouterReturns(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Setup mock NAT
+	mockNAT := NewMockNAT(ctrl)
+	mockNAT.EXPECT().GetDeviceAddress().Return(nil, errors.New("nope")).AnyTimes()
+	mockNAT.EXPECT().GetExternalAddress().Return(net.IPv4(1, 2, 3, 4), nil).AnyTimes()
+
+	// Track discovery calls with atomic counter
+	var discoveryCalls atomic.Int32
+	origDiscoverGateway := discoverGateway
+	discoverGateway = func(_ context.Context) (nat.NAT, error) {
+		count := discoveryCalls.Add(1)
+		if count == 2 {
+			// During rediscovery, return the same NAT (router came back)
+			return mockNAT, nil
+		}
+		return mockNAT, nil
+	}
+	defer func() {
+		discoverGateway = origDiscoverGateway
+	}()
+
+	n, err := DiscoverNAT(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		mockNAT.EXPECT().DeletePortMapping(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		n.Close()
+	}()
+
+	// Add existing mapping
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 4001, gomock.Any(), MappingDuration).Return(4001, nil).Times(1)
+	require.NoError(t, n.AddMapping(context.Background(), "tcp", 4001))
+
+	errConnectionRefused := errors.New("goupnp: error performing SOAP HTTP request: dial tcp 192.168.1.1:1234: connect: connection refused")
+
+	// Set up expectations for the first two failures
+	for i := 0; i < 2; i++ {
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000+i, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).Times(1)
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000+i, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).Times(1)
+	}
+
+	// Third failure triggers rediscovery, but router is back now
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10002, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).Times(1)
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10002, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).Times(1)
+
+	// Expect mapping restoration on the same NAT
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 4001, gomock.Any(), MappingDuration).Return(4001, nil).Times(1)
+
+	// Trigger the failures
+	for i := 0; i < 2; i++ {
+		n.establishMapping(context.Background(), "tcp", 10000+i)
+	}
+	n.establishMapping(context.Background(), "tcp", 10002)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify we still have our mapping
+	mapped, found := n.GetMapping("tcp", 4001)
+	require.True(t, found)
+	addr, _ := netip.AddrFromSlice(net.IPv4(1, 2, 3, 4))
+	require.Equal(t, netip.AddrPortFrom(addr, 4001), mapped)
+	require.Equal(t, int32(2), discoveryCalls.Load()) // Initial + rediscovery
+}
+
+// TestNATRediscoveryFailureThreshold tests the 3-failure threshold and counter reset behavior
+// to ensure we don't trigger rediscovery on transient errors.
+func TestNATRediscoveryFailureThreshold(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockNAT := NewMockNAT(ctrl)
+	mockNAT.EXPECT().GetDeviceAddress().Return(nil, errors.New("nope")).AnyTimes()
+	mockNAT.EXPECT().GetExternalAddress().Return(net.IPv4(1, 2, 3, 4), nil).AnyTimes()
+
+	// Track discovery calls with atomic counter
+	var discoveryCalls atomic.Int32
+	origDiscoverGateway := discoverGateway
+	discoverGateway = func(_ context.Context) (nat.NAT, error) {
+		discoveryCalls.Add(1)
+		return mockNAT, nil
+	}
+	defer func() {
+		discoverGateway = origDiscoverGateway
+	}()
+
+	n, err := DiscoverNAT(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		mockNAT.EXPECT().DeletePortMapping(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		n.Close()
+	}()
+
+	errConnectionRefused := errors.New("connection refused")
+	errOther := errors.New("some other error")
+
+	// Test 1: Only 2 failures - should NOT trigger rediscovery
+	for i := 0; i < 2; i++ {
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000+i, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).Times(1)
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000+i, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).Times(1)
+		n.establishMapping(context.Background(), "tcp", 10000+i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), discoveryCalls.Load(), "should not trigger rediscovery with only 2 failures")
+
+	// Test 2: Non-connection error resets counter
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10002, gomock.Any(), MappingDuration).Return(0, errOther).Times(1)
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10002, gomock.Any(), time.Duration(0)).Return(0, errOther).Times(1)
+	n.establishMapping(context.Background(), "tcp", 10002)
+
+	// Now even 2 more connection failures shouldn't trigger (counter was reset)
+	for i := 0; i < 2; i++ {
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10003+i, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).Times(1)
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10003+i, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).Times(1)
+		n.establishMapping(context.Background(), "tcp", 10003+i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), discoveryCalls.Load(), "counter should reset on non-connection error")
+
+	// Test 3: Success resets counter
+	mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10005, gomock.Any(), MappingDuration).Return(10005, nil).Times(1)
+	n.establishMapping(context.Background(), "tcp", 10005)
+
+	// Again, 2 failures shouldn't trigger
+	for i := 0; i < 2; i++ {
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10006+i, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).Times(1)
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10006+i, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).Times(1)
+		n.establishMapping(context.Background(), "tcp", 10006+i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), discoveryCalls.Load(), "counter should reset on success")
+}
+
+// TestNATRediscoveryConcurrency tests concurrent connection failures to ensure only one
+// rediscovery happens even with multiple goroutines hitting errors.
+func TestNATRediscoveryConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockNAT := NewMockNAT(ctrl)
+	mockNAT.EXPECT().GetDeviceAddress().Return(nil, errors.New("nope")).AnyTimes()
+	mockNAT.EXPECT().GetExternalAddress().Return(net.IPv4(1, 2, 3, 4), nil).AnyTimes()
+
+	newMockNAT := NewMockNAT(ctrl)
+	newMockNAT.EXPECT().GetDeviceAddress().Return(nil, errors.New("nope")).AnyTimes()
+	newMockNAT.EXPECT().GetExternalAddress().Return(net.IPv4(5, 6, 7, 8), nil).AnyTimes()
+
+	// Track discovery calls with atomic counter
+	var discoveryCalls atomic.Int32
+	origDiscoverGateway := discoverGateway
+	discoverGateway = func(_ context.Context) (nat.NAT, error) {
+		count := discoveryCalls.Add(1)
+		if count == 1 {
+			return mockNAT, nil
+		}
+		// Simulate slow discovery to test concurrent calls
+		time.Sleep(200 * time.Millisecond)
+		return newMockNAT, nil
+	}
+	defer func() {
+		discoverGateway = origDiscoverGateway
+	}()
+
+	n, err := DiscoverNAT(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		newMockNAT.EXPECT().DeletePortMapping(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		n.Close()
+	}()
+
+	errConnectionRefused := errors.New("connection refused")
+
+	// Simulate multiple goroutines hitting failures after threshold
+	// First get to threshold
+	for i := 0; i < 3; i++ {
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000+i, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).Times(1)
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", 10000+i, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).Times(1)
+		n.establishMapping(context.Background(), "tcp", 10000+i)
+	}
+
+	// Set up expectations for concurrent failure attempts
+	for i := 0; i < 5; i++ {
+		port := 10003 + i
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", port, gomock.Any(), MappingDuration).Return(0, errConnectionRefused).AnyTimes()
+		mockNAT.EXPECT().AddPortMapping(gomock.Any(), "tcp", port, gomock.Any(), time.Duration(0)).Return(0, errConnectionRefused).AnyTimes()
+	}
+
+	// Now launch multiple goroutines that would all try to trigger rediscovery
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(port int) {
+			defer wg.Done()
+			// These would all try to trigger rediscovery if not protected
+			n.establishMapping(context.Background(), "tcp", port)
+		}(10003 + i)
+	}
+
+	wg.Wait()
+	time.Sleep(300 * time.Millisecond) // Wait for rediscovery to complete
+
+	// Should only have triggered one rediscovery despite multiple concurrent failures
+	require.Equal(t, int32(2), discoveryCalls.Load(), "should only trigger one rediscovery")
 }


### PR DESCRIPTION
This PR makes NAT port mappings self-healing after router restarts.
It also adds bunch of tests and eliminates duplicate mapping requests that occur on node start.

## Changes

### 1. Automatic NAT recovery after router restart

Router restarts can cause UPnP (SOAP) services to change their listening ports, leading to "connection refused" errors that permanently break port mappings. 
This is the problem described in https://github.com/libp2p/go-libp2p/issues/3224#issuecomment-2866844723 (cc @sukunrt @MarcoPolo)

We had Kubo users impacted this since forever, impacting their ability to provide data:
- https://github.com/ipfs/kubo/issues/8963
- https://github.com/ipfs/kubo/issues/9759

This PR implements automatic NAT rediscovery that detects consecutive connection failures, triggers rediscovery after 3 failures, and restores all existing port mappings on the new NAT instance.

FWIW I've tested it extensively in my own LAN – see "Demo" at the end.

IIUC this
- Fixes #3224
- Fixes #2502

### 2. Port mapping deduplication

This is something I've discovered while testing (1), so also fixed it in this PR.

Multiple libp2p transports sharing the same port (TCP, QUIC, WebTransport, WebRTC-direct) were causing duplicate NAT mapping requests. The fix adds deduplication in `NAT.AddMapping()` that checks if mapping already exists before making NAT API calls.

In case of Kubo IPFS node:
- Before: 10 (5 TCP + 5 UDP) mapping attempts for the same port
- After: 2 (1 TCP + 1 UDP) mapping attempt (visible at 04:14:06 in the demo)

## Demo

The following log shows automatic NAT recovery in action. The router's UPnP service (miniupnpd) restarts and changes its SOAP/HTTP endpoint from port 45251 to a different port, causing "connection refused" errors. After 3 consecutive failures, go-libp2p automatically rediscovers the NAT and restores all mappings:

```console
$ export GOLOG_LOG_LEVEL="error,nat=debug"
$ ipfs daemon
Initializing daemon...
Kubo version: 0.37.0-dev-710953446-dirty
Repo version: 16
System version: amd64/linux
Golang version: go1.25.0
PeerID: 12D3KooWAFYEQLmxbY5xowmqMAFADRbwRDQiSM1cfbmphdHKbhex
Swarm listening on 127.0.0.1:4001 (TCP+UDP)
Swarm listening on 172.17.0.1:4001 (TCP+UDP)
Swarm listening on 172.18.0.1:4001 (TCP+UDP)
Swarm listening on 192.168.1.102:4001 (TCP+UDP)
Swarm listening on [::1]:4001 (TCP+UDP)
Run 'ipfs id' to inspect announced and discovered multiaddrs of this node.
RPC API server listening on /ip4/127.0.0.1/tcp/5001
WebUI: http://127.0.0.1:5001/webui
Gateway server listening on /ip4/127.0.0.1/tcp/8080
Daemon is ready
2025-08-16T04:14:06.558+0200	INFO	nat	nat/nat.go:67	DiscoverGateway address:192.168.1.1
2025-08-16T04:14:06.559+0200	INFO	nat	nat/nat.go:172	Starting maintenance of port mapping: tcp/4001
2025-08-16T04:14:06.559+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:14:06.668+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 16174
2025-08-16T04:14:06.668+0200	INFO	nat	nat/nat.go:172	Starting maintenance of port mapping: udp/4001
2025-08-16T04:14:06.668+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:14:06.954+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 16174
2025-08-16T04:14:26.559+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:14:26.567+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 16174
2025-08-16T04:14:26.568+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:14:26.573+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 16174
2025-08-16T04:14:46.574+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:14:46.580+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 16174
2025-08-16T04:14:46.580+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:14:46.585+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 16174
2025-08-16T04:15:06.586+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:15:06.596+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 16174
2025-08-16T04:15:06.596+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:15:06.601+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 16174
2025-08-16T04:15:26.601+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:15:26.607+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 16174
2025-08-16T04:15:26.607+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:15:26.612+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 16174
2025-08-16T04:15:46.613+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:16:16.616+0200	WARN	nat	nat/nat.go:326	NAT port mapping failed: protocol=tcp internal_port=4001 external_port=0
2025-08-16T04:16:16.616+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:16:16.616+0200	WARN	nat	nat/nat.go:326	NAT port mapping failed: protocol=udp internal_port=4001 external_port=0
2025-08-16T04:16:36.617+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:16:36.617+0200	WARN	nat	nat/nat.go:326	NAT port mapping failed: protocol=tcp internal_port=4001 external_port=0
2025-08-16T04:16:36.617+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:16:36.618+0200	WARN	nat	nat/nat.go:326	NAT port mapping failed: protocol=udp internal_port=4001 external_port=0
2025-08-16T04:17:16.619+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:17:16.619+0200	WARN	nat	nat/nat.go:326	NAT port mapping failed: protocol=tcp internal_port=4001 external_port=0
2025-08-16T04:17:16.619+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:17:16.620+0200	WARN	nat	nat/nat.go:326	NAT port mapping failed: protocol=udp internal_port=4001 external_port=0
2025-08-16T04:17:36.621+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:17:36.654+0200	WARN	nat	nat/nat.go:304	NAT port mapping failed: protocol=tcp internal_port=4001 error="goupnp: error performing SOAP HTTP request: Post \"http://192.168.1.1:45251/ctl/IPConn\": dial tcp 192.168.1.1:45251: connect: connection refused"
2025-08-16T04:17:36.654+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:17:36.678+0200	WARN	nat	nat/nat.go:304	NAT port mapping failed: protocol=udp internal_port=4001 error="goupnp: error performing SOAP HTTP request: Post \"http://192.168.1.1:45251/ctl/IPConn\": dial tcp 192.168.1.1:45251: connect: connection refused"
2025-08-16T04:17:56.678+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:17:56.694+0200	WARN	nat	nat/nat.go:304	NAT port mapping failed: protocol=tcp internal_port=4001 error="goupnp: error performing SOAP HTTP request: Post \"http://192.168.1.1:45251/ctl/IPConn\": dial tcp 192.168.1.1:45251: connect: connection refused"
2025-08-16T04:17:56.694+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:17:56.694+0200	INFO	nat	nat/nat.go:332	NAT rediscovery triggered due to repeated connection failures
2025-08-16T04:17:56.715+0200	WARN	nat	nat/nat.go:304	NAT port mapping failed: protocol=udp internal_port=4001 error="goupnp: error performing SOAP HTTP request: Post \"http://192.168.1.1:45251/ctl/IPConn\": dial tcp 192.168.1.1:45251: connect: connection refused"
2025-08-16T04:18:00.824+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:18:00.930+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 65008
2025-08-16T04:18:00.930+0200	INFO	nat	nat/nat.go:367	NAT mapping restored after rediscovery: tcp 4001 -> 65008
2025-08-16T04:18:00.930+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:18:01.223+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 65008
2025-08-16T04:18:01.223+0200	INFO	nat	nat/nat.go:367	NAT mapping restored after rediscovery: udp 4001 -> 65008
2025-08-16T04:18:01.223+0200	INFO	nat	nat/nat.go:372	NAT rediscovery successful
2025-08-16T04:18:16.716+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:18:16.722+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 65008
2025-08-16T04:18:16.722+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:18:16.726+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 65008
2025-08-16T04:18:36.728+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: udp/4001
2025-08-16T04:18:36.734+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: udp 4001 -> 65008
2025-08-16T04:18:36.734+0200	DEBUG	nat	nat/nat.go:281	Attempting port map: tcp/4001
2025-08-16T04:18:36.742+0200	DEBUG	nat	nat/nat.go:298	NAT port mapping established: tcp 4001 -> 65008
^C
Received interrupt signal, shutting down...
(Hit ctrl-c again to force-shutdown the daemon.)
2025-08-16T04:18:45.085+0200	INFO	nat	nat/nat.go:196	Stopping maintenance of port mapping: tcp/4001
2025-08-16T04:18:45.097+0200	INFO	nat	nat/nat.go:196	Stopping maintenance of port mapping: udp/4001
ipfs daemon  14.25s user 3.83s system 6% cpu 4:43.00 total
```

Key moments in the log:
- **04:14:06**: Initial NAT discovery succeeds, only 2 mapping attempts (deduplication working)
- **04:15:46**: Router restarts, UPnP service begins failing
- **04:17:36**: Connection refused errors indicate UPnP port changed from :45251
- **04:17:56**: After 3rd failure, automatic rediscovery triggered
- **04:18:00**: NAT rediscovered, mappings restored with new external port 65008
- **04:18:45**: Clean shutdown removes all mappings

Without this fix, the connection refused errors would continue indefinitely, requiring manual daemon restart.

<!-- 

## Sidequest: improved log levels

Everything wa sin DEBUG, which was a lot of noise. I've adjusted meaningful things to INFO and WARN. With default logging (INFO level), users will only see:
- "DiscoverGateway address: 192.168.1.1" on startup
- "Starting maintenance of port mapping: tcp/4001" for each port
- "NAT rediscovery triggered" if router issues occur
- "NAT rediscovery successful" when recovery completes
- "Stopping maintenance of port mapping" on shutdown

The periodic refreshes and attempts are hidden at DEBUG level, keeping logs clean.

-->