### PR TITLE
 enhancement: include non public relay addresses to be advertised too #3361 #3365 

### DIFF
--- a/p2p/protocol/circuitv2/relay/options.go
+++ b/p2p/protocol/circuitv2/relay/options.go
@@ -1,5 +1,9 @@
 package relay
 
+import (
+	"github.com/multiformats/go-multiaddr"
+)
+
 type Option func(*Relay) error
 
 // WithResources is a Relay option that sets specific relay resources for the relay.
@@ -14,6 +18,18 @@ func WithResources(rc Resources) Option {
 func WithLimit(limit *RelayLimit) Option {
 	return func(r *Relay) error {
 		r.rc.Limit = limit
+		return nil
+	}
+}
+
+// Reservation address function used to promote addresses to connected nodes
+type ReservationAddressFilterFunc func(addr multiaddr.Multiaddr) (include bool)
+
+// Overrides the default reservation address filter.
+// This will permit the relay let the client know it have access to non public addresses too.
+func WithReservationAddressFilter(filter ReservationAddressFilterFunc) (option Option) {
+	return func(r *Relay) (err error) {
+		r.reservationAddrFilter = filter
 		return nil
 	}
 }

--- a/p2p/protocol/circuitv2/relay/relay_priv_test.go
+++ b/p2p/protocol/circuitv2/relay/relay_priv_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr/matest"
+	manet "github.com/multiformats/go-multiaddr/net"
 )
 
 func genKeyAndID(t *testing.T) (crypto.PrivKey, peer.ID) {
@@ -28,26 +30,49 @@ func TestMakeReservationWithP2PAddrs(t *testing.T) {
 	_, otherID := genKeyAndID(t)
 	_, reserverID := genKeyAndID(t)
 
-	addrs := []ma.Multiaddr{
-		ma.StringCast("/ip4/1.2.3.4/tcp/1234"),                         // No p2p part
-		ma.StringCast("/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String()),  // Already has p2p part
-		ma.StringCast("/ip4/1.2.3.4/tcp/1236/p2p/" + otherID.String()), // Some other peer (?? Not expected, but we could get anything in this func)
+	tcs := []struct {
+		name     string
+		filter   func(ma.Multiaddr) bool
+		input    []ma.Multiaddr
+		expected []ma.Multiaddr
+	}{{
+		name:   "only public",
+		filter: manet.IsPublicAddr,
+		input: []ma.Multiaddr{
+			ma.StringCast("/ip4/1.2.3.4/tcp/1234"),                            // No p2p part
+			ma.StringCast("/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String()),     // Already has p2p part
+			ma.StringCast("/ip4/192.168.1.9/tcp/1235/p2p/" + selfID.String()), // Already has p2p part
+			ma.StringCast("/ip4/1.2.3.4/tcp/1236/p2p/" + otherID.String()),    // Some other peer (?? Not expected, but we could get anything in this func)
+		},
+		expected: []ma.Multiaddr{
+			ma.StringCast("/ip4/1.2.3.4/tcp/1234/p2p/" + selfID.String()),
+			ma.StringCast("/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String()),
+		},
+	}, {
+		name:   "only not public",
+		filter: func(m ma.Multiaddr) bool { return !manet.IsPublicAddr(m) },
+		input: []ma.Multiaddr{
+			ma.StringCast("/ip4/1.2.3.4/tcp/1234"),                            // No p2p part
+			ma.StringCast("/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String()),     // Already has p2p part
+			ma.StringCast("/ip4/192.168.1.9/tcp/1235/p2p/" + selfID.String()), // Already has p2p part
+			ma.StringCast("/ip4/1.2.3.4/tcp/1236/p2p/" + otherID.String()),    // Some other peer (?? Not expected, but we could get anything in this func)
+		},
+		expected: []ma.Multiaddr{
+			ma.StringCast("/ip4/192.168.1.9/tcp/1235/p2p/" + selfID.String()),
+		},
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			rsvp := makeReservationMsg(tc.filter, selfKey, selfID, tc.input, reserverID, time.Now().Add(time.Minute))
+			require.NotNil(t, rsvp)
+
+			addrsFromRsvp := make([]ma.Multiaddr, 0, len(rsvp.GetAddrs()))
+			for _, addr := range rsvp.GetAddrs() {
+				a, err := ma.NewMultiaddrBytes(addr)
+				require.NoError(t, err)
+				addrsFromRsvp = append(addrsFromRsvp, a)
+			}
+			matest.AssertEqualMultiaddrs(t, tc.expected, addrsFromRsvp)
+		})
 	}
-
-	rsvp := makeReservationMsg(selfKey, selfID, addrs, reserverID, time.Now().Add(time.Minute))
-	require.NotNil(t, rsvp)
-
-	expectedAddrs := []string{
-		"/ip4/1.2.3.4/tcp/1234/p2p/" + selfID.String(),
-		"/ip4/1.2.3.4/tcp/1235/p2p/" + selfID.String(),
-	}
-
-	addrsFromRsvp := make([]string, 0, len(rsvp.GetAddrs()))
-	for _, addr := range rsvp.GetAddrs() {
-		a, err := ma.NewMultiaddrBytes(addr)
-		require.NoError(t, err)
-		addrsFromRsvp = append(addrsFromRsvp, a.String())
-	}
-
-	require.Equal(t, expectedAddrs, addrsFromRsvp)
 }


### PR DESCRIPTION
Moved the code in my fork to its own branch. GitHub automatically closed [old](https://github.com/libp2p/go-libp2p/pull/3365)

## Reference

https://github.com/libp2p/go-libp2p/issues/3361

## What is the issue

Private based relays are unable to populate the `Reservation.Addrs` when non of its addresses are public.

## Expected behavior.

Permit the relay to respond with all its public addresses which is already filtered with the following line:

https://github.com/libp2p/go-libp2p/blob/f6c14a215b2012f3839f1b7157dfec70a772143a/p2p/protocol/circuitv2/relay/relay.go#L596

But also include those addresses shared with the connected peer. This could be performed by comparing `stream.Conn().RemoteMultiaddr()` and `stream.Conn().LocalMultiaddr()`. 

Even so, **what about including all of its addresses with filtering?** Is there any security consideration. Because they could anyway be guessed based on the statements of bellow.

## Why this is a issue

A valid circuit multiaddress can be successfully constructed and used based on the known addresses found on the `AddrInfo` of the connected peer. The problem is, then why we even care of `Reservation.Addrs` if that is possible this field is latency in the packet. We need to enforce the use of `Reservation.Addrs` by including information that can be actually used by the relay client.
