### PR TITLE
refactor: replace context.WithCancel with t.Context

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -550,8 +550,7 @@ func TestWebRTCReuseAddrWithQUIC(t *testing.T) {
 			}
 
 			t.Run("quic client can connect", func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				ctx := t.Context()
 				p := ping.NewPingService(quicClient)
 				resCh := p.Ping(ctx, h1.ID())
 				res := <-resCh
@@ -559,8 +558,7 @@ func TestWebRTCReuseAddrWithQUIC(t *testing.T) {
 			})
 
 			t.Run("webrtc client can connect", func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				ctx := t.Context()
 				p := ping.NewPingService(webrtcClient)
 				resCh := p.Ping(ctx, h1.ID())
 				res := <-resCh

--- a/p2p/discovery/backoff/backoffcache_test.go
+++ b/p2p/discovery/backoff/backoffcache_test.go
@@ -89,8 +89,7 @@ func withClock(c clock) BackoffDiscoveryOption {
 }
 
 func TestBackoffDiscoverySingleBackoff(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	clock := mockClock.NewMock()
 	discServer := mocks.NewDiscoveryServer(clock)
@@ -137,8 +136,7 @@ func TestBackoffDiscoverySingleBackoff(t *testing.T) {
 
 func TestBackoffDiscoveryMultipleBackoff(t *testing.T) {
 	clock := mockClock.NewMock()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	discServer := mocks.NewDiscoveryServer(clock)
 
@@ -195,8 +193,7 @@ func TestBackoffDiscoveryMultipleBackoff(t *testing.T) {
 }
 
 func TestBackoffDiscoverySimultaneousQuery(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	clock := mockClock.NewMock()
 	discServer := mocks.NewDiscoveryServer(clock)
@@ -257,8 +254,7 @@ func TestBackoffDiscoverySimultaneousQuery(t *testing.T) {
 }
 
 func TestBackoffDiscoveryCacheCapacity(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	clock := mockClock.NewMock()
 	discServer := mocks.NewDiscoveryServer(clock)

--- a/p2p/discovery/routing/routing_test.go
+++ b/p2p/discovery/routing/routing_test.go
@@ -76,8 +76,7 @@ func (m *mockRouting) FindProvidersAsync(ctx context.Context, cid cid.Cid, _ int
 }
 
 func TestRoutingDiscovery(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))
@@ -110,8 +109,7 @@ func TestRoutingDiscovery(t *testing.T) {
 }
 
 func TestDiscoveryRouting(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := bhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := bhost.NewBlankHost(swarmt.GenSwarm(t))

--- a/p2p/host/autonat/svc_test.go
+++ b/p2p/host/autonat/svc_test.go
@@ -43,8 +43,7 @@ func makeAutoNATClient(t *testing.T) (host.Host, Client) {
 
 // Note: these tests assume that the host has only private network addresses!
 func TestAutoNATServiceDialRefused(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	c := makeAutoNATConfig(t)
 	defer c.host.Close()
@@ -68,8 +67,7 @@ func TestAutoNATServiceDialRefused(t *testing.T) {
 }
 
 func TestAutoNATServiceDialSuccess(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	c := makeAutoNATConfig(t)
 	defer c.host.Close()
@@ -88,8 +86,7 @@ func TestAutoNATServiceDialSuccess(t *testing.T) {
 }
 
 func TestAutoNATServiceDialRateLimiter(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	c := makeAutoNATConfig(t)
 	defer c.host.Close()
@@ -128,8 +125,7 @@ func TestAutoNATServiceDialRateLimiter(t *testing.T) {
 }
 
 func TestAutoNATServiceGlobalLimiter(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	c := makeAutoNATConfig(t)
 	defer c.host.Close()

--- a/p2p/host/basic/basic_host_test.go
+++ b/p2p/host/basic/basic_host_test.go
@@ -375,8 +375,7 @@ func TestHostProtoPreference(t *testing.T) {
 }
 
 func TestHostProtoMismatch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, h2 := getHostPair(t)
 	defer h1.Close()
@@ -469,8 +468,7 @@ func TestHostProtoPreknowledge(t *testing.T) {
 }
 
 func TestNewDialOld(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, h2 := getHostPair(t)
 	defer h1.Close()
@@ -541,8 +539,7 @@ func TestNewStreamResolve(t *testing.T) {
 }
 
 func TestProtoDowngrade(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, h2 := getHostPair(t)
 	defer h1.Close()
@@ -756,8 +753,7 @@ func TestHostAddrChangeDetection(t *testing.T) {
 }
 
 func TestNegotiationCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, h2 := getHostPair(t)
 	defer h1.Close()

--- a/p2p/net/gostream/gostream_test.go
+++ b/p2p/net/gostream/gostream_test.go
@@ -2,7 +2,6 @@ package gostream
 
 import (
 	"bufio"
-	"context"
 	"io"
 	"testing"
 	"time"
@@ -38,8 +37,7 @@ func TestServerClient(t *testing.T) {
 	clientHost.Peerstore().AddAddrs(srvHost.ID(), srvHost.Addrs(), peerstore.PermanentAddrTTL)
 
 	var tag protocol.ID = "/testitytest"
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	done := make(chan struct{})
 	go func() {

--- a/p2p/net/pnet/psk_conn_test.go
+++ b/p2p/net/pnet/psk_conn_test.go
@@ -24,8 +24,7 @@ func setupPSKConns(_ context.Context, t *testing.T) (net.Conn, net.Conn) {
 }
 
 func TestPSKSimpelMessges(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	ctx := t.Context()
 
 	psk1, psk2 := setupPSKConns(ctx, t)
 	msg1 := []byte("hello world")
@@ -56,8 +55,7 @@ func TestPSKSimpelMessges(t *testing.T) {
 }
 
 func TestPSKFragmentation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	ctx := t.Context()
 
 	psk1, psk2 := setupPSKConns(ctx, t)
 

--- a/p2p/net/swarm/limiter_test.go
+++ b/p2p/net/swarm/limiter_test.go
@@ -81,8 +81,7 @@ func TestLimiterBasicDials(t *testing.T) {
 
 	resch := make(chan transport.DialUpdate)
 	pid := peer.ID("testpeer")
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tryDialAddrs(ctx, l, pid, bads, resch)
 

--- a/p2p/net/swarm/swarm_net_test.go
+++ b/p2p/net/swarm/swarm_net_test.go
@@ -88,8 +88,7 @@ func printConns(n network.Network) string {
 }
 
 func TestNetworkOpenStream(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	testString := "hello ipfs"
 

--- a/p2p/protocol/circuitv2/relay/relay_test.go
+++ b/p2p/protocol/circuitv2/relay/relay_test.go
@@ -97,8 +97,7 @@ func addTransport(t *testing.T, h host.Host, upgrader transport.Upgrader) {
 }
 
 func TestBasicRelay(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	hosts, upgraders := getNetHosts(t, ctx, 3)
 	addTransport(t, hosts[0], upgraders[0])
@@ -205,8 +204,7 @@ func TestBasicRelay(t *testing.T) {
 }
 
 func TestRelayLimitTime(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	hosts, upgraders := getNetHosts(t, ctx, 3)
 	addTransport(t, hosts[0], upgraders[0])
@@ -279,8 +277,7 @@ func TestRelayLimitTime(t *testing.T) {
 }
 
 func TestRelayLimitData(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	hosts, upgraders := getNetHosts(t, ctx, 3)
 	addTransport(t, hosts[0], upgraders[0])

--- a/p2p/protocol/identify/id_test.go
+++ b/p2p/protocol/identify/id_test.go
@@ -363,8 +363,7 @@ func TestLocalhostAddrFiltering(t *testing.T) {
 // TestIdentifyPushWhileIdentifyingConn tests that the host waits to push updates if an identify is ongoing.
 func TestIdentifyPushWhileIdentifyingConn(t *testing.T) {
 	t.Skip()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
@@ -436,8 +435,7 @@ func TestIdentifyPushWhileIdentifyingConn(t *testing.T) {
 }
 
 func TestIdentifyPushOnAddrChange(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
@@ -510,8 +508,7 @@ func TestIdentifyPushOnAddrChange(t *testing.T) {
 }
 
 func TestUserAgent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, err := libp2p.New(libp2p.UserAgent("foo"), libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	if err != nil {
@@ -542,8 +539,7 @@ func TestNotListening(t *testing.T) {
 	// Make sure we don't panic if we're not listening on any addresses.
 	//
 	// https://github.com/libp2p/go-libp2p/issues/939
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, err := libp2p.New(libp2p.NoListenAddrs)
 	if err != nil {
@@ -564,8 +560,7 @@ func TestNotListening(t *testing.T) {
 }
 
 func TestSendPush(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
@@ -729,8 +724,7 @@ func randString(n int) string {
 }
 
 func TestLargePushMessage(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
@@ -805,8 +799,7 @@ func TestLargePushMessage(t *testing.T) {
 }
 
 func TestIdentifyResponseReadTimeout(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := blhost.NewBlankHost(swarmt.GenSwarm(t))
 	h2 := blhost.NewBlankHost(swarmt.GenSwarm(t))
@@ -845,8 +838,7 @@ func TestIdentifyResponseReadTimeout(t *testing.T) {
 }
 
 func TestIncomingIDStreamsTimeout(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	protocols := []protocol.ID{identify.IDPush}
 

--- a/p2p/protocol/ping/ping_test.go
+++ b/p2p/protocol/ping/ping_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestPing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	h1, err := bhost.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)
 	defer h1.Close()

--- a/p2p/test/backpressure/backpressure_test.go
+++ b/p2p/test/backpressure/backpressure_test.go
@@ -1,7 +1,6 @@
 package backpressure_tests
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -20,8 +19,7 @@ var log = logging.Logger("backpressure")
 // TestStBackpressureStreamWrite tests whether streams see proper
 // backpressure when writing data over the network streams.
 func TestStBackpressureStreamWrite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1, err := bhost.NewHost(swarmt.GenSwarm(t), nil)
 	require.NoError(t, err)

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -860,8 +860,7 @@ func TestDiscoverPeerIDFromSecurityNegotiation(t *testing.T) {
 
 			// runs a test to verify we can extract the peer ID from a target with just its address
 			t.Helper()
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			// Use a bogus peer ID so that when we connect to the target we get an error telling
 			// us the targets real peer ID


### PR DESCRIPTION
Optimize code using a more concise and modern approach.