### PR TITLE
README: remove Drand from notable users section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ informed by Go's own [security policy](https://go.dev/doc/security/policy).
 Some notable users of go-libp2p are:
 - [Kubo](https://github.com/ipfs/kubo) - The original Go implementation of IPFS
 - [Lotus](https://github.com/filecoin-project/lotus) - An implementation of the Filecoin protocol
-- [Drand](https://github.com/drand/drand) - A distributed random beacon daemon
 - [Prysm](https://github.com/prysmaticlabs/prysm) - An Ethereum Beacon Chain consensus client built by [Prysmatic Labs](https://prysmaticlabs.com/)
 - [Berty](https://github.com/berty/berty) - An open, secure, offline-first, peer-to-peer and zero trust messaging app.
 - [Wasp](https://github.com/iotaledger/wasp) - A node that runs IOTA Smart Contracts built by the [IOTA Foundation](https://www.iota.org/)


### PR DESCRIPTION
I can't find libp2p in https://github.com/drand/drand/blob/master/go.mod. Looks like it was removed in v2.0.0.