### PR TITLE
fix(dcutr): Fix client/server roles to match DCUtR specification

### DIFF
--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -161,9 +161,9 @@ func (hp *holePuncher) directConnect(rp peer.ID) error {
 			hp.tracer.StartHolePunch(rp, addrs, rtt)
 			hp.tracer.HolePunchAttempt(pi.ID)
 			ctx, cancel := context.WithTimeout(hp.ctx, hp.directDialTimeout)
-			isClient := true
+			isClient := false
 			if hp.legacyBehavior {
-				isClient = false
+				isClient = true
 			}
 			err := holePunchConnect(ctx, hp.host, pi, isClient)
 			cancel()

--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -284,9 +284,9 @@ func (s *Service) handleNewStream(str network.Stream) {
 	start := time.Now()
 	s.tracer.HolePunchAttempt(pi.ID)
 	ctx, cancel := context.WithTimeout(s.ctx, s.directDialTimeout)
-	isClient := false
+	isClient := true
 	if s.legacyBehavior {
-		isClient = true
+		isClient = false
 	}
 	err = holePunchConnect(ctx, s.host, pi, isClient)
 	cancel()


### PR DESCRIPTION
- In svc.go: Stream receiver (A) now acts as client per spec
- In holepuncher.go: Stream initiator (B) now acts as server per spec
- This fixes hole punching compatibility with Rust nodes
- Backwards compatibility preserved via legacyBehavior flag

Fixes #3171