### PR TITLE
p2p/host/basic: using testing.B.Loop

### DIFF
--- a/p2p/host/basic/addrs_manager_test.go
+++ b/p2p/host/basic/addrs_manager_test.go
@@ -452,7 +452,7 @@ func BenchmarkAreAddrsDifferent(b *testing.B) {
 	b.Run("areAddrsDifferent", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			areAddrsDifferent(addrs[:], addrs[:])
 		}
 	})
@@ -464,8 +464,8 @@ func BenchmarkRemoveIfNotInSource(b *testing.B) {
 		addrs[i] = ma.StringCast(fmt.Sprintf("/ip4/1.1.1.%d/tcp/1", i))
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		removeNotInSource(slices.Clone(addrs[:5]), addrs[:])
 	}
 }

--- a/p2p/host/basic/addrs_reachability_tracker_test.go
+++ b/p2p/host/basic/addrs_reachability_tracker_test.go
@@ -730,9 +730,9 @@ func BenchmarkAddrTracker(b *testing.B) {
 	}
 	t.UpdateAddrs(addrs)
 	b.ReportAllocs()
-	b.ResetTimer()
+
 	p := t.GetProbe()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		pp := t.GetProbe()
 		if len(pp) == 0 {
 			pp = p


### PR DESCRIPTION

use b.Loop() to simplify the code and improve performance


<img width="998" height="484" alt="image" src="https://github.com/user-attachments/assets/b067a3b9-6c3e-4bfa-a001-61a39556a5ba" />



before:

```shell
go test -run=^$ -bench=. ./p2p/host/basic -timeout=1h          
goos: darwin
goarch: arm64
pkg: github.com/libp2p/go-libp2p/p2p/host/basic
cpu: Apple M4
BenchmarkAreAddrsDifferent/areAddrsDifferent-10         	

 4204777	       280.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemoveIfNotInSource-10                         	10994522	       108.4 ns/op	     128 B/op	       1 allocs/op
BenchmarkAddrTracker-10                                 	   45888	    125901 ns/op	     154 B/op	       2 allocs/op
PASS
ok  	github.com/libp2p/go-libp2p/p2p/host/basic	9.227s
```


after change:

```shell
 go test -run=^$ -bench=. ./p2p/host/basic -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/libp2p/go-libp2p/p2p/host/basic
cpu: Apple M4
BenchmarkAreAddrsDifferent/areAddrsDifferent-10         	 4247346	       272.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemoveIfNotInSource-10                         	11759013	       101.6 ns/op	     128 B/op	       1 allocs/op
BenchmarkAddrTracker-10                                 	   43258	    110878 ns/op	     130 B/op	       2 allocs/op
PASS
ok  	github.com/libp2p/go-libp2p/p2p/host/basic	7.557s

```

