### PR TITLE
fix: assignment to entry in nil map

### DIFF
--- a/p2p/protocol/autonatv2/server.go
+++ b/p2p/protocol/autonatv2/server.go
@@ -527,6 +527,9 @@ func (r *rateLimiter) cleanup(now time.Time) {
 func (r *rateLimiter) CompleteRequest(p peer.ID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
 	r.inProgressReqs[p]--
 	if r.inProgressReqs[p] <= 0 {
 		delete(r.inProgressReqs, p)


### PR DESCRIPTION
fixes: https://github.com/ipfs/kubo/issues/10992

```
caught panic: assignment to entry in nil map
goroutine 40717 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x64
github.com/libp2p/go-libp2p/p2p/protocol/autonatv2.(*server).handleDialRequest.func1()
	github.com/libp2p/go-libp2p@v0.43.0/p2p/protocol/autonatv2/server.go:96 +0x44
panic({0x1042e9c20?, 0x105b46720?})
	runtime/panic.go:783 +0x120
github.com/libp2p/go-libp2p/p2p/protocol/autonatv2.(*rateLimiter).CompleteRequest(0x1400034b900, {0x14001c3c8a0, 0x26})
	github.com/libp2p/go-libp2p@v0.43.0/p2p/protocol/autonatv2/server.go:500 +0xd0
github.com/libp2p/go-libp2p/p2p/protocol/autonatv2.(*server).serveDialRequest(0x14000a2b0e0, {0x104739370, 0x14001a1a280})
	github.com/libp2p/go-libp2p@v0.43.0/p2p/protocol/autonatv2/server.go:291 +0x135c
github.com/libp2p/go-libp2p/p2p/protocol/autonatv2.(*server).handleDialRequest(0x14000a2b0e0, {0x104739370, 0x14001a1a280})
	github.com/libp2p/go-libp2p@v0.43.0/p2p/protocol/autonatv2/server.go:102 +0x134
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1({0x14000304860?, 0xff?}, {0x14c4e02b0?, 0x14001a1a280?})
	github.com/libp2p/go-libp2p@v0.43.0/p2p/host/basic/basic_host.go:557 +0x8c
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler(0x14000a343c0, {0x104739370, 0x14001a1a280})
	github.com/libp2p/go-libp2p@v0.43.0/p2p/host/basic/basic_host.go:405 +0x5f4
github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1.1()
	github.com/libp2p/go-libp2p@v0.43.0/p2p/net/swarm/swarm_conn.go:155 +0xa0
created by github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1 in goroutine 39332
	github.com/libp2p/go-libp2p@v0.43.0/p2p/net/swarm/swarm_conn.go:141 +0x17c
```