### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/p2p/host/eventbus/basic.go
+++ b/p2p/host/eventbus/basic.go
@@ -133,7 +133,7 @@ func (w *wildcardSub) Close() error {
 	w.closeOnce.Do(func() {
 		w.w.removeSink(w.ch)
 		if w.metricsTracer != nil {
-			w.metricsTracer.RemoveSubscriber(reflect.TypeOf(event.WildcardSubscription))
+			w.metricsTracer.RemoveSubscriber(reflect.TypeFor[*event.wildcardSubscriptionType]())
 		}
 	})
 
@@ -345,7 +345,7 @@ func (n *wildcardNode) addSink(sink *namedSink) {
 	n.Unlock()
 
 	if n.metricsTracer != nil {
-		n.metricsTracer.AddSubscriber(reflect.TypeOf(event.WildcardSubscription))
+		n.metricsTracer.AddSubscriber(reflect.TypeFor[*event.wildcardSubscriptionType]())
 	}
 }
 
@@ -368,7 +368,7 @@ func (n *wildcardNode) removeSink(ch chan interface{}) {
 	n.Unlock()
 }
 
-var wildcardType = reflect.TypeOf(event.WildcardSubscription)
+var wildcardType = reflect.TypeFor[*event.wildcardSubscriptionType]()
 
 func (n *wildcardNode) emit(evt interface{}) {
 	if n.nSinks.Load() == 0 {

--- a/p2p/host/eventbus/basic_test.go
+++ b/p2p/host/eventbus/basic_test.go
@@ -113,15 +113,15 @@ func TestGetAllEventTypes(t *testing.T) {
 
 	evts := bus.GetAllEventTypes()
 	require.Len(t, evts, 1)
-	require.Equal(t, reflect.TypeOf((*EventB)(nil)).Elem(), evts[0])
+	require.Equal(t, reflect.TypeFor[EventB](), evts[0])
 
 	_, err = bus.Emitter(new(EventA))
 	require.NoError(t, err)
 
 	evts = bus.GetAllEventTypes()
 	require.Len(t, evts, 2)
-	require.Contains(t, evts, reflect.TypeOf((*EventB)(nil)).Elem())
-	require.Contains(t, evts, reflect.TypeOf((*EventA)(nil)).Elem())
+	require.Contains(t, evts, reflect.TypeFor[EventB]())
+	require.Contains(t, evts, reflect.TypeFor[EventA]())
 }
 
 func TestEmitNoSubNoBlock(t *testing.T) {


### PR DESCRIPTION
Try to use better api `reflect.TypeFor`  recommend by Go Team instead of `reflect.TypeOf` when we have known the type.

More info https://github.com/golang/go/issues/60088