### PR TITLE
webtransport: fix upgrade error handling

### DIFF
--- a/p2p/transport/webtransport/listener.go
+++ b/p2p/transport/webtransport/listener.go
@@ -193,8 +193,7 @@ func (l *listener) httpHandlerWithConnScope(w http.ResponseWriter, r *http.Reque
 	sess, err := l.server.Upgrade(w, r)
 	if err != nil {
 		log.Debug("upgrade failed", "error", err)
-		// TODO: think about the status code to use here
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return err
 	}
 	ctx, cancel := context.WithTimeout(l.ctx, handshakeTimeout)


### PR DESCRIPTION
Replaced the undefined webtransport.HandshakeError with a simple error check.
Returns 400 for failed upgrades instead of hardcoded 500 and adds debug logging.