### PR TITLE
fix(websocket): use debug level for operational noise errors

### DIFF
--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -126,8 +126,10 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 		},
 	}
 	ln.server = http.Server{
-		Handler:     ln,
-		ErrorLog:    slog.NewLogLogger(log.Handler(), slog.LevelError),
+		Handler: ln,
+		// Use LevelDebug for http.Server errors (TLS handshake failures, connection issues).
+		// These are operational noise from misbehaving/buggy remote clients, not server errors.
+		ErrorLog:    slog.NewLogLogger(log.Handler(), slog.LevelDebug),
 		ConnContext: ln.ConnContext,
 		TLSConfig:   tlsConf,
 	}


### PR DESCRIPTION
@MarcoPolo this seems to be a regression in 0.44. FYSA this is blocking Kubo 0.39, any chance we could have a patch with this or maybe 0.45 is soon enough (week-two?)

---- 

Log refactor done in
 
- https://github.com/libp2p/go-libp2p/pull/3364 

migrated from zap to slog but accidentally changed the log level for `http.Server.ErrorLog` from implicit INFO to explicit ERROR. This caused client EOF and TLS handshake errors to spam error logs and stdout in apps which log only ERROR by default.

These `http.Server` errors (client EOFs, TLS handshake failures from clients with naive TLS implementations, connection timeouts from clients that abort early) are normal operational noise, not actual server errors. 

Rationale for using `LevelDebug`:
- matches semantic meaning (similar to existing connection timeout logs)
- respects user's configured threshold (all legacy software using both go-log and go-libp2p uses ERROR level by default and prints ERROR to stdout/err, users expected apps to filter this noise out)
- allows users to enable for debugging via log level configuration

This PR helps with noise reported in:
- https://github.com/ipfs/kubo/issues/11027
- https://github.com/ipfs/kubo/issues/11033 