### PR TITLE
fix(webrtc): use debug level for pion errors

### DIFF
--- a/p2p/transport/webrtc/logger.go
+++ b/p2p/transport/webrtc/logger.go
@@ -14,10 +14,11 @@ var log = logging.Logger("webrtc-transport")
 // pionLog is the logger provided to pion for internal logging
 var pionLog = logging.Logger("webrtc-transport-pion")
 
-// pionLogger wraps the StandardLogger interface to provide a LeveledLogger interface
-// as expected by pion
-// Pion logs are too noisy and have invalid log levels. pionLogger downgrades all the
-// logs to debug
+// pionLogger adapts pion's logger to go-libp2p's semantics.
+// Pion logs routine connection events (client disconnects, protocol mismatches,
+// state races) as ERROR/WARN, but these are normal operational noise from a
+// service perspective. We downgrade all pion logs to DEBUG to prevent log spam
+// while preserving debuggability when needed.
 type pionLogger struct {
 	*slog.Logger
 }
@@ -37,32 +38,32 @@ func (l pionLogger) Debugf(s string, args ...interface{}) {
 }
 
 func (l pionLogger) Error(s string) {
-	l.Logger.Error(s)
+	l.Logger.Debug(s)
 }
 
 func (l pionLogger) Errorf(s string, args ...interface{}) {
-	if l.Logger.Enabled(context.Background(), slog.LevelError) {
-		l.Logger.Error(fmt.Sprintf(s, args...))
+	if l.Logger.Enabled(context.Background(), slog.LevelDebug) {
+		l.Logger.Debug(fmt.Sprintf(s, args...))
 	}
 }
 
 func (l pionLogger) Info(s string) {
-	l.Logger.Info(s)
+	l.Logger.Debug(s)
 }
 
 func (l pionLogger) Infof(s string, args ...interface{}) {
-	if l.Logger.Enabled(context.Background(), slog.LevelInfo) {
-		l.Logger.Info(fmt.Sprintf(s, args...))
+	if l.Logger.Enabled(context.Background(), slog.LevelDebug) {
+		l.Logger.Debug(fmt.Sprintf(s, args...))
 	}
 }
 
 func (l pionLogger) Warn(s string) {
-	l.Logger.Warn(s)
+	l.Logger.Debug(s)
 }
 
 func (l pionLogger) Warnf(s string, args ...interface{}) {
-	if l.Logger.Enabled(context.Background(), slog.LevelWarn) {
-		l.Logger.Warn(fmt.Sprintf(s, args...))
+	if l.Logger.Enabled(context.Background(), slog.LevelDebug) {
+		l.Logger.Debug(fmt.Sprintf(s, args...))
 	}
 }
 


### PR DESCRIPTION
## Problem

go-libp2p 0.44 and 0.45 log operational webrtc noise ad loud ERRORs

This impacts projects like kubo, which run webrtc-direct listener by default:

- https://github.com/ipfs/kubo/issues/11053

## Analysis

### Pre-v0.44 (Working State)

PR #2915 by @sukunrt  deliberately downgraded all pion logs to Debug level because "Pion logs are too noisy and have invalid log levels". This worked correctly for ~1 year without issues.

### v0.44.0 (Regression)

PR #3364 by @MarcoPolo  migrated from go-log/v2 to log/slog but accidentally reverted the pion log level downgrade. The migration kept the comment claiming logs were downgraded but changed the implementation to log Error/Warn/Info at their face values, causing routine connection events to spam error logs.


## Solution

Similar to PR #3413 which fixed this issue for websocket transport, WebRTC transport needs the same treatment. Pion logs client disconnects, protocol mismatches, and state races as ERROR/WARN, but these are normal operational noise from a service perspective, not actual errors requiring operator attention.

This restores PR #2915 behavior: downgrade all pion logs to Debug level.
Users who need to debug WebRTC issues can still use that level.

Fixes https://github.com/ipfs/kubo/issues/11053