### PR TITLE
fix: handle error from mh.Sum in IDFromPublicKey

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -169,7 +169,10 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 	if AdvancedEnableInlining && len(b) <= maxInlineKeyLength {
 		alg = mh.IDENTITY
 	}
-	hash, _ := mh.Sum(b, alg, -1)
+	hash, err := mh.Sum(b, alg, -1)
+	if err != nil {
+		return "", err
+	}
 	return ID(hash), nil
 }
 


### PR DESCRIPTION
IDFromPublicKey previously ignored the error returned by mh.Sum, assuming it could not fail for the supported algorithms. This change makes the function fail fast if multihash.Sum ever returns an error (for example due to future registry or parameter changes), instead of silently producing an invalid peer ID. Under normal conditions behavior stays the same, but the code is now more robust against go-multihash evolution.