### PR TITLE
fix(basic_host): `stream.Close()` blocks indefinitely on unresponsive peers

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -683,6 +683,11 @@ func (s *streamWrapper) Write(b []byte) (int, error) {
 }
 
 func (s *streamWrapper) Close() error {
+	// Set a read deadline to prevent Close() from blocking indefinitely
+	// waiting for the multistream-select handshake to complete.
+	// This can happen when the remote peer is slow or unresponsive.
+	// See: https://github.com/multiformats/go-multistream/issues/47
+	_ = s.Stream.SetReadDeadline(time.Now().Add(DefaultNegotiationTimeout))
 	return s.rw.Close()
 }
 

--- a/p2p/host/basic/basic_host_synctest_test.go
+++ b/p2p/host/basic/basic_host_synctest_test.go
@@ -1,0 +1,81 @@
+//go:build go1.25
+
+package basichost_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	"github.com/libp2p/go-libp2p/x/simlibp2p"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamCloseDoesNotHangOnUnresponsivePeer verifies that stream.Close()
+// returns within DefaultNegotiationTimeout even when the remote peer never
+// completes the multistream handshake. Without the read deadline fix in
+// streamWrapper.Close(), this would hang indefinitely.
+func TestStreamCloseDoesNotHangOnUnresponsivePeer_synctest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		h1, h2 := simlibp2p.GetBasicHostPair(t)
+		defer h1.Close()
+		defer h2.Close()
+
+		const testProto = "/test/hang"
+
+		// Manually add protocol to peerstore so h1 thinks h2 supports it.
+		// This makes NewStream use lazy multistream (skipping negotiation until Close).
+		h1.Peerstore().AddProtocols(h2.ID(), testProto)
+
+		// h2 accepts streams at the network level but never responds to
+		// multistream protocol negotiation, simulating an unresponsive peer.
+		h2.Network().SetStreamHandler(func(s network.Stream) {
+			// Read incoming data but never write back - simulates unresponsive peer
+			buf := make([]byte, 1024)
+			for {
+				_, err := s.Read(buf)
+				if err != nil {
+					return
+				}
+			}
+		})
+
+		// Open stream to h2 - uses lazy multistream because protocol is "known"
+		s, err := h1.NewStream(ctx, h2.ID(), testProto)
+		require.NoError(t, err)
+
+		// Trigger the lazy handshake by writing data.
+		// The write succeeds (buffered), but the read handshake will block
+		// because h2 never sends a response.
+		_, err = s.Write([]byte("trigger handshake"))
+		require.NoError(t, err)
+
+		// Close() should return within DefaultNegotiationTimeout because the fix
+		// sets a read deadline before calling the underlying Close().
+		// Without the fix, this would hang indefinitely.
+		elapsedCh := make(chan time.Duration)
+		go func() {
+			start := time.Now()
+			_ = s.Close()
+			elapsedCh <- time.Since(start)
+		}()
+
+		maxExpected := basichost.DefaultNegotiationTimeout
+		var elapsed time.Duration
+		select {
+		case elapsed = <-elapsedCh:
+		case <-time.After(maxExpected + time.Second):
+			t.Fatal("timeout waiting for Close()")
+		}
+
+		require.Equal(t, elapsed, maxExpected,
+			"Close() took %v, expected < %v (DefaultNegotiationTimeout + margin)", elapsed, maxExpected)
+
+		t.Logf("Close() returned in %v (limit: %v)", elapsed, maxExpected)
+	})
+}


### PR DESCRIPTION
## Summary

`stream.Close()` can block forever when the remote peer is slow or unresponsive, causing goroutine leaks. This particularly affects WebRTC SCTP state machines and  bitswap servers, eventually preventing nodes from serving blocks.

Note: this PR aims to be a surgical fix, perhaps there is a better way?

## Affected Versions

- go-libp2p: all versions using lazy multistream-select it seems?
- Observed in: kubo v0.39.0 (boxo v0.35.2, go-libp2p v0.45.0)

## Symptoms

- Bitswap stops serving blocks despite having them pinned
- [`vole bitswap check`](https://github.com/ipfs-shipyard/vole) returns `Responded: false`
- libp2p identify/ping work fine (connection is "alive")
- Goroutine profile shows hundreds of goroutines stuck for days/weeks

## Likely the Root Cause

When protocol is known from identify, `host.NewStream()` returns a lazy multistream wrapper that defers handshake completion until `Close()`:

```
streamWrapper.Close()
  → lazyClientConn.Close()           // go-multistream
    → Flush()                        // sends write handshake
    → rhandshakeOnce.Do(doReadHandshake)
      → ReadNextToken(l.con)         // BLOCKS HERE - no timeout!
    → l.con.Close()
```

`ReadNextToken()` reads from the stream with **no deadline**. If the peer doesn't respond, the goroutine blocks forever.

**Why This Happens?**

1. Bitswap server opens stream, sends blocks, calls `Close()`
2. `Close()` must complete multistream handshake before closing
3. Handshake read blocks waiting for peer's protocol confirmation
4. Peer is unresponsive (network issue, overloaded, disconnected uncleanly)
5. Read never returns → goroutine leaked

This affects all transports but WebRTC is more prone due to NAT traversal issues and complex SCTP state machines.

### Evidence

Goroutine profile from production node (35 days uptime):

```
goroutine 1421 [chan receive, 20381 minutes]:
github.com/multiformats/go-multistream.(*once).Do(...)
    lazyClient.go:53
github.com/multiformats/go-multistream.(*lazyClientConn[...]).Close(...)
    lazyClient.go:196
github.com/ipfs/boxo/bitswap/server.(*Server).sendBlocks(...)
    server.go:335
```

- 400+ goroutines stuck in `sendBlocks` → `Close()` path
- Blocked for 20,000+ minutes (14+ days)
- All waiting on WebRTC/SCTP reads

## Proposed Fix (this PR)

Set a read deadline before calling multistream `Close()`:

```go
// go-libp2p/p2p/host/basic/basic_host.go

func (s *streamWrapper) Close() error {
    // Prevent indefinite blocking on multistream handshake completion.
    _ = s.Stream.SetReadDeadline(time.Now().Add(DefaultNegotiationTimeout))
    return s.rw.Close()
}
```

This uses the existing 10-second `DefaultNegotiationTimeout`.

**Why this location?** 
- Minimal change (5 lines)
- Uses existing timeout configuration
- Fixes all callers automatically
- No API changes required

**Why not fix in go-multistream?**
- PR #48 attempted this in 2019 but was never merged
- Would require API changes or hardcoded timeout
- go-libp2p fix is simpler and can be deployed faster

**Fix Verification**

- `s.Stream` and `lazyClientConn.con` are the same object
- `SetReadDeadline` affects in-progress reads (per Go spec)
- pion/sctp correctly signals blocked readers on deadline
- Stream is closed at end of `lazyClientConn.Close()` regardless
- All existing tests pass

## Related

- https://github.com/multiformats/go-multistream/issues/47 (2019)
- https://github.com/multiformats/go-multistream/pull/48 (2019, never merged)
- https://github.com/ipshipyard/waterworks-infra/issues/860 (internal, about `collab-cluster-am6-1`)

## Workaround (without this PR)

Restart affected nodes to clear stuck goroutines.