### PR TITLE
fix(mocknet): make stream deadline methods noop instead of returning error 

### DIFF
--- a/p2p/net/mock/mock_stream.go
+++ b/p2p/net/mock/mock_stream.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"net"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -174,17 +173,12 @@ func (s *stream) Conn() network.Conn {
 	return s.conn
 }
 
-func (s *stream) SetDeadline(_ time.Time) error {
-	return &net.OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
-}
-
-func (s *stream) SetReadDeadline(_ time.Time) error {
-	return &net.OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
-}
-
-func (s *stream) SetWriteDeadline(_ time.Time) error {
-	return &net.OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
-}
+// SetDeadline is a noop for mocknet streams since the underlying pipe
+// transport does not support deadlines. Callers should not treat the
+// absence of deadline support as an error.
+func (s *stream) SetDeadline(_ time.Time) error      { return nil }
+func (s *stream) SetReadDeadline(_ time.Time) error  { return nil }
+func (s *stream) SetWriteDeadline(_ time.Time) error { return nil }
 
 func (s *stream) Read(b []byte) (int, error) {
 	return s.read.Read(b)


### PR DESCRIPTION
## Summary                                                                                                                                     
  - Make `SetDeadline`, `SetReadDeadline`, and `SetWriteDeadline` on mocknet streams return nil instead of an error
  - Mocknet uses `io.Pipe` which doesn't support deadlines, but returning an error breaks callers that treat `SetWriteDeadline` failure as fatal
  - Since writes on in-memory pipes complete immediately, deadline enforcement is unnecessary and the noop is safe

  ## Context
  go-libp2p-pubsub added `SetWriteDeadline` calls in [`handleSendingMessages`](https://github.com/libp2p/go-libp2p-pubsub/commit/6587e8e72b35957a53d61dcf91f05b1b9a78bfdf) (part of https://github.com/libp2p/go-libp2p-pubsub/pull/631). The deadline error is treated as fatal. The stream is reset and the hello packet is never sent. This prevents gossipsub peers from discovering each other's subscriptions in any mocknet-based test.
