### PR TITLE
Add ability to pass through TLS options to the QUIC transport.

### DIFF
--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -261,7 +261,7 @@ func TestTransportConstructorWithWrongOpts(t *testing.T) {
 		Transport(quic.NewTransport, tcp.DisableReuseport()),
 		DisableRelay(),
 	)
-	require.EqualError(t, err, "transport constructor doesn't take any options")
+	require.EqualError(t, err, "transport option of type tcp.Option not assignable to libp2pquic.Option")
 }
 
 func TestSecurityConstructor(t *testing.T) {

--- a/p2p/transport/quic/options.go
+++ b/p2p/transport/quic/options.go
@@ -1,0 +1,19 @@
+package libp2pquic
+
+import p2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
+
+// Option is a function that configures the QUIC transport.
+type Option func(o *transportConfig) error
+
+type transportConfig struct {
+	tlsIdentityOpts []p2ptls.IdentityOption
+}
+
+// WithTLSIdentityOption passes the given p2ptls.IdentityOption through to the
+// TLS identity used by the QUIC transport.
+func WithTLSIdentityOption(opt ...p2ptls.IdentityOption) Option {
+	return func(c *transportConfig) error {
+		c.tlsIdentityOpts = append(c.tlsIdentityOpts, opt...)
+		return nil
+	}
+}

--- a/p2p/transport/quic/transport.go
+++ b/p2p/transport/quic/transport.go
@@ -70,16 +70,22 @@ type activeHolePunch struct {
 }
 
 // NewTransport creates a new QUIC transport
-func NewTransport(key ic.PrivKey, connManager *quicreuse.ConnManager, psk pnet.PSK, gater connmgr.ConnectionGater, rcmgr network.ResourceManager) (tpt.Transport, error) {
+func NewTransport(key ic.PrivKey, connManager *quicreuse.ConnManager, psk pnet.PSK, gater connmgr.ConnectionGater, rcmgr network.ResourceManager, opts ...Option) (tpt.Transport, error) {
 	if len(psk) > 0 {
 		log.Error("QUIC doesn't support private networks yet.")
 		return nil, errors.New("QUIC doesn't support private networks yet")
+	}
+	var cfg transportConfig
+	for _, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
 	}
 	localPeer, err := peer.IDFromPrivateKey(key)
 	if err != nil {
 		return nil, err
 	}
-	identity, err := p2ptls.NewIdentity(key)
+	identity, err := p2ptls.NewIdentity(key, cfg.tlsIdentityOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Useful to set the KeyLog writer so you can debug the session with Wireshark