### PR TITLE
Improve peer ID parse error context and wrap error

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -127,14 +127,14 @@ func Decode(s string) (ID, error) {
 		// base58 encoded sha256 or identity multihash
 		m, err := mh.FromB58String(s)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse peer ID: %s", err)
+			return "", fmt.Errorf("failed to parse peer ID: %w", err)
 		}
 		return ID(m), nil
 	}
 
 	c, err := cid.Decode(s)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse peer ID: %s", err)
+		return "", fmt.Errorf("failed to parse peer ID: %w", err)
 	}
 	return FromCid(c)
 }


### PR DESCRIPTION
What does this PR do?

Improve error wrapping and include the peer ID input value in the error message to improve debugging.

Why was this needed?

Including the input improves observability when diagnosing invalid peer IDs. Using %w preserves the error chain.

How was this tested?

go test ./...