### PR TITLE
Fix/error wrap envelope

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -127,14 +127,14 @@ func Decode(s string) (ID, error) {
 		// base58 encoded sha256 or identity multihash
 		m, err := mh.FromB58String(s)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse peer ID: %s", err)
+			return "", fmt.Errorf("failed to parse peer ID: %w", err)
 		}
 		return ID(m), nil
 	}
 
 	c, err := cid.Decode(s)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse peer ID: %s", err)
+		return "", fmt.Errorf("failed to parse peer ID: %w", err)
 	}
 	return FromCid(c)
 }

--- a/core/record/envelope.go
+++ b/core/record/envelope.go
@@ -51,7 +51,7 @@ var ErrInvalidSignature = errors.New("invalid signature or incorrect domain")
 func Seal(rec Record, privateKey crypto.PrivKey) (*Envelope, error) {
 	payload, err := rec.MarshalRecord()
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling record: %v", err)
+		return nil, fmt.Errorf("error marshaling record: %w", err)
 	}
 
 	domain := rec.Domain()


### PR DESCRIPTION
What does this PR do?

Wraps error using %w instead of %v to allow proper error unwrapping.

Why is this needed?

Using %w allows callers to use errors.Is and errors.As.

How to test?

go test ./...
