### PR TITLE
feat: opt-in LoopbackAddrPublishing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,6 +125,8 @@ type Config struct {
 
 	DisablePing bool
 
+	DisableLoopbackAddrPublishing bool
+
 	Routing RoutingC
 
 	EnableAutoRelay bool
@@ -442,21 +444,22 @@ func (cfg *Config) addTransports() ([]fx.Option, error) {
 
 func (cfg *Config) newBasicHost(swrm *swarm.Swarm, eventBus event.Bus, an *autonatv2.AutoNAT, o bhost.ObservedAddrsManager) (*bhost.BasicHost, error) {
 	h, err := bhost.NewHost(swrm, &bhost.HostOpts{
-		EventBus:             eventBus,
-		ConnManager:          cfg.ConnManager,
-		AddrsFactory:         cfg.AddrsFactory,
-		NATManager:           cfg.NATManager,
-		EnablePing:           !cfg.DisablePing,
-		UserAgent:            cfg.UserAgent,
-		ProtocolVersion:      cfg.ProtocolVersion,
-		EnableHolePunching:   cfg.EnableHolePunching,
-		HolePunchingOptions:  cfg.HolePunchingOptions,
-		EnableRelayService:   cfg.EnableRelayService,
-		RelayServiceOpts:     cfg.RelayServiceOpts,
-		EnableMetrics:        !cfg.DisableMetrics,
-		PrometheusRegisterer: cfg.PrometheusRegisterer,
-		AutoNATv2:            an,
-		ObservedAddrsManager: o,
+		EventBus:                      eventBus,
+		ConnManager:                   cfg.ConnManager,
+		AddrsFactory:                  cfg.AddrsFactory,
+		NATManager:                    cfg.NATManager,
+		EnablePing:                    !cfg.DisablePing,
+		UserAgent:                     cfg.UserAgent,
+		ProtocolVersion:               cfg.ProtocolVersion,
+		EnableHolePunching:            cfg.EnableHolePunching,
+		HolePunchingOptions:           cfg.HolePunchingOptions,
+		EnableRelayService:            cfg.EnableRelayService,
+		RelayServiceOpts:              cfg.RelayServiceOpts,
+		EnableMetrics:                 !cfg.DisableMetrics,
+		PrometheusRegisterer:          cfg.PrometheusRegisterer,
+		DisableLoopbackAddrPublishing: cfg.DisableLoopbackAddrPublishing,
+		AutoNATv2:                     an,
+		ObservedAddrsManager:          o,
 	})
 	if err != nil {
 		return nil, err

--- a/options.go
+++ b/options.go
@@ -441,6 +441,20 @@ func Ping(enable bool) Option {
 	}
 }
 
+// LoopbackAddrPublishing controls whether the host advertises loopback
+// addresses (127.0.0.0/8 and ::1) to remote peers through the peerstore and
+// signed peer records. Loopback connectivity is still usable locally because
+// identify handles loopback-to-loopback connections separately.
+//
+// Defaults to true for backward compatibility. Set to false to avoid leaking
+// loopback addresses through DHT provider records and identify exchanges.
+func LoopbackAddrPublishing(enable bool) Option {
+	return func(cfg *Config) error {
+		cfg.DisableLoopbackAddrPublishing = !enable
+		return nil
+	}
+}
+
 // Routing will configure libp2p to use routing.
 func Routing(rt config.RoutingC) Option {
 	return func(cfg *Config) error {

--- a/p2p/host/basic/addrs_manager.go
+++ b/p2p/host/basic/addrs_manager.go
@@ -71,10 +71,11 @@ type addrsManager struct {
 	addrsMx      sync.RWMutex
 	currentAddrs hostAddrs
 
-	signKey           crypto.PrivKey
-	addrStore         addrStore
-	signedRecordStore peerstore.CertifiedAddrBook
-	hostID            peer.ID
+	signKey                       crypto.PrivKey
+	addrStore                     addrStore
+	signedRecordStore             peerstore.CertifiedAddrBook
+	hostID                        peer.ID
+	disableLoopbackAddrPublishing bool
 
 	wg        sync.WaitGroup
 	ctx       context.Context
@@ -92,26 +93,28 @@ func newAddrsManager(
 	enableMetrics bool,
 	registerer prometheus.Registerer,
 	disableSignedPeerRecord bool,
+	disableLoopbackAddrPublishing bool,
 	signKey crypto.PrivKey,
 	addrStore addrStore,
 	hostID peer.ID,
 ) (*addrsManager, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	as := &addrsManager{
-		bus:                       bus,
-		listenAddrs:               listenAddrs,
-		addCertHashes:             addCertHashes,
-		observedAddrsManager:      observedAddrsManager,
-		natManager:                natmgr,
-		addrsFactory:              addrsFactory,
-		triggerAddrsUpdateChan:    make(chan chan struct{}, 1),
-		triggerReachabilityUpdate: make(chan struct{}, 1),
-		interfaceAddrs:            &interfaceAddrsCache{},
-		signKey:                   signKey,
-		addrStore:                 addrStore,
-		hostID:                    hostID,
-		ctx:                       ctx,
-		ctxCancel:                 cancel,
+		bus:                           bus,
+		listenAddrs:                   listenAddrs,
+		addCertHashes:                 addCertHashes,
+		observedAddrsManager:          observedAddrsManager,
+		natManager:                    natmgr,
+		addrsFactory:                  addrsFactory,
+		triggerAddrsUpdateChan:        make(chan chan struct{}, 1),
+		triggerReachabilityUpdate:     make(chan struct{}, 1),
+		interfaceAddrs:                &interfaceAddrsCache{},
+		signKey:                       signKey,
+		addrStore:                     addrStore,
+		hostID:                        hostID,
+		disableLoopbackAddrPublishing: disableLoopbackAddrPublishing,
+		ctx:                           ctx,
+		ctxCancel:                     cancel,
 	}
 	unknownReachability := network.ReachabilityUnknown
 	as.hostReachability.Store(&unknownReachability)
@@ -343,9 +346,16 @@ func (a *addrsManager) updateAddrs(prevHostAddrs hostAddrs, relayAddrs []ma.Mult
 
 // updatePeerStore updates the peer store for the host
 func (a *addrsManager) updatePeerStore(currentAddrs []ma.Multiaddr, removedAddrs []ma.Multiaddr) {
+	publishedAddrs := currentAddrs
+	var excludedAddrs []ma.Multiaddr
+	if a.disableLoopbackAddrPublishing {
+		publishedAddrs, excludedAddrs = splitPublishedAddrs(currentAddrs)
+	}
 	// update host addresses in the peer store
-	a.addrStore.SetAddrs(a.hostID, currentAddrs, peerstore.PermanentAddrTTL)
-	a.addrStore.SetAddrs(a.hostID, removedAddrs, 0)
+	a.addrStore.SetAddrs(a.hostID, publishedAddrs, peerstore.PermanentAddrTTL)
+	// clear both the addresses removed since last update and the ones excluded
+	// from publishing (e.g. loopback) to avoid stale entries.
+	a.addrStore.SetAddrs(a.hostID, append(removedAddrs, excludedAddrs...), 0)
 
 	var sr *record.Envelope
 	// Our addresses have changed.
@@ -354,7 +364,7 @@ func (a *addrsManager) updatePeerStore(currentAddrs []ma.Multiaddr, removedAddrs
 		var err error
 		// add signed peer record to the event
 		// in case of an error drop this event.
-		sr, err = a.makeSignedPeerRecord(currentAddrs)
+		sr, err = a.makeSignedPeerRecord(publishedAddrs)
 		if err != nil {
 			log.Error("error creating a signed peer record from the set of current addresses", "err", err)
 			return
@@ -364,6 +374,19 @@ func (a *addrsManager) updatePeerStore(currentAddrs []ma.Multiaddr, removedAddrs
 			return
 		}
 	}
+}
+
+// splitPublishedAddrs separates loopback addresses so they are not announced
+// to peers via the peerstore or signed peer records.
+func splitPublishedAddrs(addrs []ma.Multiaddr) (published, excluded []ma.Multiaddr) {
+	for _, addr := range addrs {
+		if manet.IsIPLoopback(addr) {
+			excluded = append(excluded, addr)
+		} else {
+			published = append(published, addr)
+		}
+	}
+	return
 }
 
 func (a *addrsManager) notifyAddrsUpdated(emitter event.Emitter, localAddrsEmitter event.Emitter, previous, current hostAddrs) {

--- a/p2p/host/basic/addrs_manager_test.go
+++ b/p2p/host/basic/addrs_manager_test.go
@@ -64,14 +64,15 @@ type addrStoreArgs struct {
 }
 
 type addrsManagerArgs struct {
-	NATManager           NATManager
-	AddrsFactory         AddrsFactory
-	ObservedAddrsManager ObservedAddrsManager
-	ListenAddrs          func() []ma.Multiaddr
-	AddCertHashes        func([]ma.Multiaddr) []ma.Multiaddr
-	AutoNATClient        autonatv2Client
-	Bus                  event.Bus
-	AddrStoreArgs        addrStoreArgs
+	NATManager                    NATManager
+	AddrsFactory                  AddrsFactory
+	ObservedAddrsManager          ObservedAddrsManager
+	ListenAddrs                   func() []ma.Multiaddr
+	AddCertHashes                 func([]ma.Multiaddr) []ma.Multiaddr
+	AutoNATClient                 autonatv2Client
+	Bus                           event.Bus
+	AddrStoreArgs                 addrStoreArgs
+	DisableLoopbackAddrPublishing bool
 }
 
 type addrsManagerTestCase struct {
@@ -118,6 +119,7 @@ func newAddrsManagerTestCase(tb testing.TB, args addrsManagerArgs) addrsManagerT
 		true,
 		prometheus.DefaultRegisterer,
 		false,
+		args.DisableLoopbackAddrPublishing,
 		signKey,
 		addrStore,
 		pid,
@@ -486,6 +488,63 @@ func TestAddrsManagerPeerstoreUpdated(t *testing.T) {
 	pr = peerRecordFromEnvelope(t, ev)
 	require.Equal(t, pr.Addrs, []ma.Multiaddr{quic2})
 
+}
+
+func TestAddrsManagerLoopbackAddrPublishing(t *testing.T) {
+	loopback := ma.StringCast("/ip4/127.0.0.1/udp/1/quic-v1")
+	loopback6 := ma.StringCast("/ip6/::1/udp/1/quic-v1")
+	public := ma.StringCast("/ip4/1.2.3.4/udp/1/quic-v1")
+
+	t.Run("publishes loopback by default", func(t *testing.T) {
+		pstore, err := pstoremem.NewPeerstore()
+		require.NoError(t, err)
+		cab, _ := peerstore.GetCertifiedAddrBook(pstore)
+		signKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+		require.NoError(t, err)
+		pid, err := peer.IDFromPrivateKey(signKey)
+		require.NoError(t, err)
+
+		am := newAddrsManagerTestCase(t, addrsManagerArgs{
+			ListenAddrs:  func() []ma.Multiaddr { return nil },
+			AddrsFactory: func([]ma.Multiaddr) []ma.Multiaddr { return []ma.Multiaddr{loopback, loopback6, public} },
+			AddrStoreArgs: addrStoreArgs{
+				AddrStore: pstore,
+				HostID:    pid,
+				SignKey:   signKey,
+			},
+		})
+		defer am.Close()
+
+		require.ElementsMatch(t, []ma.Multiaddr{loopback, loopback6, public}, pstore.Addrs(pid))
+		pr := peerRecordFromEnvelope(t, cab.GetPeerRecord(pid))
+		require.ElementsMatch(t, []ma.Multiaddr{loopback, loopback6, public}, pr.Addrs)
+	})
+
+	t.Run("strips loopback when publishing is disabled", func(t *testing.T) {
+		pstore, err := pstoremem.NewPeerstore()
+		require.NoError(t, err)
+		cab, _ := peerstore.GetCertifiedAddrBook(pstore)
+		signKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+		require.NoError(t, err)
+		pid, err := peer.IDFromPrivateKey(signKey)
+		require.NoError(t, err)
+
+		am := newAddrsManagerTestCase(t, addrsManagerArgs{
+			ListenAddrs:  func() []ma.Multiaddr { return nil },
+			AddrsFactory: func([]ma.Multiaddr) []ma.Multiaddr { return []ma.Multiaddr{loopback, loopback6, public} },
+			AddrStoreArgs: addrStoreArgs{
+				AddrStore: pstore,
+				HostID:    pid,
+				SignKey:   signKey,
+			},
+			DisableLoopbackAddrPublishing: true,
+		})
+		defer am.Close()
+
+		matest.AssertEqualMultiaddrs(t, []ma.Multiaddr{public}, pstore.Addrs(pid))
+		pr := peerRecordFromEnvelope(t, cab.GetPeerRecord(pid))
+		matest.AssertEqualMultiaddrs(t, []ma.Multiaddr{public}, pr.Addrs)
+	})
 }
 
 func TestRemoveIfNotInSource(t *testing.T) {

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -127,6 +127,14 @@ type HostOpts struct {
 	// DisableSignedPeerRecord disables the generation of Signed Peer Records on this host.
 	DisableSignedPeerRecord bool
 
+	// DisableLoopbackAddrPublishing excludes loopback addresses (127.0.0.0/8,
+	// ::1) from the host's entry in the peerstore and from the signed peer
+	// record, preventing them from being advertised to remote peers via
+	// identify or the DHT. Local loopback connectivity still works because
+	// identify's unsigned ListenAddrs path keeps loopback addresses on
+	// loopback-to-loopback connections.
+	DisableLoopbackAddrPublishing bool
+
 	// EnableHolePunching enables the peer to initiate/respond to hole punching attempts for NAT traversal.
 	EnableHolePunching bool
 	// HolePunchingOptions are options for the hole punching service
@@ -238,6 +246,7 @@ func NewHost(n network.Network, opts *HostOpts) (*BasicHost, error) {
 		opts.EnableMetrics,
 		opts.PrometheusRegisterer,
 		opts.DisableSignedPeerRecord,
+		opts.DisableLoopbackAddrPublishing,
 		h.Peerstore().PrivKey(h.ID()),
 		h.Peerstore(),
 		h.ID(),


### PR DESCRIPTION
This PR proposes new opt-in flags:

- `libp2p.LoopbackAddrPublishing(bool)` that lets hosts exclude loopback addresses (`127.0.0.0/8`, `::1`) from the peerstore self-entry and the signed peer record so they are not advertised via identify or DHT.

> [!NOTE]
> Moved to #3489 which fixes wider issue and includes this.
