### PR TITLE
Interrupt websocket reads during close

### DIFF
--- a/p2p/transport/websocket/conn.go
+++ b/p2p/transport/websocket/conn.go
@@ -142,13 +142,14 @@ func (c *Conn) Close() error {
 }
 
 func (c *Conn) closeOnceFn() error {
+	err0 := c.Conn.SetReadDeadline(time.Now())
 	err1 := c.Conn.WriteControl(
 		ws.CloseMessage,
 		ws.FormatCloseMessage(ws.CloseNormalClosure, "closed"),
 		time.Now().Add(GracefulCloseTimeout),
 	)
 	err2 := c.Conn.Close()
-	return errors.Join(err1, err2)
+	return errors.Join(err0, err1, err2)
 }
 
 func (c *Conn) LocalAddr() net.Addr {


### PR DESCRIPTION
Fixes a hang in transport tests observed in CI.