### PR TITLE
fix(config): emit fx DI registration events at debug level

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"slices"
 	"time"
@@ -292,9 +293,11 @@ func (cfg *Config) makeAutoNATV2Host() (host.Host, error) {
 func (cfg *Config) addTransports() ([]fx.Option, error) {
 	fxopts := []fx.Option{
 		fx.WithLogger(func() fxevent.Logger {
-			return &fxevent.SlogLogger{
+			l := &fxevent.SlogLogger{
 				Logger: log.With("system", "fx"),
 			}
+			l.UseLogLevel(slog.LevelDebug)
+			return l
 		}),
 		fx.Provide(fx.Annotate(tptu.New, fx.ParamTags(`name:"security"`))),
 		fx.Supply(cfg.Muxers),


### PR DESCRIPTION
`fxevent.SlogLogger` defaults to `slog.LevelInfo` for non-error events (`Provided`, `Supplied`, `Replaced`, etc.), so each constructor in the host's DI graph emits an INFO line at `host.New(...)`, appro 70 lines per host construction under logger `p2p-config`.

Move them to DEBUG via `UseLogLevel`. Errors keep their default ERROR level. Graph remains available via `GOLOG_LOG_LEVEL=p2p-config=debug`.