### PR TITLE
fix(webrtc): cap remote addresses per ufrag

### DIFF
--- a/p2p/transport/webrtc/udpmux/mux.go
+++ b/p2p/transport/webrtc/udpmux/mux.go
@@ -25,6 +25,12 @@ var log = logging.Logger("webrtc-udpmux")
 // used to decide the packet size on the write path.
 const ReceiveBufSize = 1500
 
+// maxAddrsPerUfrag bounds the number of remote addresses we will track for a
+// single ufrag. ICE typically advertises a handful of candidates per session
+// (host + server-reflexive + relay, per IP family); 32 leaves comfortable
+// headroom while keeping the per-ufrag bookkeeping bounded.
+const maxAddrsPerUfrag = 32
+
 type Candidate struct {
 	Ufrag string
 	Addr  *net.UDPAddr
@@ -289,6 +295,12 @@ func (mux *UDPMux) getOrCreateConn(ufrag string, isIPv6 bool, _ *UDPMux, addr ne
 	defer mux.mx.Unlock()
 
 	if conn, ok := mux.ufragMap[key]; ok {
+		// Cap per-ufrag address tracking. Once we have already associated
+		// maxAddrsPerUfrag addresses with this connection, ignore further
+		// candidates rather than letting the bookkeeping grow unbounded.
+		if len(mux.ufragAddrMap[key]) >= maxAddrsPerUfrag {
+			return false, conn
+		}
 		mux.addrMap[addr.String()] = conn
 		mux.ufragAddrMap[key] = append(mux.ufragAddrMap[key], addr)
 		return false, conn

--- a/p2p/transport/webrtc/udpmux/mux_test.go
+++ b/p2p/transport/webrtc/udpmux/mux_test.go
@@ -248,6 +248,54 @@ func TestMuxedConnection(t *testing.T) {
 	require.Empty(t, addrUfragMap)
 }
 
+func TestAddrsPerUfragCap(t *testing.T) {
+	c := newPacketConn(t)
+	m := NewUDPMux(c)
+	m.Start()
+	defer m.Close()
+
+	const ufrag = "a"
+
+	// First call creates the connection. Subsequent calls below the cap each
+	// add the new address to the per-ufrag tracking.
+	base := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1}
+	_, err := m.GetConn(ufrag, base)
+	require.NoError(t, err)
+
+	for i := 2; i <= maxAddrsPerUfrag; i++ {
+		addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: i}
+		_, err := m.GetConn(ufrag, addr)
+		require.NoError(t, err)
+	}
+
+	key := ufragConnKey{ufrag: ufrag, isIPv6: false}
+	m.mx.Lock()
+	require.Len(t, m.ufragAddrMap[key], maxAddrsPerUfrag)
+	require.Len(t, m.addrMap, maxAddrsPerUfrag)
+	m.mx.Unlock()
+
+	// Past the cap, additional addresses still resolve to the same connection
+	// but do not extend the tracking maps.
+	for i := maxAddrsPerUfrag + 1; i <= maxAddrsPerUfrag+10; i++ {
+		addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: i}
+		_, err := m.GetConn(ufrag, addr)
+		require.NoError(t, err)
+	}
+
+	m.mx.Lock()
+	require.Len(t, m.ufragAddrMap[key], maxAddrsPerUfrag)
+	require.Len(t, m.addrMap, maxAddrsPerUfrag)
+	m.mx.Unlock()
+
+	// Cleanup releases the cap, so a second ufrag can populate freely.
+	m.RemoveConnByUfrag(ufrag)
+
+	m.mx.Lock()
+	require.Empty(t, m.ufragAddrMap[key])
+	require.Empty(t, m.addrMap)
+	m.mx.Unlock()
+}
+
 func TestRemovingUfragClosesConn(t *testing.T) {
 	c := newPacketConn(t)
 	m := NewUDPMux(c)


### PR DESCRIPTION
### Why 

Kubo's default `Addresses.Swarm` includes `/ip4/0.0.0.0/udp/4001/webrtc-direct`,
we should cap this to protect long running nodes.

IIUC this is high enough to never impact real STUN operations, but low enough to make certain fun activities unfeasible.

### Why reject-new instead of FIFO or LRU

FIFO or LRU would let fresh STUN packets evict known-good `addrMap` entries. Reject-new keeps tracked addresses stable, no real peer should eat up more than 32.

> [!NOTE]
> Filed as part of [_Kubo_](https://github.com/ipfs/kubo) maintenance:
> - https://github.com/ipshipyard/roadmaps/issues/50