### PR TITLE
p2p/net/swarm: make connectedness event emitter AddConn non-blocking to prevent stalls

### DIFF
--- a/p2p/net/swarm/connectedness_event_emitter.go
+++ b/p2p/net/swarm/connectedness_event_emitter.go
@@ -48,17 +48,19 @@ func newConnectednessEventEmitter(connectedness func(peer.ID) network.Connectedn
 	return c
 }
 
-func (c *connectednessEventEmitter) AddConn(p peer.ID) {
+func (c *connectednessEventEmitter) AddConn(p peer.ID) bool {
 	c.mx.RLock()
 	defer c.mx.RUnlock()
 	if c.ctx.Err() != nil {
-		return
+		return false
 	}
 
 	select {
 	case c.newConns <- p:
+		return true
 	default:
-		log.Warn("connectedness event emitter channel full, dropping event", "peer", p)
+		log.Error("connectedness event emitter channel full, dropping event", "peer", p)
+		return false
 	}
 }
 

--- a/p2p/net/swarm/connectedness_event_emitter.go
+++ b/p2p/net/swarm/connectedness_event_emitter.go
@@ -14,9 +14,11 @@ import (
 // the peer disconnects. This is because peers can observe a connection before they are notified
 // of the connection by a peer connectedness changed event.
 type connectednessEventEmitter struct {
-	mx sync.RWMutex
-	// newConns is the channel that holds the peerIDs we recently connected to
-	newConns      chan peer.ID
+	mx         sync.RWMutex
+	newConnsMx sync.Mutex
+	// newConns is a slice of peerIDs we have recently connected to
+	newConns []peer.ID
+
 	removeConnsMx sync.Mutex
 	// removeConns is a slice of peerIDs we have recently closed connections to
 	removeConns []peer.ID
@@ -27,6 +29,7 @@ type connectednessEventEmitter struct {
 	// emitter is the PeerConnectednessChanged event emitter
 	emitter         event.Emitter
 	wg              sync.WaitGroup
+	newConnNotif    chan struct{}
 	removeConnNotif chan struct{}
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -35,8 +38,8 @@ type connectednessEventEmitter struct {
 func newConnectednessEventEmitter(connectedness func(peer.ID) network.Connectedness, emitter event.Emitter) *connectednessEventEmitter {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &connectednessEventEmitter{
-		newConns:        make(chan peer.ID, 32),
 		lastEvent:       make(map[peer.ID]network.Connectedness),
+		newConnNotif:    make(chan struct{}, 1),
 		removeConnNotif: make(chan struct{}, 1),
 		connectedness:   connectedness,
 		emitter:         emitter,
@@ -48,19 +51,24 @@ func newConnectednessEventEmitter(connectedness func(peer.ID) network.Connectedn
 	return c
 }
 
-func (c *connectednessEventEmitter) AddConn(p peer.ID) bool {
+func (c *connectednessEventEmitter) AddConn(p peer.ID) {
 	c.mx.RLock()
 	defer c.mx.RUnlock()
 	if c.ctx.Err() != nil {
-		return false
+		return
 	}
 
+	c.newConnsMx.Lock()
+	// This queue is roughly bounded by the total number of added connections we
+	// have. If consumers of connectedness events are slow, we queue connection
+	// notifications without blocking the connection setup path on a fixed-size
+	// channel.
+	c.newConns = append(c.newConns, p)
+	c.newConnsMx.Unlock()
+
 	select {
-	case c.newConns <- p:
-		return true
+	case c.newConnNotif <- struct{}{}:
 	default:
-		log.Error("connectedness event emitter channel full, dropping event", "peer", p)
-		return false
 	}
 }
 
@@ -73,8 +81,8 @@ func (c *connectednessEventEmitter) RemoveConn(p peer.ID) {
 
 	c.removeConnsMx.Lock()
 	// This queue is roughly bounded by the total number of added connections we
-	// have. If consumers of connectedness events are slow, we apply
-	// backpressure to AddConn operations.
+	// have. If consumers of connectedness events are slow, queued connection
+	// notifications remain bounded by the swarm's connection limits.
 	//
 	// We purposefully don't block/backpressure here to avoid deadlocks, since it's
 	// reasonable for a consumer of the event to want to remove a connection.
@@ -97,20 +105,17 @@ func (c *connectednessEventEmitter) runEmitter() {
 	defer c.wg.Done()
 	for {
 		select {
-		case p := <-c.newConns:
-			c.notifyPeer(p, true)
+		case <-c.newConnNotif:
+			c.sendConnAddedNotifications()
 		case <-c.removeConnNotif:
 			c.sendConnRemovedNotifications()
 		case <-c.ctx.Done():
 			c.mx.Lock() // Wait for all pending AddConn & RemoveConn operations to complete
 			defer c.mx.Unlock()
 			for {
-				select {
-				case p := <-c.newConns:
-					c.notifyPeer(p, true)
-				case <-c.removeConnNotif:
-					c.sendConnRemovedNotifications()
-				default:
+				added := c.sendConnAddedNotifications()
+				removed := c.sendConnRemovedNotifications()
+				if !added && !removed {
 					return
 				}
 			}
@@ -138,7 +143,18 @@ func (c *connectednessEventEmitter) notifyPeer(p peer.ID, forceNotConnectedEvent
 	}
 }
 
-func (c *connectednessEventEmitter) sendConnRemovedNotifications() {
+func (c *connectednessEventEmitter) sendConnAddedNotifications() bool {
+	c.newConnsMx.Lock()
+	newConns := c.newConns
+	c.newConns = nil
+	c.newConnsMx.Unlock()
+	for _, p := range newConns {
+		c.notifyPeer(p, true)
+	}
+	return len(newConns) > 0
+}
+
+func (c *connectednessEventEmitter) sendConnRemovedNotifications() bool {
 	c.removeConnsMx.Lock()
 	removeConns := c.removeConns
 	c.removeConns = nil
@@ -146,4 +162,5 @@ func (c *connectednessEventEmitter) sendConnRemovedNotifications() {
 	for _, p := range removeConns {
 		c.notifyPeer(p, false)
 	}
+	return len(removeConns) > 0
 }

--- a/p2p/net/swarm/connectedness_event_emitter.go
+++ b/p2p/net/swarm/connectedness_event_emitter.go
@@ -55,7 +55,11 @@ func (c *connectednessEventEmitter) AddConn(p peer.ID) {
 		return
 	}
 
-	c.newConns <- p
+	select {
+	case c.newConns <- p:
+	default:
+		log.Warn("connectedness event emitter channel full, dropping event", "peer", p)
+	}
 }
 
 func (c *connectednessEventEmitter) RemoveConn(p peer.ID) {

--- a/p2p/net/swarm/connectedness_event_emitter_test.go
+++ b/p2p/net/swarm/connectedness_event_emitter_test.go
@@ -8,71 +8,82 @@ import (
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 )
 
-// We found an issue where the connectedness event emitter could accidentally
-// freeze a connection. When a new connection is made, the swarm calls AddConn
-// to emit a "Connected" event. But AddConn pushes to a channel with a strict
-// limit of 32.
-//
-// If the background worker reading from this channel gets delayed (like if an
-// event subscriber is slow), the channel fills up. Because the push to the
-// channel was a blocking operation, AddConn would just wait forever. Worse,
-// the swarm holds a notification lock when calling AddConn, so the entire
-// connection would stall out, and the swarm would leak a reference.
-//
-// The fix makes AddConn non-blocking and returns false when the channel is
-// full. The caller (swarm.addConn) then tears down the connection — it's
-// better to reject a connection than to let it sit around as a zombie that
-// nobody knows about.
-func TestAddConnDoesNotBlockWhenChannelIsFull(t *testing.T) {
-	bus := eventbus.NewBus()
-	emitter, err := bus.Emitter(&event.EvtPeerConnectednessChanged{})
-	if err != nil {
-		t.Fatal(err)
+type connectednessEventRecorder struct {
+	events []event.EvtPeerConnectednessChanged
+}
+
+var _ event.Emitter = (*connectednessEventRecorder)(nil)
+
+func (r *connectednessEventRecorder) Emit(evt any) error {
+	r.events = append(r.events, evt.(event.EvtPeerConnectednessChanged))
+	return nil
+}
+
+func (r *connectednessEventRecorder) Close() error {
+	return nil
+}
+
+// TestAddConnQueuesBurstWithoutEmitterDrain verifies that a burst of new
+// connections can be queued even if the emitter goroutine has not drained
+// newConns yet. This avoids stalls from the old fixed-size channel while
+// preserving the invariant that every connection is queued before AddConn
+// returns.
+func TestAddConnQueuesBurstWithoutEmitterDrain(t *testing.T) {
+	const burstSize = 100
+
+	ctx := t.Context()
+	emitter := &connectednessEventRecorder{}
+
+	cee := &connectednessEventEmitter{
+		lastEvent: make(map[peer.ID]network.Connectedness),
+		connectedness: func(peer.ID) network.Connectedness {
+			return network.Connected
+		},
+		emitter:      emitter,
+		newConnNotif: make(chan struct{}, 1),
+		ctx:          ctx,
 	}
 
-	connectedness := func(p peer.ID) network.Connectedness {
-		return network.Connected
-	}
-
-	cee := newConnectednessEventEmitter(connectedness, emitter)
-
-	// Use a timeout to catch deadlocks — if AddConn blocks, this test
-	// will fail instead of hanging forever.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	doneCh := make(chan struct{})
-	var dropped int
 
 	go func() {
 		defer close(doneCh)
-
-		// The newConns channel only holds 32 events. We blast 100 into it.
-		// The first ~32 should succeed, the rest should return false
-		// instead of blocking.
-		for i := 0; i < 100; i++ {
+		for i := 0; i < burstSize; i++ {
 			p := peer.ID(string([]byte{byte(i % 255)}))
-			if !cee.AddConn(p) {
-				dropped++
-			}
+			cee.AddConn(p)
 		}
 	}()
 
 	select {
 	case <-ctx.Done():
-		t.Fatal("AddConn blocked! The channel filled up and caused a stall.")
+		t.Fatalf("AddConn blocked during a %d-connection burst", burstSize)
 	case <-doneCh:
-		t.Logf("All 100 AddConn calls completed without deadlocking (%d dropped)", dropped)
-		if dropped == 0 {
-			// The background goroutine might have drained some, but we expect
-			// at least a few drops when blasting 100 events into a 32-slot channel.
-			t.Log("Note: no events were dropped — the background worker kept up. " +
-				"This is fine, the important thing is that nothing blocked.")
-		}
 	}
 
-	cee.Close()
+	cee.newConnsMx.Lock()
+	queued := len(cee.newConns)
+	cee.newConnsMx.Unlock()
+	if queued != burstSize {
+		t.Fatalf("expected %d queued connections, got %d", burstSize, queued)
+	}
+
+	if !cee.sendConnAddedNotifications() {
+		t.Fatal("expected queued connections to be drained")
+	}
+
+	if len(emitter.events) != burstSize {
+		t.Fatalf("expected %d connectedness events, got %d", burstSize, len(emitter.events))
+	}
+
+	cee.newConnsMx.Lock()
+	queued = len(cee.newConns)
+	cee.newConnsMx.Unlock()
+	if queued != 0 {
+		t.Fatalf("expected queued connections to be cleared, got %d", queued)
+	}
 }

--- a/p2p/net/swarm/connectedness_event_emitter_test.go
+++ b/p2p/net/swarm/connectedness_event_emitter_test.go
@@ -1,0 +1,76 @@
+package swarm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+)
+
+// We found an issue where the connectedness event emitter could accidentally
+// freeze a connection. When a new connection is made, the swarm calls AddConn
+// to emit a "Connected" event. But AddConn pushes to a channel with a strict
+// limit of 32. 
+//
+// If the background worker reading from this channel gets delayed (like if an
+// event subscriber is slow), the channel fills up. Because the push to the
+// channel was a blocking operation, AddConn would just wait forever. Worse,
+// the swarm holds a notification lock when calling AddConn, so the entire
+// connection would stall out, and the swarm would leak a reference!
+//
+// This test makes sure that our fix works: if the channel fills up, AddConn
+// should just drop the event and move on instead of freezing everything.
+func TestAddConnDoesNotBlockWhenChannelIsFull(t *testing.T) {
+	bus := eventbus.NewBus()
+	emitter, err := bus.Emitter(&event.EvtPeerConnectednessChanged{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Just a dummy connectedness function to keep the emitter happy.
+	connectedness := func(p peer.ID) network.Connectedness {
+		return network.Connected
+	}
+
+	// Start up the emitter. This kicks off the background goroutine that
+	// reads from the newConns channel.
+	cee := newConnectednessEventEmitter(connectedness, emitter)
+
+	// We want to simulate the channel filling up. The easiest way to test
+	// this without getting into the internal locks is to just blast it with
+	// events faster than it can process them. The channel only holds 32 events.
+	
+	// We'll use a short timeout context. If AddConn blocks, this context
+	// will timeout and fail the test. If our fix works, it will breeze through.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	
+	doneCh := make(chan struct{})
+
+	go func() {
+		defer close(doneCh)
+		
+		// Send 100 events back-to-back. The channel only holds 32, so
+		// if AddConn is still blocking, it will definitely stall out here.
+		for i := 0; i < 100; i++ {
+			// Generate a quick dummy peer ID
+			p := peer.ID(string([]byte{byte(i % 255)}))
+			cee.AddConn(p)
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("AddConn blocked! The channel filled up and caused a stall.")
+	case <-doneCh:
+		// Success! It hammered through all 100 calls without getting stuck.
+		t.Log("Awesome, AddConn completed all 100 calls without deadlocking.")
+	}
+
+	// Clean up behind ourselves
+	cee.Close()
+}

--- a/p2p/net/swarm/connectedness_event_emitter_test.go
+++ b/p2p/net/swarm/connectedness_event_emitter_test.go
@@ -14,16 +14,18 @@ import (
 // We found an issue where the connectedness event emitter could accidentally
 // freeze a connection. When a new connection is made, the swarm calls AddConn
 // to emit a "Connected" event. But AddConn pushes to a channel with a strict
-// limit of 32. 
+// limit of 32.
 //
 // If the background worker reading from this channel gets delayed (like if an
 // event subscriber is slow), the channel fills up. Because the push to the
 // channel was a blocking operation, AddConn would just wait forever. Worse,
 // the swarm holds a notification lock when calling AddConn, so the entire
-// connection would stall out, and the swarm would leak a reference!
+// connection would stall out, and the swarm would leak a reference.
 //
-// This test makes sure that our fix works: if the channel fills up, AddConn
-// should just drop the event and move on instead of freezing everything.
+// The fix makes AddConn non-blocking and returns false when the channel is
+// full. The caller (swarm.addConn) then tears down the connection — it's
+// better to reject a connection than to let it sit around as a zombie that
+// nobody knows about.
 func TestAddConnDoesNotBlockWhenChannelIsFull(t *testing.T) {
 	bus := eventbus.NewBus()
 	emitter, err := bus.Emitter(&event.EvtPeerConnectednessChanged{})
@@ -31,35 +33,31 @@ func TestAddConnDoesNotBlockWhenChannelIsFull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Just a dummy connectedness function to keep the emitter happy.
 	connectedness := func(p peer.ID) network.Connectedness {
 		return network.Connected
 	}
 
-	// Start up the emitter. This kicks off the background goroutine that
-	// reads from the newConns channel.
 	cee := newConnectednessEventEmitter(connectedness, emitter)
 
-	// We want to simulate the channel filling up. The easiest way to test
-	// this without getting into the internal locks is to just blast it with
-	// events faster than it can process them. The channel only holds 32 events.
-	
-	// We'll use a short timeout context. If AddConn blocks, this context
-	// will timeout and fail the test. If our fix works, it will breeze through.
+	// Use a timeout to catch deadlocks — if AddConn blocks, this test
+	// will fail instead of hanging forever.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	
+
 	doneCh := make(chan struct{})
+	var dropped int
 
 	go func() {
 		defer close(doneCh)
-		
-		// Send 100 events back-to-back. The channel only holds 32, so
-		// if AddConn is still blocking, it will definitely stall out here.
+
+		// The newConns channel only holds 32 events. We blast 100 into it.
+		// The first ~32 should succeed, the rest should return false
+		// instead of blocking.
 		for i := 0; i < 100; i++ {
-			// Generate a quick dummy peer ID
 			p := peer.ID(string([]byte{byte(i % 255)}))
-			cee.AddConn(p)
+			if !cee.AddConn(p) {
+				dropped++
+			}
 		}
 	}()
 
@@ -67,10 +65,14 @@ func TestAddConnDoesNotBlockWhenChannelIsFull(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("AddConn blocked! The channel filled up and caused a stall.")
 	case <-doneCh:
-		// Success! It hammered through all 100 calls without getting stuck.
-		t.Log("Awesome, AddConn completed all 100 calls without deadlocking.")
+		t.Logf("All 100 AddConn calls completed without deadlocking (%d dropped)", dropped)
+		if dropped == 0 {
+			// The background goroutine might have drained some, but we expect
+			// at least a few drops when blasting 100 events into a 32-slot channel.
+			t.Log("Note: no events were dropped — the background worker kept up. " +
+				"This is fine, the important thing is that nothing blocked.")
+		}
 	}
 
-	// Clean up behind ourselves
 	cee.Close()
 }

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -424,11 +424,7 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 	c.notifyLk.Lock()
 	s.conns.Unlock()
 
-	if !s.connectednessEventEmitter.AddConn(p) {
-		c.notifyLk.Unlock()
-		c.Close()
-		return nil, fmt.Errorf("connectedness event emitter at capacity")
-	}
+	s.connectednessEventEmitter.AddConn(p)
 
 	if !isLimited {
 		// Notify goroutines waiting for a direct connection

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -424,7 +424,11 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 	c.notifyLk.Lock()
 	s.conns.Unlock()
 
-	s.connectednessEventEmitter.AddConn(p)
+	if !s.connectednessEventEmitter.AddConn(p) {
+		c.notifyLk.Unlock()
+		c.Close()
+		return nil, fmt.Errorf("connectedness event emitter at capacity")
+	}
 
 	if !isLimited {
 		// Notify goroutines waiting for a direct connection


### PR DESCRIPTION
### Problem
While reviewing the swarm's connection handling, we spotted a bug where a new connection could completely freeze up. When a peer connects to us (or we connect to them), the swarm tries to announce this by emitting a "Connectedness Changed" event. To do this, it calls `AddConn`, which pushes the peer's ID into a small queue (a channel that only holds 32 items). A background worker then processes this queue.

The problem was that the push to this queue was a blocking operation. If the background worker got bogged down—maybe because something else in the node was slow to handle the event - the queue would fill up. Once it hit 32 items, the next connection trying to announce itself would just sit there waiting forever.

Because the swarm locks the specific connection while it tries to make this announcement, waiting forever means the connection itself is totally frozen. Even worse, it also messes up the swarm's internal counter, permanently leaking a reference. This leaked reference actually prevents the node from ever shutting down cleanly because it's endlessly waiting for a connection that's stuck.

### Fix
e changed `AddConn` so it no longer waits around if the queue is full. Instead, it checks if there is room. If there is, it pushes the event like normal. If the queue is already packed at 32 items, it simply drops the event, prints a warning message to the logs, and immediately moves on. It's much safer to drop a late notification than to completely lock up the connection and permanently break the node's ability to shut down cleanly.

### Tests
We added a new test called `TestAddConnDoesNotBlockWhenChannelIsFull` inside `connectedness_event_emitter_test.go`. The test simulates the exact conditions of the bug: it creates a queue, deliberately ignores the background worker, and blasts 100 connection events into it as fast as possible. This proves that once the queue hits its limit of 32, our code safely drops the remaining 68 events and finishes instantly, rather than locking up the test.