### PR TITLE
refactor(swarm): move the connected / disconnected callbacks into the events emitter

### DIFF
--- a/p2p/net/swarm/connectedness_event_emitter.go
+++ b/p2p/net/swarm/connectedness_event_emitter.go
@@ -9,10 +9,22 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// connectednessEventEmitter emits PeerConnectednessChanged events.
+// connectednessEventEmitter emits PeerConnectednessChanged events and dispatches
+// per-conn Connected / Disconnected callbacks supplied by the owner.
+//
 // We ensure that for any peer we connected to we always sent atleast 1 NotConnected Event after
 // the peer disconnects. This is because peers can observe a connection before they are notified
 // of the connection by a peer connectedness changed event.
+//
+// For the per-conn callbacks, we guarantee that for a given *Conn,
+// onDisconnected never fires before the corresponding onConnected has finished.
+// RemoveConn that arrives before AddConn for the same conn is "parked" until
+// AddConn dispatches onConnected, and then onDisconnected is dispatched
+// immediately after.
+//
+// Callers that want a non-blocking close (e.g. doClose) invoke RemoveConn
+// from a goroutine; AddConn always runs onConnected synchronously so callers
+// see Connected fire before they continue.
 type connectednessEventEmitter struct {
 	// newConns is the channel that holds the peerIDs we recently connected to
 	newConns      chan peer.ID
@@ -25,6 +37,11 @@ type connectednessEventEmitter struct {
 	lastEvent map[peer.ID]network.Connectedness
 	// connectedness is the function that gives the peers current connectedness state
 	connectedness func(peer.ID) network.Connectedness
+	// onConnected fires synchronously when a conn becomes connected.
+	onConnected func(*Conn)
+	// onDisconnected fires when a conn is removed; for the parked-RemoveConn
+	// case it runs from inside AddConn after onConnected has completed.
+	onDisconnected func(*Conn)
 	// emitter is the PeerConnectednessChanged event emitter
 	emitter event.Emitter
 	// closeMu serializes the (closed-check + wg.Add) pair against Close. It is
@@ -38,25 +55,41 @@ type connectednessEventEmitter struct {
 	loopWG sync.WaitGroup
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// notifsLk guards the connected and pendingDisconnect maps.
+	// onConnected / onDisconnected are invoked OUTSIDE this lock so concurrent
+	// conns don't serialize.
+	notifsLk          sync.Mutex
+	connected         map[*Conn]struct{}
+	pendingDisconnect map[*Conn]struct{}
 }
 
-func newConnectednessEventEmitter(connectedness func(peer.ID) network.Connectedness, emitter event.Emitter) *connectednessEventEmitter {
+func newConnectednessEventEmitter(
+	connectedness func(peer.ID) network.Connectedness,
+	emitter event.Emitter,
+	onConnected func(*Conn),
+	onDisconnected func(*Conn),
+) *connectednessEventEmitter {
 	loopCtx, loopCancel := context.WithCancel(context.Background())
 	c := &connectednessEventEmitter{
-		newConns:        make(chan peer.ID, 32),
-		lastEvent:       make(map[peer.ID]network.Connectedness),
-		removeConnNotif: make(chan struct{}, 1),
-		connectedness:   connectedness,
-		emitter:         emitter,
-		ctx:             loopCtx,
-		cancel:          loopCancel,
+		newConns:          make(chan peer.ID, 32),
+		lastEvent:         make(map[peer.ID]network.Connectedness),
+		removeConnNotif:   make(chan struct{}, 1),
+		connectedness:     connectedness,
+		emitter:           emitter,
+		ctx:               loopCtx,
+		cancel:            loopCancel,
+		connected:         make(map[*Conn]struct{}),
+		pendingDisconnect: make(map[*Conn]struct{}),
+		onConnected:       onConnected,
+		onDisconnected:    onDisconnected,
 	}
 	c.loopWG.Add(1)
 	go c.runEmitter()
 	return c
 }
 
-func (c *connectednessEventEmitter) AddConn(p peer.ID) {
+func (c *connectednessEventEmitter) AddConn(conn *Conn) {
 	c.closeMu.Lock()
 	if c.closed {
 		c.closeMu.Unlock()
@@ -66,10 +99,29 @@ func (c *connectednessEventEmitter) AddConn(p peer.ID) {
 	c.closeMu.Unlock()
 	defer c.wg.Done()
 
-	c.newConns <- p
+	c.newConns <- conn.RemotePeer()
+
+	// Dispatch onConnected before touching notifsLk so that a concurrent
+	// RemoveConn cannot observe `connected[conn]` and fire onDisconnected
+	// while onConnected is still in-flight.
+	c.onConnected(conn)
+
+	var dispatchDisconnect bool
+	c.notifsLk.Lock()
+	if _, parked := c.pendingDisconnect[conn]; parked {
+		delete(c.pendingDisconnect, conn)
+		dispatchDisconnect = true
+	} else {
+		c.connected[conn] = struct{}{}
+	}
+	c.notifsLk.Unlock()
+
+	if dispatchDisconnect {
+		c.onDisconnected(conn)
+	}
 }
 
-func (c *connectednessEventEmitter) RemoveConn(p peer.ID) {
+func (c *connectednessEventEmitter) RemoveConn(conn *Conn) {
 	c.closeMu.Lock()
 	if c.closed {
 		c.closeMu.Unlock()
@@ -84,15 +136,31 @@ func (c *connectednessEventEmitter) RemoveConn(p peer.ID) {
 	// have. If consumers of connectedness events are slow, we apply
 	// backpressure to AddConn operations.
 	//
-	// We purposefully don't block/backpressure here to avoid deadlocks, since it's
-	// reasonable for a consumer of the event to want to remove a connection.
-	c.removeConns = append(c.removeConns, p)
-
+	// We purposefully don't block/backpressure here to avoid deadlocks. If this were
+	// a channel and an event consumer closed the connection this would deadlock on a
+	// push to a full channel.
+	c.removeConns = append(c.removeConns, conn.RemotePeer())
 	c.removeConnsMx.Unlock()
 
 	select {
 	case c.removeConnNotif <- struct{}{}:
 	default:
+	}
+
+	var dispatchDisconnect bool
+	c.notifsLk.Lock()
+	if _, ok := c.connected[conn]; ok {
+		delete(c.connected, conn)
+		dispatchDisconnect = true
+	} else {
+		// RemoveConn arrived before AddConn finished dispatching onConnected.
+		// Park; AddConn will dispatch onDisconnected once onConnected is done.
+		c.pendingDisconnect[conn] = struct{}{}
+	}
+	c.notifsLk.Unlock()
+
+	if dispatchDisconnect {
+		c.onDisconnected(conn)
 	}
 }
 

--- a/p2p/net/swarm/connectedness_event_emitter.go
+++ b/p2p/net/swarm/connectedness_event_emitter.go
@@ -14,56 +14,70 @@ import (
 // the peer disconnects. This is because peers can observe a connection before they are notified
 // of the connection by a peer connectedness changed event.
 type connectednessEventEmitter struct {
-	mx sync.RWMutex
 	// newConns is the channel that holds the peerIDs we recently connected to
 	newConns      chan peer.ID
 	removeConnsMx sync.Mutex
 	// removeConns is a slice of peerIDs we have recently closed connections to
 	removeConns []peer.ID
+	// removeConnNotif is used to notify the event loop on an addition to `removeConns`.
+	removeConnNotif chan struct{}
 	// lastEvent is the last connectedness event sent for a particular peer.
 	lastEvent map[peer.ID]network.Connectedness
 	// connectedness is the function that gives the peers current connectedness state
 	connectedness func(peer.ID) network.Connectedness
 	// emitter is the PeerConnectednessChanged event emitter
-	emitter         event.Emitter
-	wg              sync.WaitGroup
-	removeConnNotif chan struct{}
-	ctx             context.Context
-	cancel          context.CancelFunc
+	emitter event.Emitter
+	// closeMu serializes the (closed-check + wg.Add) pair against Close. It is
+	// only held across that pair, never during the actual dispatch work, so
+	// Add/Remove operations across different conns still run concurrently.
+	closeMu sync.Mutex
+	closed  bool
+	wg      sync.WaitGroup
+	// loopCtx / loopWG track the runEmitter goroutine separately from the
+	// in-flight Add/Remove operations.
+	loopWG sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func newConnectednessEventEmitter(connectedness func(peer.ID) network.Connectedness, emitter event.Emitter) *connectednessEventEmitter {
-	ctx, cancel := context.WithCancel(context.Background())
+	loopCtx, loopCancel := context.WithCancel(context.Background())
 	c := &connectednessEventEmitter{
 		newConns:        make(chan peer.ID, 32),
 		lastEvent:       make(map[peer.ID]network.Connectedness),
 		removeConnNotif: make(chan struct{}, 1),
 		connectedness:   connectedness,
 		emitter:         emitter,
-		ctx:             ctx,
-		cancel:          cancel,
+		ctx:             loopCtx,
+		cancel:          loopCancel,
 	}
-	c.wg.Add(1)
+	c.loopWG.Add(1)
 	go c.runEmitter()
 	return c
 }
 
 func (c *connectednessEventEmitter) AddConn(p peer.ID) {
-	c.mx.RLock()
-	defer c.mx.RUnlock()
-	if c.ctx.Err() != nil {
+	c.closeMu.Lock()
+	if c.closed {
+		c.closeMu.Unlock()
 		return
 	}
+	c.wg.Add(1)
+	c.closeMu.Unlock()
+	defer c.wg.Done()
 
 	c.newConns <- p
 }
 
 func (c *connectednessEventEmitter) RemoveConn(p peer.ID) {
-	c.mx.RLock()
-	defer c.mx.RUnlock()
-	if c.ctx.Err() != nil {
+	c.closeMu.Lock()
+	if c.closed {
+		c.closeMu.Unlock()
 		return
 	}
+	c.wg.Add(1)
+	c.closeMu.Unlock()
+	defer c.wg.Done()
 
 	c.removeConnsMx.Lock()
 	// This queue is roughly bounded by the total number of added connections we
@@ -83,12 +97,16 @@ func (c *connectednessEventEmitter) RemoveConn(p peer.ID) {
 }
 
 func (c *connectednessEventEmitter) Close() {
+	c.closeMu.Lock()
+	c.closed = true
+	c.closeMu.Unlock()
+	c.wg.Wait() // safe: closed=true blocks any new wg.Add
 	c.cancel()
-	c.wg.Wait()
+	c.loopWG.Wait()
 }
 
 func (c *connectednessEventEmitter) runEmitter() {
-	defer c.wg.Done()
+	defer c.loopWG.Done()
 	for {
 		select {
 		case p := <-c.newConns:
@@ -96,8 +114,6 @@ func (c *connectednessEventEmitter) runEmitter() {
 		case <-c.removeConnNotif:
 			c.sendConnRemovedNotifications()
 		case <-c.ctx.Done():
-			c.mx.Lock() // Wait for all pending AddConn & RemoveConn operations to complete
-			defer c.mx.Unlock()
 			for {
 				select {
 				case p := <-c.newConns:

--- a/p2p/net/swarm/connectedness_event_emitter_test.go
+++ b/p2p/net/swarm/connectedness_event_emitter_test.go
@@ -1,0 +1,215 @@
+package swarm
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/libp2p/go-libp2p/core/transport"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+
+	"github.com/stretchr/testify/require"
+)
+
+// peerOnlyConn satisfies transport.CapableConn but only answers RemotePeer().
+// All other interface methods are nil and will panic if called — the emitter
+// only ever asks for the peer ID.
+type peerOnlyConn struct {
+	transport.CapableConn
+	p peer.ID
+}
+
+func (p *peerOnlyConn) RemotePeer() peer.ID { return p.p }
+
+func newTestConn(t *testing.T) *Conn {
+	t.Helper()
+	return &Conn{conn: &peerOnlyConn{p: test.RandPeerIDFatal(t)}}
+}
+
+type notifEvent struct {
+	conn  *Conn
+	isAdd bool // true = Connected, false = Disconnected
+}
+
+// recordingCallbacks returns onConnected and onDisconnected callbacks that
+// append to a shared slice, plus a snapshot getter.
+func recordingCallbacks() (onConnected func(*Conn), onDisconnected func(*Conn), get func() []notifEvent) {
+	var mu sync.Mutex
+	events := []notifEvent{}
+	onConnected = func(c *Conn) {
+		mu.Lock()
+		events = append(events, notifEvent{conn: c, isAdd: true})
+		mu.Unlock()
+	}
+	onDisconnected = func(c *Conn) {
+		mu.Lock()
+		events = append(events, notifEvent{conn: c, isAdd: false})
+		mu.Unlock()
+	}
+	get = func() []notifEvent {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]notifEvent, len(events))
+		copy(out, events)
+		return out
+	}
+	return
+}
+
+func newEmitterForTest(t *testing.T, onConnected, onDisconnected func(*Conn)) *connectednessEventEmitter {
+	t.Helper()
+	bus := eventbus.NewBus()
+	em, err := bus.Emitter(new(event.EvtPeerConnectednessChanged))
+	require.NoError(t, err)
+	connectedness := func(peer.ID) network.Connectedness { return network.NotConnected }
+	e := newConnectednessEventEmitter(connectedness, em, onConnected, onDisconnected)
+	t.Cleanup(func() { e.Close() })
+	return e
+}
+
+// TestEmitter_RemoveConnBeforeAddConn verifies that a RemoveConn arriving
+// before AddConn is parked, and the deferred Disconnected fires only after
+// AddConn has dispatched Connected, in the right order.
+func TestEmitter_RemoveConnBeforeAddConn(t *testing.T) {
+	onConnected, onDisconnected, events := recordingCallbacks()
+	e := newEmitterForTest(t, onConnected, onDisconnected)
+	c := newTestConn(t)
+
+	e.RemoveConn(c)
+
+	e.notifsLk.Lock()
+	_, parked := e.pendingDisconnect[c]
+	e.notifsLk.Unlock()
+	require.True(t, parked, "RemoveConn before AddConn should park")
+	require.Empty(t, events(), "no Notifiee callbacks fire from a parked RemoveConn")
+
+	e.AddConn(c)
+
+	// Disconnected is dispatched from a goroutine in the parked path.
+	require.Eventually(t, func() bool { return len(events()) == 2 }, time.Second, time.Millisecond)
+
+	got := events()
+	require.Len(t, got, 2)
+	require.True(t, got[0].isAdd, "first event must be Connected")
+	require.False(t, got[1].isAdd, "second event must be Disconnected")
+	require.Same(t, c, got[0].conn)
+	require.Same(t, c, got[1].conn)
+
+	e.notifsLk.Lock()
+	require.Empty(t, e.pendingDisconnect)
+	require.Empty(t, e.connected)
+	e.notifsLk.Unlock()
+}
+
+// TestEmitter_NormalOrder verifies the standard AddConn-then-RemoveConn flow
+// dispatches one Connected and one Disconnected, and leaves no leaked state.
+func TestEmitter_NormalOrder(t *testing.T) {
+	onConnected, onDisconnected, events := recordingCallbacks()
+	e := newEmitterForTest(t, onConnected, onDisconnected)
+	c := newTestConn(t)
+
+	e.AddConn(c)
+
+	e.notifsLk.Lock()
+	_, conn := e.connected[c]
+	e.notifsLk.Unlock()
+	require.True(t, conn, "AddConn should mark the conn as connected")
+
+	e.RemoveConn(c)
+
+	got := events()
+	require.Len(t, got, 2)
+	require.True(t, got[0].isAdd)
+	require.False(t, got[1].isAdd)
+
+	e.notifsLk.Lock()
+	require.Empty(t, e.connected)
+	require.Empty(t, e.pendingDisconnect)
+	e.notifsLk.Unlock()
+}
+
+// TestEmitter_ConcurrentAddRemoveOrdering exercises many conns in parallel,
+// each with a randomized AddConn/RemoveConn order. For every conn, we must see
+// exactly one Connected followed by exactly one Disconnected (never reversed),
+// and no map entries should leak.
+func TestEmitter_ConcurrentAddRemoveOrdering(t *testing.T) {
+	const N = 200
+
+	var perConnMu sync.Mutex
+	connectedSeen := make(map[*Conn]int)
+	disconnectedSeen := make(map[*Conn]int)
+	var orderViolations atomic.Int64
+
+	onConnected := func(c *Conn) {
+		perConnMu.Lock()
+		if disconnectedSeen[c] > 0 {
+			orderViolations.Add(1)
+		}
+		connectedSeen[c]++
+		perConnMu.Unlock()
+	}
+	onDisconnected := func(c *Conn) {
+		perConnMu.Lock()
+		if connectedSeen[c] == 0 {
+			orderViolations.Add(1)
+		}
+		disconnectedSeen[c]++
+		perConnMu.Unlock()
+	}
+	e := newEmitterForTest(t, onConnected, onDisconnected)
+
+	conns := make([]*Conn, N)
+	for i := range conns {
+		conns[i] = newTestConn(t)
+	}
+
+	var wg sync.WaitGroup
+	for i := range N {
+		c := conns[i]
+		addFirst := rand.Intn(2) == 0
+		jitter := time.Duration(rand.Intn(1000)) * time.Microsecond
+		wg.Add(2)
+		if addFirst {
+			go func() { defer wg.Done(); e.AddConn(c) }()
+			go func() {
+				defer wg.Done()
+				time.Sleep(jitter)
+				e.RemoveConn(c)
+			}()
+		} else {
+			go func() { defer wg.Done(); e.RemoveConn(c) }()
+			go func() {
+				defer wg.Done()
+				time.Sleep(jitter)
+				e.AddConn(c)
+			}()
+		}
+	}
+	wg.Wait()
+
+	// Parked-RemoveConn dispatches Disconnected from a goroutine, so wait for
+	// every conn to have seen one.
+	require.Eventually(t, func() bool {
+		perConnMu.Lock()
+		defer perConnMu.Unlock()
+		for _, c := range conns {
+			if connectedSeen[c] != 1 || disconnectedSeen[c] != 1 {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 5*time.Millisecond)
+
+	require.Zero(t, orderViolations.Load(), "no per-conn ordering violations expected")
+
+	e.notifsLk.Lock()
+	require.Empty(t, e.connected, "connected map should drain")
+	require.Empty(t, e.pendingDisconnect, "pendingDisconnect map should drain")
+	e.notifsLk.Unlock()
+}

--- a/p2p/net/swarm/connection_events_emitter.go
+++ b/p2p/net/swarm/connection_events_emitter.go
@@ -9,6 +9,18 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+type peerConnectednessEventType int
+
+const (
+	removeConnEvent peerConnectednessEventType = iota
+	addConnEvent
+)
+
+type peerConnectednessEvent struct {
+	PeerID peer.ID
+	Type   peerConnectednessEventType
+}
+
 // connectionEventsEmitter emits PeerConnectednessChanged events and dispatches
 // per-conn Connected / Disconnected callbacks supplied by the owner.
 //
@@ -26,15 +38,11 @@ import (
 // from a goroutine; AddConn always runs onConnected synchronously so callers
 // see Connected fire before they continue.
 type connectionEventsEmitter struct {
-	// newConns is the channel that holds the peerIDs we recently connected to
-	newConns      chan peer.ID
-	removeConnsMx sync.Mutex
-	// removeConns is a slice of peerIDs we have recently closed connections to
-	removeConns []peer.ID
-	// removeConnNotif is used to notify the event loop on an addition to `removeConns`.
-	removeConnNotif chan struct{}
-	// lastEvent is the last connectedness event sent for a particular peer.
-	lastEvent map[peer.ID]network.Connectedness
+	// peerConnectednessCh carries add and remove events to the run loop, which
+	// uses them to emit PeerConnectednessChanged events.
+	peerConnectednessCh chan peerConnectednessEvent
+	// lastConnectednessEvent is the last connectedness event sent for a particular peer.
+	lastConnectednessEvent map[peer.ID]network.Connectedness
 	// connectedness is the function that gives the peers current connectedness state
 	connectedness func(peer.ID) network.Connectedness
 	// onConnected fires synchronously when a conn becomes connected.
@@ -72,17 +80,16 @@ func newConnectionEventsEmitter(
 ) *connectionEventsEmitter {
 	loopCtx, loopCancel := context.WithCancel(context.Background())
 	c := &connectionEventsEmitter{
-		newConns:          make(chan peer.ID, 32),
-		lastEvent:         make(map[peer.ID]network.Connectedness),
-		removeConnNotif:   make(chan struct{}, 1),
-		connectedness:     connectedness,
-		emitter:           emitter,
-		ctx:               loopCtx,
-		cancel:            loopCancel,
-		connected:         make(map[*Conn]struct{}),
-		pendingDisconnect: make(map[*Conn]struct{}),
-		onConnected:       onConnected,
-		onDisconnected:    onDisconnected,
+		peerConnectednessCh:    make(chan peerConnectednessEvent, 32),
+		lastConnectednessEvent: make(map[peer.ID]network.Connectedness),
+		connectedness:          connectedness,
+		emitter:                emitter,
+		ctx:                    loopCtx,
+		cancel:                 loopCancel,
+		connected:              make(map[*Conn]struct{}),
+		pendingDisconnect:      make(map[*Conn]struct{}),
+		onConnected:            onConnected,
+		onDisconnected:         onDisconnected,
 	}
 	c.loopWG.Add(1)
 	go c.runEmitter()
@@ -99,7 +106,10 @@ func (c *connectionEventsEmitter) AddConn(conn *Conn) {
 	c.closeMu.Unlock()
 	defer c.wg.Done()
 
-	c.newConns <- conn.RemotePeer()
+	c.peerConnectednessCh <- peerConnectednessEvent{
+		PeerID: conn.RemotePeer(),
+		Type:   addConnEvent,
+	}
 
 	// Dispatch onConnected before touching notifsLk so that a concurrent
 	// RemoveConn cannot observe `connected[conn]` and fire onDisconnected
@@ -108,7 +118,7 @@ func (c *connectionEventsEmitter) AddConn(conn *Conn) {
 
 	var dispatchDisconnect bool
 	c.notifsLk.Lock()
-	if _, parked := c.pendingDisconnect[conn]; parked {
+	if _, ok := c.pendingDisconnect[conn]; ok {
 		delete(c.pendingDisconnect, conn)
 		dispatchDisconnect = true
 	} else {
@@ -121,6 +131,14 @@ func (c *connectionEventsEmitter) AddConn(conn *Conn) {
 	}
 }
 
+// RemoveConn emits connection close events.
+//
+// Callers reachable from a PeerConnectednessChanged event subscriber
+// or a Notifiee.Disconnected handler MUST invoke this async from a goroutine: a
+// synchronous call from a subscriber/handler can deadlock the run loop (the
+// loop is waiting for the subscriber, the subscriber is waiting on the channel
+// push). swarm_conn.go's doClose dispatches RemoveConn from a goroutine for
+// this reason.
 func (c *connectionEventsEmitter) RemoveConn(conn *Conn) {
 	c.closeMu.Lock()
 	if c.closed {
@@ -131,20 +149,9 @@ func (c *connectionEventsEmitter) RemoveConn(conn *Conn) {
 	c.closeMu.Unlock()
 	defer c.wg.Done()
 
-	c.removeConnsMx.Lock()
-	// This queue is roughly bounded by the total number of added connections we
-	// have. If consumers of connectedness events are slow, we apply
-	// backpressure to AddConn operations.
-	//
-	// We purposefully don't block/backpressure here to avoid deadlocks. If this were
-	// a channel and an event consumer closed the connection this would deadlock on a
-	// push to a full channel.
-	c.removeConns = append(c.removeConns, conn.RemotePeer())
-	c.removeConnsMx.Unlock()
-
-	select {
-	case c.removeConnNotif <- struct{}{}:
-	default:
+	c.peerConnectednessCh <- peerConnectednessEvent{
+		PeerID: conn.RemotePeer(),
+		Type:   removeConnEvent,
 	}
 
 	var dispatchDisconnect bool
@@ -177,17 +184,13 @@ func (c *connectionEventsEmitter) runEmitter() {
 	defer c.loopWG.Done()
 	for {
 		select {
-		case p := <-c.newConns:
-			c.notifyPeer(p, true)
-		case <-c.removeConnNotif:
-			c.sendConnRemovedNotifications()
+		case pce := <-c.peerConnectednessCh:
+			c.notifyPeer(pce)
 		case <-c.ctx.Done():
 			for {
 				select {
-				case p := <-c.newConns:
-					c.notifyPeer(p, true)
-				case <-c.removeConnNotif:
-					c.sendConnRemovedNotifications()
+				case pce := <-c.peerConnectednessCh:
+					c.notifyPeer(pce)
 				default:
 					return
 				}
@@ -196,32 +199,26 @@ func (c *connectionEventsEmitter) runEmitter() {
 	}
 }
 
-// notifyPeer sends the peer connectedness event using the emitter.
-// Use forceNotConnectedEvent = true to send a NotConnected event even if
-// no Connected event was sent for this peer.
-// In case a peer is disconnected before we sent the Connected event, we still
-// send the Disconnected event because a connection to the peer can be observed
-// in such cases.
-func (c *connectionEventsEmitter) notifyPeer(p peer.ID, forceNotConnectedEvent bool) {
-	oldState := c.lastEvent[p]
-	c.lastEvent[p] = c.connectedness(p)
-	if c.lastEvent[p] == network.NotConnected {
-		delete(c.lastEvent, p)
+// notifyPeer emits a PeerConnectednessChanged event when the peer's
+// connectedness has changed since the last emit. For add events, it additionally
+// emits NotConnected if the peer is already disconnected by the time we get
+// here (i.e. a RemoveConn raced ahead of the matching AddConn): the peer may
+// have observed the connection, so subscribers must still learn about it.
+func (c *connectionEventsEmitter) notifyPeer(pce peerConnectednessEvent) {
+	p := pce.PeerID
+	forceNotConnectedEvent := pce.Type == addConnEvent
+
+	oldState := c.lastConnectednessEvent[p]
+	newState := c.connectedness(p)
+	c.lastConnectednessEvent[p] = newState
+	if c.lastConnectednessEvent[p] == network.NotConnected {
+		delete(c.lastConnectednessEvent, p)
 	}
-	if (forceNotConnectedEvent && c.lastEvent[p] == network.NotConnected) || c.lastEvent[p] != oldState {
+	if newState != oldState ||
+		(forceNotConnectedEvent && newState == network.NotConnected) {
 		c.emitter.Emit(event.EvtPeerConnectednessChanged{
 			Peer:          p,
-			Connectedness: c.lastEvent[p],
+			Connectedness: newState,
 		})
-	}
-}
-
-func (c *connectionEventsEmitter) sendConnRemovedNotifications() {
-	c.removeConnsMx.Lock()
-	removeConns := c.removeConns
-	c.removeConns = nil
-	c.removeConnsMx.Unlock()
-	for _, p := range removeConns {
-		c.notifyPeer(p, false)
 	}
 }

--- a/p2p/net/swarm/connection_events_emitter.go
+++ b/p2p/net/swarm/connection_events_emitter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// connectednessEventEmitter emits PeerConnectednessChanged events and dispatches
+// connectionEventsEmitter emits PeerConnectednessChanged events and dispatches
 // per-conn Connected / Disconnected callbacks supplied by the owner.
 //
 // We ensure that for any peer we connected to we always sent atleast 1 NotConnected Event after
@@ -25,7 +25,7 @@ import (
 // Callers that want a non-blocking close (e.g. doClose) invoke RemoveConn
 // from a goroutine; AddConn always runs onConnected synchronously so callers
 // see Connected fire before they continue.
-type connectednessEventEmitter struct {
+type connectionEventsEmitter struct {
 	// newConns is the channel that holds the peerIDs we recently connected to
 	newConns      chan peer.ID
 	removeConnsMx sync.Mutex
@@ -64,14 +64,14 @@ type connectednessEventEmitter struct {
 	pendingDisconnect map[*Conn]struct{}
 }
 
-func newConnectednessEventEmitter(
+func newConnectionEventsEmitter(
 	connectedness func(peer.ID) network.Connectedness,
 	emitter event.Emitter,
 	onConnected func(*Conn),
 	onDisconnected func(*Conn),
-) *connectednessEventEmitter {
+) *connectionEventsEmitter {
 	loopCtx, loopCancel := context.WithCancel(context.Background())
-	c := &connectednessEventEmitter{
+	c := &connectionEventsEmitter{
 		newConns:          make(chan peer.ID, 32),
 		lastEvent:         make(map[peer.ID]network.Connectedness),
 		removeConnNotif:   make(chan struct{}, 1),
@@ -89,7 +89,7 @@ func newConnectednessEventEmitter(
 	return c
 }
 
-func (c *connectednessEventEmitter) AddConn(conn *Conn) {
+func (c *connectionEventsEmitter) AddConn(conn *Conn) {
 	c.closeMu.Lock()
 	if c.closed {
 		c.closeMu.Unlock()
@@ -121,7 +121,7 @@ func (c *connectednessEventEmitter) AddConn(conn *Conn) {
 	}
 }
 
-func (c *connectednessEventEmitter) RemoveConn(conn *Conn) {
+func (c *connectionEventsEmitter) RemoveConn(conn *Conn) {
 	c.closeMu.Lock()
 	if c.closed {
 		c.closeMu.Unlock()
@@ -164,7 +164,7 @@ func (c *connectednessEventEmitter) RemoveConn(conn *Conn) {
 	}
 }
 
-func (c *connectednessEventEmitter) Close() {
+func (c *connectionEventsEmitter) Close() {
 	c.closeMu.Lock()
 	c.closed = true
 	c.closeMu.Unlock()
@@ -173,7 +173,7 @@ func (c *connectednessEventEmitter) Close() {
 	c.loopWG.Wait()
 }
 
-func (c *connectednessEventEmitter) runEmitter() {
+func (c *connectionEventsEmitter) runEmitter() {
 	defer c.loopWG.Done()
 	for {
 		select {
@@ -202,7 +202,7 @@ func (c *connectednessEventEmitter) runEmitter() {
 // In case a peer is disconnected before we sent the Connected event, we still
 // send the Disconnected event because a connection to the peer can be observed
 // in such cases.
-func (c *connectednessEventEmitter) notifyPeer(p peer.ID, forceNotConnectedEvent bool) {
+func (c *connectionEventsEmitter) notifyPeer(p peer.ID, forceNotConnectedEvent bool) {
 	oldState := c.lastEvent[p]
 	c.lastEvent[p] = c.connectedness(p)
 	if c.lastEvent[p] == network.NotConnected {
@@ -216,7 +216,7 @@ func (c *connectednessEventEmitter) notifyPeer(p peer.ID, forceNotConnectedEvent
 	}
 }
 
-func (c *connectednessEventEmitter) sendConnRemovedNotifications() {
+func (c *connectionEventsEmitter) sendConnRemovedNotifications() {
 	c.removeConnsMx.Lock()
 	removeConns := c.removeConns
 	c.removeConns = nil

--- a/p2p/net/swarm/connection_events_emitter_test.go
+++ b/p2p/net/swarm/connection_events_emitter_test.go
@@ -62,13 +62,13 @@ func recordingCallbacks() (onConnected func(*Conn), onDisconnected func(*Conn), 
 	return
 }
 
-func newEmitterForTest(t *testing.T, onConnected, onDisconnected func(*Conn)) *connectednessEventEmitter {
+func newEmitterForTest(t *testing.T, onConnected, onDisconnected func(*Conn)) *connectionEventsEmitter {
 	t.Helper()
 	bus := eventbus.NewBus()
 	em, err := bus.Emitter(new(event.EvtPeerConnectednessChanged))
 	require.NoError(t, err)
 	connectedness := func(peer.ID) network.Connectedness { return network.NotConnected }
-	e := newConnectednessEventEmitter(connectedness, em, onConnected, onDisconnected)
+	e := newConnectionEventsEmitter(connectedness, em, onConnected, onDisconnected)
 	t.Cleanup(func() { e.Close() })
 	return e
 }

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -217,11 +217,11 @@ type Swarm struct {
 
 	dialRanker network.DialRanker
 
-	connectednessEventEmitter *connectednessEventEmitter
-	udpBHF                    *BlackHoleSuccessCounter
-	ipv6BHF                   *BlackHoleSuccessCounter
-	bhd                       *blackHoleDetector
-	readOnlyBHD               bool
+	connectionEventsEmitter *connectionEventsEmitter
+	udpBHF                  *BlackHoleSuccessCounter
+	ipv6BHF                 *BlackHoleSuccessCounter
+	bhd                     *blackHoleDetector
+	readOnlyBHD             bool
 }
 
 // NewSwarm constructs a Swarm.
@@ -254,7 +254,7 @@ func NewSwarm(local peer.ID, peers peerstore.Peerstore, eventBus event.Bus, opts
 	s.transports.m = make(map[int]transport.Transport)
 	s.notifs.m = make(map[network.Notifiee]struct{})
 	s.directConnNotifs.m = make(map[peer.ID][]chan struct{})
-	s.connectednessEventEmitter = newConnectednessEventEmitter(
+	s.connectionEventsEmitter = newConnectionEventsEmitter(
 		s.Connectedness, emitter,
 		func(c *Conn) { s.notifyAll(func(f network.Notifiee) { f.Connected(s, c) }) },
 		func(c *Conn) { s.notifyAll(func(f network.Notifiee) { f.Disconnected(s, c) }) },
@@ -333,7 +333,7 @@ func (s *Swarm) close() {
 	// We must wait for all the connection notifications to complete before
 	// closing the events emitter.
 	s.refs.Wait()
-	s.connectednessEventEmitter.Close()
+	s.connectionEventsEmitter.Close()
 	s.emitter.Close()
 
 	// Now close out any transports (if necessary). Do this after closing
@@ -443,7 +443,7 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 	// AddConn dispatches PeerConnectednessChanged and Notifiee.Connected before
 	// c.start() spawns the AcceptStream loop, so handlers see the conn before
 	// any inbound stream arrives.
-	s.connectednessEventEmitter.AddConn(c)
+	s.connectionEventsEmitter.AddConn(c)
 
 	c.start()
 	return c, nil

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -254,7 +254,11 @@ func NewSwarm(local peer.ID, peers peerstore.Peerstore, eventBus event.Bus, opts
 	s.transports.m = make(map[int]transport.Transport)
 	s.notifs.m = make(map[network.Notifiee]struct{})
 	s.directConnNotifs.m = make(map[peer.ID][]chan struct{})
-	s.connectednessEventEmitter = newConnectednessEventEmitter(s.Connectedness, emitter)
+	s.connectednessEventEmitter = newConnectednessEventEmitter(
+		s.Connectedness, emitter,
+		func(c *Conn) { s.notifyAll(func(f network.Notifiee) { f.Connected(s, c) }) },
+		func(c *Conn) { s.notifyAll(func(f network.Notifiee) { f.Disconnected(s, c) }) },
+	)
 
 	for _, opt := range opts {
 		if err := opt(s); err != nil {
@@ -326,6 +330,8 @@ func (s *Swarm) close() {
 	}
 
 	// Wait for everything to finish.
+	// We must wait for all the connection notifications to complete before
+	// closing the events emitter.
 	s.refs.Wait()
 	s.connectednessEventEmitter.Close()
 	s.emitter.Close()
@@ -416,18 +422,12 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 	// * One will be decremented after the close notifications fire in Conn.doClose
 	// * The other will be decremented when Conn.start exits.
 	s.refs.Add(2)
-	// Take the notification lock before releasing the conns lock to block
-	// Disconnect notifications until after the Connect notifications done.
-	// This lock also ensures that swarm.refs.Wait() exits after we have
-	// enqueued the peer connectedness changed notification.
-	// TODO: Fix this fragility by taking a swarm ref for dial worker loop
-	c.notifyLk.Lock()
 	s.conns.Unlock()
-
-	s.connectednessEventEmitter.AddConn(p)
 
 	if !isLimited {
 		// Notify goroutines waiting for a direct connection
+		// do this before connected events, as there's no reason to stall this
+		// notification for the events.
 		//
 		// Go routines interested in waiting for direct connection first acquire this lock
 		// and then acquire s.conns.RLock. Do not acquire this lock before conns.Unlock to
@@ -439,10 +439,11 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 		delete(s.directConnNotifs.m, p)
 		s.directConnNotifs.Unlock()
 	}
-	s.notifyAll(func(f network.Notifiee) {
-		f.Connected(s, c)
-	})
-	c.notifyLk.Unlock()
+
+	// AddConn dispatches PeerConnectednessChanged and Notifiee.Connected before
+	// c.start() spawns the AcceptStream loop, so handlers see the conn before
+	// any inbound stream arrives.
+	s.connectednessEventEmitter.AddConn(c)
 
 	c.start()
 	return c, nil
@@ -785,6 +786,8 @@ func (s *Swarm) removeConn(c *Conn) {
 	p := c.RemotePeer()
 
 	s.conns.Lock()
+	defer s.conns.Unlock()
+
 	cs := s.conns.m[p]
 	for i, ci := range cs {
 		if ci == c {
@@ -800,7 +803,6 @@ func (s *Swarm) removeConn(c *Conn) {
 	if len(s.conns.m[p]) == 0 {
 		delete(s.conns.m, p)
 	}
-	s.conns.Unlock()
 }
 
 // String returns a string representation of Network.

--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -92,9 +92,17 @@ func (c *Conn) doClose(errCode network.ConnErrorCode) {
 		s.Reset()
 	}
 
-	// Dispatch the close notifications in a goroutine: a Notifiee.Disconnected
-	// handler that calls Conn.Close would otherwise deadlock on closeOnce,
-	// since the in-flight doClose hasn't returned yet.
+	// Dispatch the close notifications in a goroutine. Two deadlocks are
+	// avoided by this:
+	//   - A PeerConnectednessChanged subscriber that calls Conn.Close would
+	//     otherwise call RemoveConn synchronously, blocking on the emitter's
+	//     event channel while the run loop is itself blocked waiting for the
+	//     subscriber to return.
+	//   - A Notifiee.Disconnected handler that calls Conn.Close (which is a
+	//     misuse — Disconnected fires because the conn is already closing)
+	//     would otherwise re-enter closeOnce.Do while the in-flight doClose
+	//     still holds it, deadlocking on sync.Once's internal mutex. We
+	//     tolerate the misuse rather than deadlock the caller.
 	// The s.refs ref added in addConn is released here.
 	go func() {
 		defer c.swarm.refs.Done()

--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -98,7 +98,7 @@ func (c *Conn) doClose(errCode network.ConnErrorCode) {
 	// The s.refs ref added in addConn is released here.
 	go func() {
 		defer c.swarm.refs.Done()
-		c.swarm.connectednessEventEmitter.RemoveConn(c)
+		c.swarm.connectionEventsEmitter.RemoveConn(c)
 	}()
 }
 

--- a/p2p/net/swarm/swarm_conn.go
+++ b/p2p/net/swarm/swarm_conn.go
@@ -30,8 +30,6 @@ type Conn struct {
 	closeOnce sync.Once
 	err       error
 
-	notifyLk sync.Mutex
-
 	streams struct {
 		sync.Mutex
 		m map[*Stream]struct{}
@@ -55,12 +53,10 @@ func (c *Conn) ID() string {
 	return fmt.Sprintf("%s-%d", c.RemotePeer().String()[:10], c.id)
 }
 
-// Close closes this connection.
-//
-// Note: This method won't wait for the close notifications to finish as that
-// would create a deadlock when called from an open notification (because all
-// open notifications must finish before we can fire off the close
-// notifications).
+// Close closes this connection. It does not wait for the Disconnected
+// notification to be dispatched to Notifiees: doClose spawns a goroutine for
+// that, tracked by swarm.refs, so Close is safe to call from inside a
+// Notifiee.Connected handler without deadlocking.
 func (c *Conn) Close() error {
 	c.closeOnce.Do(func() {
 		c.doClose(0)
@@ -90,28 +86,19 @@ func (c *Conn) doClose(errCode network.ConnErrorCode) {
 		c.err = c.conn.Close()
 	}
 
-	// Send the connectedness event after closing the connection.
-	// This ensures that both remote connection close and local connection
-	// close events are sent after the underlying transport connection is closed.
-	c.swarm.connectednessEventEmitter.RemoveConn(c.RemotePeer())
-
 	// This is just for cleaning up state. The connection has already been closed.
 	// We *could* optimize this but it really isn't worth it.
 	for s := range streams {
 		s.Reset()
 	}
 
-	// do this in a goroutine to avoid deadlocking if we call close in an open notification.
+	// Dispatch the close notifications in a goroutine: a Notifiee.Disconnected
+	// handler that calls Conn.Close would otherwise deadlock on closeOnce,
+	// since the in-flight doClose hasn't returned yet.
+	// The s.refs ref added in addConn is released here.
 	go func() {
-		// prevents us from issuing close notifications before finishing the open notifications
-		c.notifyLk.Lock()
-		defer c.notifyLk.Unlock()
-
-		// Only notify for disconnection if we notified for connection
-		c.swarm.notifyAll(func(f network.Notifiee) {
-			f.Disconnected(c.swarm, c)
-		})
-		c.swarm.refs.Done()
+		defer c.swarm.refs.Done()
+		c.swarm.connectednessEventEmitter.RemoveConn(c)
 	}()
 }
 

--- a/p2p/net/swarm/swarm_event_test.go
+++ b/p2p/net/swarm/swarm_event_test.go
@@ -217,9 +217,10 @@ func TestConnectednessEventDeadlock(t *testing.T) {
 	go func() {
 		defer close(done)
 		count := 0
+		// sleep to simulate a slow consumer
+		time.Sleep(1 * time.Second)
 		for count < N {
 			e := <-sub1.Out()
-			// sleep to simulate a slow consumer
 			evt, ok := e.(event.EvtPeerConnectednessChanged)
 			if !ok {
 				t.Error("invalid event received", e)
@@ -228,6 +229,8 @@ func TestConnectednessEventDeadlock(t *testing.T) {
 			if evt.Connectedness != network.Connected {
 				continue
 			}
+			// sleep to simulate a slow consumer
+			time.Sleep(20 * time.Millisecond)
 			count++
 			s1.ClosePeer(evt.Peer)
 		}
@@ -241,7 +244,7 @@ func TestConnectednessEventDeadlock(t *testing.T) {
 	}
 	select {
 	case <-done:
-	case <-time.After(100 * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatal("expected all connectedness events to be completed")
 	}
 }
@@ -261,9 +264,7 @@ func TestConnectednessEventDeadlockWithDial(t *testing.T) {
 	// First check all connected events
 	done := make(chan struct{})
 	var subWG sync.WaitGroup
-	subWG.Add(1)
-	go func() {
-		defer subWG.Done()
+	subWG.Go(func() {
 		count := 0
 		for {
 			var e any
@@ -290,7 +291,7 @@ func TestConnectednessEventDeadlockWithDial(t *testing.T) {
 				cancel()
 			}
 		}
-	}()
+	})
 	var wg sync.WaitGroup
 	wg.Add(N)
 	for i := range N {

--- a/p2p/net/swarm/swarm_notif_test.go
+++ b/p2p/net/swarm/swarm_notif_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	. "github.com/libp2p/go-libp2p/p2p/net/swarm"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -180,4 +181,93 @@ func (nn *netNotifiee) Connected(_ network.Network, v network.Conn) {
 }
 func (nn *netNotifiee) Disconnected(_ network.Network, v network.Conn) {
 	nn.disconnected <- v
+}
+
+// TestNotifications_CloseFromConnected verifies that closing a conn from
+// inside a Notifiee.Connected handler does not deadlock.
+func TestNotifications_CloseFromConnected(t *testing.T) {
+	const timeout = 5 * time.Second
+
+	swarms := makeSwarms(t, 2)
+	defer func() {
+		for _, s := range swarms {
+			require.NoError(t, s.Close())
+		}
+	}()
+
+	connected := make(chan network.Conn, 8)
+	disconnected := make(chan network.Conn, 8)
+	swarms[0].Notify(&network.NotifyBundle{
+		ConnectedF: func(_ network.Network, c network.Conn) {
+			_ = c.Close()
+			connected <- c
+		},
+		DisconnectedF: func(_ network.Network, c network.Conn) {
+			disconnected <- c
+		},
+	})
+
+	swarms[0].Peerstore().AddAddrs(swarms[1].LocalPeer(), swarms[1].ListenAddresses(), peerstore.TempAddrTTL)
+	// DialPeer may return an error because the conn is closed from the
+	// notification handler before dial bookkeeping completes; we don't care.
+	_, _ = swarms[0].DialPeer(context.Background(), swarms[1].LocalPeer())
+
+	var connectedConn network.Conn
+	select {
+	case connectedConn = <-connected:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for Connected notification")
+	}
+
+	select {
+	case dc := <-disconnected:
+		require.Same(t, connectedConn, dc, "Disconnected must fire for the same conn")
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for Disconnected notification")
+	}
+}
+
+// TestNotifications_CloseFromDisconnected verifies that calling Conn.Close
+// from inside a Notifiee.Disconnected handler does not deadlock. doClose
+// dispatches notifications in a goroutine, so closeOnce has already returned
+// by the time the handler runs and the re-entrant Close is a no-op.
+func TestNotifications_CloseFromDisconnected(t *testing.T) {
+	const timeout = 5 * time.Second
+
+	swarms := makeSwarms(t, 2)
+	defer func() {
+		for _, s := range swarms {
+			require.NoError(t, s.Close())
+		}
+	}()
+
+	connected := make(chan network.Conn, 8)
+	disconnected := make(chan network.Conn, 8)
+	swarms[0].Notify(&network.NotifyBundle{
+		ConnectedF: func(_ network.Network, c network.Conn) {
+			connected <- c
+		},
+		DisconnectedF: func(_ network.Network, c network.Conn) {
+			_ = c.Close()
+			disconnected <- c
+		},
+	})
+
+	swarms[0].Peerstore().AddAddrs(swarms[1].LocalPeer(), swarms[1].ListenAddresses(), peerstore.TempAddrTTL)
+	conn, err := swarms[0].DialPeer(context.Background(), swarms[1].LocalPeer())
+	require.NoError(t, err)
+
+	select {
+	case <-connected:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for Connected notification")
+	}
+
+	require.NoError(t, conn.Close())
+
+	select {
+	case <-disconnected:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for Disconnected notification (potential deadlock)")
+	}
 }

--- a/p2p/test/basichost/swarm_close_blocked_notifiee_test.go
+++ b/p2p/test/basichost/swarm_close_blocked_notifiee_test.go
@@ -1,0 +1,81 @@
+package basichost
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/x/simlibp2p"
+	"github.com/marcopolo/simnet"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloseWithBlockingConnectedNotifee verifies that swarm.Close
+// eventually returns even when Notifiee.Connected handlers block for a
+// long time. The handler blocks for blockDur after first being called and
+// becomes a noop afterwards. After closeDelay we close the dialer; Close
+// must return once the handlers unblock.
+func TestCloseWithBlockingConnectedNotifee(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			numListeners = 100
+			blockDur     = 5 * time.Second
+			closeDelay   = 2 * time.Second
+		)
+
+		latency := 10 * time.Millisecond
+		sn, meta, err := simlibp2p.SimpleLibp2pNetwork([]simlibp2p.NodeLinkSettingsAndCount{
+			{LinkSettings: simnet.NodeBiDiLinkSettings{
+				Downlink: simnet.LinkSettings{BitsPerSecond: 20 * simlibp2p.OneMbps}, // Divide by two since this is latency for each direction
+				Uplink:   simnet.LinkSettings{BitsPerSecond: 20 * simlibp2p.OneMbps},
+			}, Count: 100},
+		}, simnet.StaticLatency(latency/2), simlibp2p.NetworkSettings{})
+		require.NoError(t, err)
+		defer sn.Close()
+		defer func() {
+			for _, h := range meta.Nodes {
+				h.Close()
+			}
+		}()
+
+		dialer := meta.Nodes[0]
+
+		// Connected handler blocks on this channel; we close it after blockDur.
+		unblock := make(chan struct{})
+		time.AfterFunc(blockDur, func() { close(unblock) })
+		dialer.Network().Notify(&network.NotifyBundle{
+			ConnectedF: func(_ network.Network, _ network.Conn) {
+				<-unblock
+			},
+		})
+		var wg sync.WaitGroup
+		for i := 1; i < len(meta.Nodes); i++ {
+			wg.Go(func() {
+				node := meta.Nodes[i]
+				ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+				dialer.Connect(ctx, node.Peerstore().PeerInfo(node.ID()))
+				cancel()
+				// we don't care about the error. swarm closing might return error here.
+			})
+		}
+
+		time.Sleep(closeDelay)
+
+		closed := make(chan struct{})
+		wg.Go(func() {
+			require.NoError(t, dialer.Close())
+			close(closed)
+		})
+		select {
+		case <-closed:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("close timed out")
+		}
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
removes the notification lock on connectiosn with a single lock on the events emitter. This consolidates all the connection events into one file making it easier to reason about them. 

A lot of it was written by Claude. I've reviewed everything. 