### PR TITLE
fix holepunch shutdown deadlock on canceled address discovery

### DIFF
--- a/p2p/protocol/holepunch/svc.go
+++ b/p2p/protocol/holepunch/svc.go
@@ -143,13 +143,13 @@ func (s *Service) waitForPublicAddr() {
 	}
 
 	s.holePuncherMx.Lock()
+	defer s.holePuncherMx.Unlock()
 	if s.ctx.Err() != nil {
 		// service is closed
 		return
 	}
 	s.holePuncher = newHolePuncher(s.host, s.ids, s.listenAddrs, s.tracer, s.filter)
 	s.holePuncher.directDialTimeout = s.directDialTimeout
-	s.holePuncherMx.Unlock()
 	close(s.hasPublicAddrsChan)
 }
 

--- a/p2p/protocol/holepunch/svc_close_test.go
+++ b/p2p/protocol/holepunch/svc_close_test.go
@@ -1,0 +1,76 @@
+package holepunch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+type closeTestHost struct {
+	host.Host
+}
+
+func (closeTestHost) ID() peer.ID                                         { return peer.ID("close-test-peer") }
+func (closeTestHost) Addrs() []ma.Multiaddr                               { return nil }
+func (closeTestHost) SetStreamHandler(protocol.ID, network.StreamHandler) {}
+func (closeTestHost) RemoveStreamHandler(protocol.ID)                     {}
+
+func TestWaitForPublicAddrUnlocksMutexWhenCanceledAfterAddressDiscovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	enteredListenAddrs := make(chan struct{})
+	releaseListenAddrs := make(chan struct{})
+	done := make(chan struct{})
+
+	s := &Service{
+		ctx:                ctx,
+		ctxCancel:          cancel,
+		host:               closeTestHost{},
+		hasPublicAddrsChan: make(chan struct{}),
+		listenAddrs: func() []ma.Multiaddr {
+			close(enteredListenAddrs)
+			<-releaseListenAddrs
+			return []ma.Multiaddr{ma.StringCast("/ip4/1.2.3.4/tcp/1234")}
+		},
+	}
+
+	s.refCount.Add(1)
+	go func() {
+		s.waitForPublicAddr()
+		close(done)
+	}()
+
+	// Force cancellation after waitForPublicAddr has entered listenAddrs, but
+	// before listenAddrs returns a public address. The next code path in
+	// waitForPublicAddr acquires holePuncherMx and observes the canceled context.
+	<-enteredListenAddrs
+	cancel()
+	close(releaseListenAddrs)
+	<-done
+
+	// The canceled-after-address-discovery path must not leak the mutex.
+	if !s.holePuncherMx.TryLock() {
+		t.Fatal("holePuncherMx remained locked after cancellation path")
+	}
+	s.holePuncherMx.Unlock()
+
+	// Close takes the same mutex. If waitForPublicAddr leaked it, Close would
+	// block forever.
+	closed := make(chan struct{})
+	go func() {
+		_ = s.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked after waitForPublicAddr cancellation")
+	}
+}

--- a/p2p/protocol/holepunch/svc_close_test.go
+++ b/p2p/protocol/holepunch/svc_close_test.go
@@ -22,7 +22,7 @@ func (closeTestHost) Addrs() []ma.Multiaddr                               { retu
 func (closeTestHost) SetStreamHandler(protocol.ID, network.StreamHandler) {}
 func (closeTestHost) RemoveStreamHandler(protocol.ID)                     {}
 
-func TestWaitForPublicAddrUnlocksMutexWhenCanceledAfterAddressDiscovery(t *testing.T) {
+func TestWaitForPublicAddr_NoDeadlockOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	enteredListenAddrs := make(chan struct{})
 	releaseListenAddrs := make(chan struct{})
@@ -46,22 +46,16 @@ func TestWaitForPublicAddrUnlocksMutexWhenCanceledAfterAddressDiscovery(t *testi
 		close(done)
 	}()
 
-	// Force cancellation after waitForPublicAddr has entered listenAddrs, but
-	// before listenAddrs returns a public address. The next code path in
-	// waitForPublicAddr acquires holePuncherMx and observes the canceled context.
 	<-enteredListenAddrs
 	cancel()
 	close(releaseListenAddrs)
 	<-done
 
-	// The canceled-after-address-discovery path must not leak the mutex.
 	if !s.holePuncherMx.TryLock() {
 		t.Fatal("holePuncherMx remained locked after cancellation path")
 	}
 	s.holePuncherMx.Unlock()
 
-	// Close takes the same mutex. If waitForPublicAddr leaked it, Close would
-	// block forever.
 	closed := make(chan struct{})
 	go func() {
 		_ = s.Close()


### PR DESCRIPTION
## Summary

This PR fixes a shutdown deadlock in the holepunch service.

`Service.waitForPublicAddr` waits until the host has a public address, then initializes the hole puncher while holding `holePuncherMx`. If the service context is canceled after public address discovery but before hole puncher initialization, the function could return without unlocking `holePuncherMx`.

That can make `Service.Close()` block forever because `Close()` also needs the same mutex.

## Impact

This can cause shutdown or teardown to hang when hole punching is enabled.

Possible effects:

- `Host.Close()` or service shutdown can get stuck
- goroutines can remain blocked during teardown
- process restart can stall
- tests or applications that create and close hosts repeatedly can hang

## Fix

Unlock `holePuncherMx` with a `defer` immediately after locking it:

```go
s.holePuncherMx.Lock()
defer s.holePuncherMx.Unlock()
```
This guarantees the mutex is released on both the normal path and the cancellation path.

### Test
The test reproduces the race by:
1. Starting `waitForPublicAddr`.
2. Blocking inside `listenAddrs`.
3. Canceling the service context.
4. Returning a public address from `listenAddrs`.
5. Verifying `holePuncherMx` is not left locked.
6. Verifying `Close()` returns instead of blocking.