### PR TITLE
config: disable black hole detector on AutoNAT v2 dialerHost

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -230,22 +230,28 @@ func (cfg *Config) makeAutoNATV2Host() (host.Host, error) {
 	}
 
 	autoNatCfg := Config{
-		Transports:                  cfg.Transports,
-		Muxers:                      cfg.Muxers,
-		SecurityTransports:          cfg.SecurityTransports,
-		Insecure:                    cfg.Insecure,
-		PSK:                         cfg.PSK,
-		ConnectionGater:             cfg.ConnectionGater,
-		Reporter:                    cfg.Reporter,
-		PeerKey:                     autonatPrivKey,
-		Peerstore:                   ps,
-		DialRanker:                  swarm.NoDelayDialRanker,
-		UDPBlackHoleSuccessCounter:  cfg.UDPBlackHoleSuccessCounter,
-		IPv6BlackHoleSuccessCounter: cfg.IPv6BlackHoleSuccessCounter,
-		ResourceManager:             cfg.ResourceManager,
+		Transports:         cfg.Transports,
+		Muxers:             cfg.Muxers,
+		SecurityTransports: cfg.SecurityTransports,
+		Insecure:           cfg.Insecure,
+		PSK:                cfg.PSK,
+		ConnectionGater:    cfg.ConnectionGater,
+		Reporter:           cfg.Reporter,
+		PeerKey:            autonatPrivKey,
+		Peerstore:          ps,
+		DialRanker:         swarm.NoDelayDialRanker,
+		ResourceManager:    cfg.ResourceManager,
 		SwarmOpts: []swarm.Option{
-			// Don't update black hole state for failed autonat dials
-			swarm.WithReadOnlyBlackHoleDetector(),
+			// The dialerHost only dials addresses clients explicitly ask
+			// us to test, so the black hole detector has no useful role
+			// here. Sharing the main host's counters in read-only mode
+			// causes every dial-back to be refused with E_DIAL_REFUSED
+			// while the main host is still in the Probing state, which
+			// in turn keeps the client's QUIC address stuck in Unknown
+			// (see #3491). Disable the detectors entirely, matching the
+			// approach used for the AutoNAT v1 dialer (#2529).
+			swarm.WithUDPBlackHoleSuccessCounter(nil),
+			swarm.WithIPv6BlackHoleSuccessCounter(nil),
 		},
 	}
 	fxopts, err := autoNatCfg.addTransports()


### PR DESCRIPTION
Closes #3491.

## Problem

The AutoNAT v2 `dialerHost` constructed by `makeAutoNATV2Host()` shares the main host's UDP/IPv6 black-hole counters in read-only mode. Read-only mode treats anything other than `Allowed` as `Blocked` (see `swarm/black_hole_detector.go`), so while the main host is still in `Probing` — the natural state for fresh servers, low-traffic nodes, and isolated testbeds — every QUIC dial-back is refused with `E_DIAL_REFUSED`.

`AddRefusal` (`p2p/host/basic/addrs_reachability_tracker.go`) does not feed `AddOutcome`, so the client's QUIC address never flips to `Unreachable`, but it never accumulates positive evidence either and stays stuck in `Unknown`.

This was systematically observed in the cross-implementation [ProbeLab AutoNAT v2 audit](https://github.com/probe-lab/autonat-perf-audit/blob/main/docs/final-report.md) and reported in #3491.

## Fix

Apply the same approach already used for AutoNAT v1 (#2529): stop inheriting `UDPBlackHoleSuccessCounter` / `IPv6BlackHoleSuccessCounter` from the parent config, drop `WithReadOnlyBlackHoleDetector()`, and pass `nil` counters to swarm via `SwarmOpts`. The dialerHost only dials addresses clients explicitly asked us to test, so the detector has no useful role on it.

```go
SwarmOpts: []swarm.Option{
    swarm.WithUDPBlackHoleSuccessCounter(nil),
    swarm.WithIPv6BlackHoleSuccessCounter(nil),
},
```

This mirrors the existing AutoNAT v1 dialer construction in the same file.

## Test plan

```
$ go test -short -count=1 -timeout 120s ./p2p/protocol/autonatv2/... ./p2p/host/autonat/... ./config
ok  	github.com/libp2p/go-libp2p/p2p/protocol/autonatv2	23.380s
ok  	github.com/libp2p/go-libp2p/p2p/host/autonat	7.079s
ok  	github.com/libp2p/go-libp2p/p2p/host/autonat/test	0.840s
ok  	github.com/libp2p/go-libp2p/config	0.595s
```

No new tests added; the change is a configuration delta inside a private host-construction helper and is covered by the AutoNAT v2 integration tests that already exercise the dial-back path. If you want a more targeted regression test (assertion that the dialerHost's swarm has black-hole detection disabled), happy to add one.
