### PR TITLE
fix: duplicated "the" in p2p/net/swarm metrics and core/network mux comments

### DIFF
--- a/core/network/mux.go
+++ b/core/network/mux.go
@@ -121,7 +121,7 @@ type MuxedStream interface {
 // connection that has been "upgraded" to support the libp2p capabilities
 // of secure communication and stream multiplexing.
 type MuxedConn interface {
-	// Close closes the stream muxer and the the underlying net.Conn.
+	// Close closes the stream muxer and the underlying net.Conn.
 	io.Closer
 
 	// CloseWithError closes the connection with errCode. The errCode is sent

--- a/p2p/net/swarm/swarm_metrics.go
+++ b/p2p/net/swarm/swarm_metrics.go
@@ -229,7 +229,7 @@ func (m *metricsTracer) CompletedHandshake(t time.Duration, cs network.Connectio
 func (m *metricsTracer) FailedDialing(addr ma.Multiaddr, dialErr error, cause error) {
 	transport := metricshelper.GetTransport(addr)
 	e := "other"
-	// dial deadline exceeded or the the parent contexts deadline exceeded
+	// dial deadline exceeded or the parent contexts deadline exceeded
 	if errors.Is(dialErr, context.DeadlineExceeded) || errors.Is(cause, context.DeadlineExceeded) {
 		e = "deadline"
 	} else if errors.Is(dialErr, context.Canceled) {


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in source comments:
- `p2p/net/swarm/swarm_metrics.go` — "// dial deadline exceeded or the the parent contexts deadline exceeded" → "// dial deadline exceeded or the parent contexts deadline exceeded"
- `core/network/mux.go` — "// Close closes the stream muxer and the the underlying net.Conn." → "// Close closes the stream muxer and the underlying net.Conn."

No code/behavior change.