### PR TITLE
feat(websocket): share port with HTTP handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.48.0
+	golang.org/x/net v0.50.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.41.0
 	golang.org/x/time v0.12.0
@@ -101,7 +102,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/p2p/transport/tcpreuse/demultiplex.go
+++ b/p2p/transport/tcpreuse/demultiplex.go
@@ -85,6 +85,14 @@ func IsHTTP(s Prefix) bool {
 	switch string(s[:]) {
 	case "GET", "HEA", "POS", "PUT", "DEL", "CON", "OPT", "TRA", "PAT":
 		return true
+	case "PRI":
+		// HTTP/2 cleartext (h2c) connection preface starts with
+		// "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" (RFC 7540 §3.5). PRI is not a
+		// real HTTP method; the IETF chose it specifically because no h1
+		// method begins with those bytes, so this match is unambiguous.
+		// Routing h2c to the HTTP demux branch lets the WebSocket listener
+		// serve both h1 and h2c on the same plaintext port.
+		return true
 	default:
 		return false
 	}

--- a/p2p/transport/tcpreuse/demultiplex_test.go
+++ b/p2p/transport/tcpreuse/demultiplex_test.go
@@ -18,6 +18,7 @@ func FuzzClash(f *testing.F) {
 	add('O', 'P', 'T')
 	add('T', 'R', 'A')
 	add('P', 'A', 'T')
+	add('P', 'R', 'I') // h2c preface
 	// tls
 	add('\x16', '\x03', '\x01')
 	add('\x16', '\x03', '\x02')

--- a/p2p/transport/websocket/fallback_http_handler_test.go
+++ b/p2p/transport/websocket/fallback_http_handler_test.go
@@ -1,12 +1,15 @@
 package websocket
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -16,6 +19,7 @@ import (
 	gws "github.com/gorilla/websocket"
 	"github.com/libp2p/go-libp2p/core/network"
 	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
 	"golang.org/x/sync/errgroup"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -319,39 +323,145 @@ func TestModernBrowserWSSFlow(t *testing.T) {
 	})
 }
 
-// TestFallbackHTTPHandler_HTTP2NeverReachesWSPath locks down the dispatch
-// invariant that lets h2 and WSS coexist on the same listener: every HTTP/2
-// request must reach the fallback handler, never the WebSocket upgrade path.
+// sendH2ExtendedConnect opens a raw HTTP/2 connection to hostPort and sends one
+// RFC 8441 extended CONNECT request (":method = CONNECT", ":protocol =
+// websocket"). This is how a browser starts a WebSocket over HTTP/2. The
+// net/http client cannot build such a request, so we write the frames
+// ourselves. It returns the response ":status" and body. If the server resets
+// the stream instead of replying, the request never reached the handler, so
+// the test fails.
+func sendH2ExtendedConnect(t *testing.T, hostPort string) (status string, body []byte) {
+	t.Helper()
+	conn, err := tls.Dial("tcp", hostPort, &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+	require.Equal(t, "h2", conn.ConnectionState().NegotiatedProtocol)
+
+	// HTTP/2 client preface + our (empty) SETTINGS, then the request headers.
+	_, err = conn.Write([]byte(http2.ClientPreface))
+	require.NoError(t, err)
+	framer := http2.NewFramer(conn, conn)
+	require.NoError(t, framer.WriteSettings())
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	var hbuf bytes.Buffer
+	enc := hpack.NewEncoder(&hbuf)
+	for _, hf := range []hpack.HeaderField{
+		{Name: ":method", Value: "CONNECT"},
+		{Name: ":protocol", Value: "websocket"}, // the RFC 8441 marker
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/"},
+		{Name: ":authority", Value: hostPort},
+		{Name: "sec-websocket-version", Value: "13"},
+		{Name: "sec-websocket-key", Value: "dGhlIHNhbXBsZSBub25jZQ=="},
+	} {
+		require.NoError(t, enc.WriteField(hf))
+	}
+	require.NoError(t, framer.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: hbuf.Bytes(),
+		EndHeaders:    true,
+		EndStream:     true,
+	}))
+
+	// Read response frames until the stream ends, collecting status and body.
+	dec := hpack.NewDecoder(4096, nil)
+	for range 30 {
+		f, err := framer.ReadFrame()
+		require.NoError(t, err)
+		switch fr := f.(type) {
+		case *http2.RSTStreamFrame:
+			t.Fatalf("server reset the stream (%v); the request never reached the handler", fr.ErrCode)
+		case *http2.HeadersFrame:
+			fields, err := dec.DecodeFull(fr.HeaderBlockFragment())
+			require.NoError(t, err)
+			for _, hf := range fields {
+				if hf.Name == ":status" {
+					status = hf.Value
+				}
+			}
+			if fr.StreamEnded() {
+				return status, body
+			}
+		case *http2.DataFrame:
+			body = append(body, fr.Data()...)
+			if fr.StreamEnded() {
+				return status, body
+			}
+		}
+	}
+	t.Fatal("server never ended the response stream")
+	return status, body
+}
+
+// TestFallbackHTTPHandler_HTTP2NeverReachesWSPath checks one rule that lets a
+// WebSocket and an HTTP/2 fallback share a single /tls/ws port: a WebSocket
+// request sent over HTTP/2 (RFC 8441 extended CONNECT) must go to the fallback
+// handler, not to gorilla's WebSocket upgrade path.
 //
-// This holds today because gorilla/websocket's IsWebSocketUpgrade only looks
-// at HTTP/1 Upgrade headers, which the HTTP/2 framer (RFC 7540 §8.1.2.2)
-// refuses to carry. If a future version of gorilla/websocket adds RFC 8441
-// ("Bootstrapping WebSockets with HTTP/2", extended CONNECT) and silently
-// extends IsWebSocketUpgrade to detect it, this test will start failing,
-// which is the right cue to revisit the dispatch comment in
-// listener.ServeHTTP and decide whether to embrace WS-over-h2 or pin the
-// behaviour.
+// Why this matters: listener.ServeHTTP decides using ws.IsWebSocketUpgrade,
+// which today only looks at the HTTP/1 Upgrade handshake. So an HTTP/2 extended
+// CONNECT falls through to the fallback handler. If a later gorilla/websocket
+// release teaches IsWebSocketUpgrade to detect extended CONNECT as well, the
+// same request would start taking the upgrade path. That is a real change in
+// behaviour, and we want this test to fail when it happens (see the RFC 8441
+// note in newListener).
+//
+// Checking this end to end means a real extended CONNECT has to reach the
+// handler. By default Go's HTTP/2 server does not advertise
+// SETTINGS_ENABLE_CONNECT_PROTOCOL, so it rejects extended CONNECT before any
+// handler runs (golang/go#71128). GODEBUG=http2xconnect=1 turns that
+// advertisement on, but Go reads it once at startup, so t.Setenv cannot set it.
+// The parent process therefore re-runs just this test in a child with that
+// GODEBUG set, and the child does the real work.
 func TestFallbackHTTPHandler_HTTP2NeverReachesWSPath(t *testing.T) {
+	const childEnv = "GO_LIBP2P_WS_EXTCONNECT_CHILD"
+	if os.Getenv(childEnv) != "1" {
+		// Parent: re-run just this test in a child that accepts extended
+		// CONNECT, so the request reaches listener.ServeHTTP.
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+t.Name()+"$", "-test.v", "-test.count=1")
+		// Merge http2xconnect into any inherited GODEBUG rather than
+		// shadowing it; the last GODEBUG entry wins, so this keeps whatever
+		// the suite/CI already set while still enabling extended CONNECT.
+		godebug := "http2xconnect=1"
+		if prev := os.Getenv("GODEBUG"); prev != "" {
+			godebug = prev + ",http2xconnect=1"
+		}
+		cmd.Env = append(os.Environ(), "GODEBUG="+godebug, childEnv+"=1")
+		out, err := cmd.CombinedOutput()
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf("child process timed out after 30s:\n%s", out)
+		}
+		require.NoError(t, err, "child process failed:\n%s", out)
+		// Guard against a silent pass: a -test.run that matches nothing also
+		// exits 0. Require the child to report this test as passed.
+		require.Contains(t, string(out), "--- PASS: "+t.Name(),
+			"child did not run the extended CONNECT test:\n%s", out)
+		return
+	}
+
+	// Child: the HTTP/2 server now delivers extended CONNECT to ServeHTTP.
 	var fallbackHits atomic.Int32
+	var gotMethod atomic.Value
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fallbackHits.Add(1)
-		// Record the protocol so a regression makes the failure obvious.
-		w.Header().Set("X-Proto", r.Proto)
+		gotMethod.Store(r.Method)
 		fmt.Fprint(w, "fallback")
 	})
-
 	hostPort := startWSSListener(t, handler)
 
-	// Force ALPN to h2 only, so the connection MUST be HTTP/2 or fail.
-	resp, err := httpsClient([]string{"h2"}).Get("https://" + hostPort + "/")
-	require.NoError(t, err)
-	defer resp.Body.Close()
+	status, body := sendH2ExtendedConnect(t, hostPort)
 
-	require.Equal(t, "HTTP/2.0", resp.Proto)
-	require.Equal(t, "HTTP/2.0", resp.Header.Get("X-Proto"))
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "200", status, "extended CONNECT must be answered by the fallback handler")
+	require.Equal(t, "fallback", string(body))
 	require.Equal(t, int32(1), fallbackHits.Load(),
-		"HTTP/2 request must reach the fallback handler, not the WebSocket upgrade path")
+		"WebSocket-over-HTTP/2 must reach the fallback handler, not the WebSocket upgrade path")
+	require.Equal(t, "CONNECT", gotMethod.Load(), "the handler must see the original extended CONNECT request")
 }
 
 // TestFallbackHTTPHandler_KeepAlive ensures the handshake-timeout AfterFunc

--- a/p2p/transport/websocket/fallback_http_handler_test.go
+++ b/p2p/transport/websocket/fallback_http_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	gws "github.com/gorilla/websocket"
 	"github.com/libp2p/go-libp2p/core/network"
 	"golang.org/x/net/http2"
+	"golang.org/x/sync/errgroup"
 
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
@@ -416,4 +418,85 @@ func TestFallbackHTTPHandler_KeepAlive(t *testing.T) {
 	resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, "HTTP/2.0", resp.Proto, "second request must reuse the same h2 connection")
+}
+
+// TestFallbackHTTPHandler_ConcurrentH2Streams exercises the handshake-timer
+// disarm under HTTP/2 multiplexing. All streams on one h2 connection share
+// a single *negotiatingConn, so Unwrap must be safe under concurrent calls.
+// Run with `go test -race`. Before the sync.Once fix, two goroutines could
+// both pass the stopClose nil-check and race on the AfterFunc stop; the
+// loser silently dropped its request.
+func TestFallbackHTTPHandler_ConcurrentH2Streams(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+
+	hostPort := startWSSListener(t, handler)
+
+	// ALPN-h2-only keeps every Get on a single TCP connection, so the
+	// streams really do race for the same *negotiatingConn.
+	client := httpsClient([]string{"h2"})
+
+	const streams = 32
+	ready := make(chan struct{})
+	var g errgroup.Group
+	for range streams {
+		g.Go(func() error {
+			<-ready
+			resp, err := client.Get("https://" + hostPort + "/concurrent")
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("status=%d", resp.StatusCode)
+			}
+			if resp.Proto != "HTTP/2.0" {
+				return fmt.Errorf("proto=%s, want HTTP/2.0", resp.Proto)
+			}
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	close(ready)
+	require.NoError(t, g.Wait())
+}
+
+// TestNegotiatingConnUnwrapConcurrent locks down the disarm contract that
+// the HTTP/2 fallback path relies on: many goroutines calling Unwrap on the
+// same *negotiatingConn must all return nil, and the underlying stopClose
+// must fire exactly once. Before the sync.Once fix, only the first caller
+// returned nil; every other caller saw "timed out" because the AfterFunc
+// stop function returns false after the first stop.
+func TestNegotiatingConnUnwrapConcurrent(t *testing.T) {
+	var stopCalls atomic.Int32
+	nc := &negotiatingConn{
+		cancelCtx: func() {},
+		stopClose: func() bool {
+			// Mirror context.AfterFunc: only the first stop call returns true.
+			return stopCalls.Add(1) == 1
+		},
+	}
+
+	const goroutines = 256
+	ready := make(chan struct{})
+	var ok atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-ready
+			if _, err := nc.Unwrap(); err == nil {
+				ok.Add(1)
+			}
+		}()
+	}
+	close(ready)
+	wg.Wait()
+
+	require.Equal(t, int32(goroutines), ok.Load(), "every concurrent Unwrap must succeed")
+	require.Equal(t, int32(1), stopCalls.Load(), "stopClose must fire exactly once")
 }

--- a/p2p/transport/websocket/fallback_http_handler_test.go
+++ b/p2p/transport/websocket/fallback_http_handler_test.go
@@ -134,7 +134,7 @@ func TestFallbackHTTPHandler_HTTP2(t *testing.T) {
 // TestFallbackHTTPHandler_WebSocketStillWorks confirms that installing a
 // fallback handler does not break the original /tls/ws traffic.
 func TestFallbackHTTPHandler_WebSocketStillWorks(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		t.Errorf("fallback should not be called for a websocket upgrade, got %s %s", r.Method, r.URL.Path)
 	})
 
@@ -211,7 +211,7 @@ func TestFallbackHTTPHandler_PlainWS_H2C(t *testing.T) {
 // behind a reverse proxy that terminates TLS upstream and may forward
 // HTTP/1.1.
 func TestFallbackHTTPHandler_PlainWS(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, "plain")
 	})
 

--- a/p2p/transport/websocket/fallback_http_handler_test.go
+++ b/p2p/transport/websocket/fallback_http_handler_test.go
@@ -64,7 +64,7 @@ func startWSSListener(t *testing.T, fallback http.Handler) string {
 	_, u := newSecureUpgrader(t)
 	opts := []Option{WithTLSConfig(tlsConf)}
 	if fallback != nil {
-		opts = append(opts, WithFallbackHTTPHandler(fallback))
+		opts = append(opts, WithHTTPHandler(fallback))
 	}
 	tpt, err := New(u, &network.NullResourceManager{}, nil, opts...)
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestFallbackHTTPHandler_PlainWS_H2C(t *testing.T) {
 	})
 
 	_, u := newSecureUpgrader(t)
-	tpt, err := New(u, &network.NullResourceManager{}, nil, WithFallbackHTTPHandler(handler))
+	tpt, err := New(u, &network.NullResourceManager{}, nil, WithHTTPHandler(handler))
 	require.NoError(t, err)
 
 	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/ws"))
@@ -222,7 +222,7 @@ func TestFallbackHTTPHandler_PlainWS(t *testing.T) {
 	})
 
 	_, u := newSecureUpgrader(t)
-	tpt, err := New(u, &network.NullResourceManager{}, nil, WithFallbackHTTPHandler(handler))
+	tpt, err := New(u, &network.NullResourceManager{}, nil, WithHTTPHandler(handler))
 	require.NoError(t, err)
 
 	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/ws"))
@@ -483,7 +483,7 @@ func TestFallbackHTTPHandler_KeepAlive(t *testing.T) {
 	tpt, err := New(u, &network.NullResourceManager{}, nil,
 		WithTLSConfig(tlsConf),
 		WithHandshakeTimeout(200*time.Millisecond),
-		WithFallbackHTTPHandler(handler),
+		WithHTTPHandler(handler),
 	)
 	require.NoError(t, err)
 	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/tls/ws"))

--- a/p2p/transport/websocket/fallback_http_handler_test.go
+++ b/p2p/transport/websocket/fallback_http_handler_test.go
@@ -1,0 +1,419 @@
+package websocket
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+	"github.com/libp2p/go-libp2p/core/network"
+	"golang.org/x/net/http2"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+// listenerHostPort returns a "host:port" string for a listener multiaddr,
+// suitable for building an HTTP URL.
+func listenerHostPort(t *testing.T, m ma.Multiaddr) string {
+	t.Helper()
+	host, err := m.ValueForProtocol(ma.P_IP4)
+	require.NoError(t, err)
+	port, err := m.ValueForProtocol(ma.P_TCP)
+	require.NoError(t, err)
+	return net.JoinHostPort(host, port)
+}
+
+// httpsClient returns an http.Client that trusts self-signed certs and
+// negotiates the requested ALPN protocols. Pass {"h2", "http/1.1"} to allow
+// HTTP/2 with HTTP/1.1 fallback, or {"http/1.1"} to force HTTP/1.1 only.
+//
+// Note: the Go http.Transport adds h2 itself when TLSClientConfig.NextProtos
+// is empty, which is why we always set NextProtos explicitly here.
+func httpsClient(nextProtos []string) *http.Client {
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         nextProtos,
+	}
+	tr := &http.Transport{
+		ForceAttemptHTTP2: slices.Contains(nextProtos, "h2"),
+		TLSClientConfig:   tlsConf,
+	}
+	return &http.Client{Timeout: 10 * time.Second, Transport: tr}
+}
+
+// startWSSListener spins up a /tls/ws listener bound to 127.0.0.1 with the
+// given fallback handler (may be nil). Returns the host:port string of the
+// listener; the listener is closed via t.Cleanup.
+func startWSSListener(t *testing.T, fallback http.Handler) string {
+	t.Helper()
+	tlsConf := getTLSConf(t, net.ParseIP("127.0.0.1"), time.Now(), time.Now().Add(time.Hour))
+	_, u := newSecureUpgrader(t)
+	opts := []Option{WithTLSConfig(tlsConf)}
+	if fallback != nil {
+		opts = append(opts, WithFallbackHTTPHandler(fallback))
+	}
+	tpt, err := New(u, &network.NullResourceManager{}, nil, opts...)
+	require.NoError(t, err)
+
+	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/tls/ws"))
+	require.NoError(t, err)
+	t.Cleanup(func() { l.Close() })
+
+	// Drain accepted libp2p conns so they don't deadlock the listener.
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	return listenerHostPort(t, l.Multiaddr())
+}
+
+// TestFallbackHTTPHandler_TLS_HTTP1 confirms that a /tls/ws listener serves
+// the fallback handler over HTTPS/1.1 too. The transport does not pre-screen
+// HTTP versions; maximal interop with curl, legacy clients, and any HTTP-only
+// tooling is the priority. Multiplexing-sensitive clients should opt into h2
+// by offering it in ALPN; this listener will accept whichever ALPN they pick.
+func TestFallbackHTTPHandler_TLS_HTTP1(t *testing.T) {
+	const body = "hello from fallback"
+	var hits atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("X-Test", "ok")
+		fmt.Fprint(w, body)
+	})
+
+	hostPort := startWSSListener(t, handler)
+
+	resp, err := httpsClient([]string{"http/1.1"}).Get("https://" + hostPort + "/anything")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "HTTP/1.1", resp.Proto)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "ok", resp.Header.Get("X-Test"))
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(got))
+	require.Equal(t, int32(1), hits.Load())
+}
+
+// TestFallbackHTTPHandler_HTTP2 confirms ALPN selects "h2" and the fallback
+// handler still serves the request. This is the censorship-resistance shape:
+// HTTP/2 traffic on the same port as /tls/ws.
+func TestFallbackHTTPHandler_HTTP2(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "proto=%s", r.Proto)
+	})
+
+	hostPort := startWSSListener(t, handler)
+
+	resp, err := httpsClient([]string{"h2", "http/1.1"}).Get("https://" + hostPort + "/h2-test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "HTTP/2.0", resp.Proto, "client should negotiate h2 via ALPN")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "proto=HTTP/2.0", string(got))
+}
+
+// TestFallbackHTTPHandler_WebSocketStillWorks confirms that installing a
+// fallback handler does not break the original /tls/ws traffic.
+func TestFallbackHTTPHandler_WebSocketStillWorks(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("fallback should not be called for a websocket upgrade, got %s %s", r.Method, r.URL.Path)
+	})
+
+	hostPort := startWSSListener(t, handler)
+
+	dialer := gws.Dialer{
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+		HandshakeTimeout: 5 * time.Second,
+	}
+	conn, _, err := dialer.Dial("wss://"+hostPort+"/", nil)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+// TestFallbackHTTPHandler_NotSetReturns404 preserves the historical behaviour:
+// if no fallback handler is configured, non-upgrade requests get a 404.
+func TestFallbackHTTPHandler_NotSetReturns404(t *testing.T) {
+	hostPort := startWSSListener(t, nil)
+
+	resp, err := httpsClient([]string{"http/1.1"}).Get("https://" + hostPort + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestFallbackHTTPHandler_PlainWS_H2C confirms that a plain /ws listener
+// also serves the fallback handler over HTTP/2 cleartext (h2c). This is
+// what reverse proxies that speak h2c to backends (Caddy, Traefik, nginx
+// with the right directives) use to get connection multiplexing all the
+// way to the kubo node, instead of degrading to HTTP/1.1 just because the
+// last hop is plaintext.
+func TestFallbackHTTPHandler_PlainWS_H2C(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "proto=%s", r.Proto)
+	})
+
+	_, u := newSecureUpgrader(t)
+	tpt, err := New(u, &network.NullResourceManager{}, nil, WithFallbackHTTPHandler(handler))
+	require.NoError(t, err)
+
+	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/ws"))
+	require.NoError(t, err)
+	t.Cleanup(func() { l.Close() })
+
+	hostPort := listenerHostPort(t, l.Multiaddr())
+
+	// http2.Transport with AllowHTTP and a custom DialTLSContext that does
+	// a plain TCP dial is the canonical way to drive prior-knowledge h2c
+	// from a Go client.
+	h2cTransport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}
+	defer h2cTransport.CloseIdleConnections()
+	client := &http.Client{Transport: h2cTransport, Timeout: 5 * time.Second}
+
+	resp, err := client.Get("http://" + hostPort + "/h2c-test")
+	require.NoError(t, err, "h2c request must reach the fallback handler")
+	defer resp.Body.Close()
+
+	require.Equal(t, "HTTP/2.0", resp.Proto, "client should be talking h2c, not h1")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "proto=HTTP/2.0", string(got))
+}
+
+// TestFallbackHTTPHandler_PlainWS confirms that on a plain /ws listener
+// (no TLS), the fallback handler accepts HTTP/1.1 traffic. The HTTP/2
+// requirement only applies to /tls/ws listeners; plain /ws is meant to sit
+// behind a reverse proxy that terminates TLS upstream and may forward
+// HTTP/1.1.
+func TestFallbackHTTPHandler_PlainWS(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "plain")
+	})
+
+	_, u := newSecureUpgrader(t)
+	tpt, err := New(u, &network.NullResourceManager{}, nil, WithFallbackHTTPHandler(handler))
+	require.NoError(t, err)
+
+	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/ws"))
+	require.NoError(t, err)
+	t.Cleanup(func() { l.Close() })
+
+	hostPort := listenerHostPort(t, l.Multiaddr())
+	resp, err := http.Get("http://" + hostPort + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "plain", string(got))
+}
+
+// TestModernBrowserWSSFlow is the load-bearing test for "browsers must keep
+// being able to open wss:// against this listener". This is a hard
+// requirement when the listener also serves an HTTP/2 fallback handler.
+//
+// What modern browsers (Chrome, Firefox, Safari) do for `wss://`:
+//
+//  1. Open a TLS handshake offering ALPN ["h2", "http/1.1"].
+//  2. If the server picks "h2", read the server's first SETTINGS frame and
+//     check for SETTINGS_ENABLE_CONNECT_PROTOCOL=1 (RFC 8441 §3). If absent,
+//     close the HTTP/2 connection.
+//  3. Open a brand-new TLS handshake offering ALPN ["http/1.1"] only and
+//     perform the classic HTTP/1.1 Upgrade dance.
+//
+// This listener does not (and cannot today, see the comment in newListener)
+// advertise ENABLE_CONNECT_PROTOCOL, so the contract is:
+//
+//   - The h2 SETTINGS frame on the first attempt MUST NOT contain
+//     SettingEnableConnectProtocol; this is the signal browsers use to know
+//     they should fall back.
+//   - The HTTP/1.1 attempt MUST succeed — the WebSocket upgrade goes through
+//     gorilla as before.
+//
+// If either check fails, browser wss:// breaks. Do not relax this test
+// without also updating gorilla/websocket and the listener to actually
+// handle WS-over-HTTP/2 (RFC 8441 ext-CONNECT) end to end.
+func TestModernBrowserWSSFlow(t *testing.T) {
+	hostPort := startWSSListener(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "fallback")
+	}))
+
+	// Step 1: simulate the browser's first TLS handshake.
+	t.Run("h2_does_not_advertise_ext_connect", func(t *testing.T) {
+		conn, err := tls.Dial("tcp", hostPort, &tls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         []string{"h2", "http/1.1"},
+		})
+		require.NoError(t, err)
+		defer conn.Close()
+		require.Equal(t, "h2", conn.ConnectionState().NegotiatedProtocol,
+			"server must select h2 when client offers it; this is the path browsers take")
+
+		// Send the HTTP/2 client preface plus our own (empty) SETTINGS so
+		// the server is free to write its own SETTINGS frame back.
+		_, err = conn.Write([]byte(http2.ClientPreface))
+		require.NoError(t, err)
+		framer := http2.NewFramer(conn, conn)
+		require.NoError(t, framer.WriteSettings())
+
+		// Read frames until we see the server's initial (non-ACK) SETTINGS.
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
+		var serverSettings *http2.SettingsFrame
+		for i := 0; i < 8 && serverSettings == nil; i++ {
+			f, err := framer.ReadFrame()
+			require.NoError(t, err, "did not receive server SETTINGS in time")
+			if sf, ok := f.(*http2.SettingsFrame); ok && !sf.IsAck() {
+				serverSettings = sf
+			}
+		}
+		require.NotNil(t, serverSettings, "server never sent a non-ACK SETTINGS frame")
+
+		_, hasExtConnect := serverSettings.Value(http2.SettingEnableConnectProtocol)
+		require.False(t, hasExtConnect,
+			"server must NOT advertise SETTINGS_ENABLE_CONNECT_PROTOCOL; browsers rely on its absence to fall back to HTTP/1.1 for wss://")
+	})
+
+	// Step 2: simulate the browser's second attempt with ALPN restricted to
+	// HTTP/1.1, where the WebSocket upgrade actually happens.
+	t.Run("http1_fallback_wss_upgrade_succeeds", func(t *testing.T) {
+		dialer := gws.Dialer{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"http/1.1"},
+			},
+			HandshakeTimeout: 5 * time.Second,
+		}
+		conn, resp, err := dialer.Dial("wss://"+hostPort+"/", nil)
+		require.NoError(t, err, "browser HTTP/1.1 fallback must succeed; this is the actual WSS path")
+		defer conn.Close()
+		require.Equal(t, "HTTP/1.1", resp.Proto)
+		require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	})
+}
+
+// TestFallbackHTTPHandler_HTTP2NeverReachesWSPath locks down the dispatch
+// invariant that lets h2 and WSS coexist on the same listener: every HTTP/2
+// request must reach the fallback handler, never the WebSocket upgrade path.
+//
+// This holds today because gorilla/websocket's IsWebSocketUpgrade only looks
+// at HTTP/1 Upgrade headers, which the HTTP/2 framer (RFC 7540 §8.1.2.2)
+// refuses to carry. If a future version of gorilla/websocket adds RFC 8441
+// ("Bootstrapping WebSockets with HTTP/2", extended CONNECT) and silently
+// extends IsWebSocketUpgrade to detect it, this test will start failing,
+// which is the right cue to revisit the dispatch comment in
+// listener.ServeHTTP and decide whether to embrace WS-over-h2 or pin the
+// behaviour.
+func TestFallbackHTTPHandler_HTTP2NeverReachesWSPath(t *testing.T) {
+	var fallbackHits atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackHits.Add(1)
+		// Record the protocol so a regression makes the failure obvious.
+		w.Header().Set("X-Proto", r.Proto)
+		fmt.Fprint(w, "fallback")
+	})
+
+	hostPort := startWSSListener(t, handler)
+
+	// Force ALPN to h2 only, so the connection MUST be HTTP/2 or fail.
+	resp, err := httpsClient([]string{"h2"}).Get("https://" + hostPort + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "HTTP/2.0", resp.Proto)
+	require.Equal(t, "HTTP/2.0", resp.Header.Get("X-Proto"))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(1), fallbackHits.Load(),
+		"HTTP/2 request must reach the fallback handler, not the WebSocket upgrade path")
+}
+
+// TestFallbackHTTPHandler_KeepAlive ensures the handshake-timeout AfterFunc
+// is disarmed once a fallback request arrives. Otherwise the connection
+// would be force-closed at handshakeTimeout (default 15s) regardless of
+// active traffic.
+//
+// We exercise this with two HTTP/2 requests on a single shared connection,
+// spaced further apart than the handshake-timeout window. HTTP/2 keeps both
+// streams on one TCP connection by design, so if the timer were not
+// disarmed, the second request would race against the closer.
+func TestFallbackHTTPHandler_KeepAlive(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+
+	tlsConf := getTLSConf(t, net.ParseIP("127.0.0.1"), time.Now(), time.Now().Add(time.Hour))
+	_, u := newSecureUpgrader(t)
+	tpt, err := New(u, &network.NullResourceManager{}, nil,
+		WithTLSConfig(tlsConf),
+		WithHandshakeTimeout(200*time.Millisecond),
+		WithFallbackHTTPHandler(handler),
+	)
+	require.NoError(t, err)
+	l, err := tpt.Listen(ma.StringCast("/ip4/127.0.0.1/tcp/0/tls/ws"))
+	require.NoError(t, err)
+	t.Cleanup(func() { l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	hostPort := listenerHostPort(t, l.Multiaddr())
+
+	tr := &http.Transport{
+		ForceAttemptHTTP2: true,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         []string{"h2"},
+		},
+	}
+	defer tr.CloseIdleConnections()
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	resp, err := client.Get("https://" + hostPort + "/first")
+	require.NoError(t, err)
+	require.Equal(t, "HTTP/2.0", resp.Proto)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Wait past the handshake-timeout window. If Unwrap had not been
+	// called, the AfterFunc would have closed the underlying TCP
+	// connection that the HTTP/2 transport pools.
+	time.Sleep(400 * time.Millisecond)
+
+	resp, err = client.Get("https://" + hostPort + "/second")
+	require.NoError(t, err)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "HTTP/2.0", resp.Proto, "second request must reuse the same h2 connection")
+}

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -43,8 +43,7 @@ type listener struct {
 	wsurl     *url.URL
 
 	// httpHandler serves any request that is not a WebSocket upgrade.
-	// Nil means non-upgrade requests get a 404 (the historical behaviour).
-	// See [WithHTTPHandler] for the full rationale.
+	// Nil means non-upgrade requests get a 404. See [WithHTTPHandler].
 	httpHandler http.Handler
 }
 

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -226,8 +226,8 @@ func (l *listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// underlying connection 15s after Accept. The fallback handler may
 		// run for longer than that (HTTP/2 streams, HTTP/1.1 keep-alive),
 		// so the timer must go away once we know a request has arrived.
-		// Unwrap is idempotent; subsequent requests on a kept-alive
-		// connection are no-ops.
+		// Unwrap serializes through sync.Once, so concurrent h2 streams
+		// on the same TCP connection all see the same result.
 		if nc, err := l.extractConnFromContext(r.Context()); err == nil {
 			if _, err := nc.Unwrap(); err != nil {
 				// The handshake-timeout fired between Accept and now; the
@@ -352,28 +352,39 @@ func (c connWithScope) Close() error {
 
 type negotiatingConn struct {
 	connWithScope
-	ctx       context.Context
-	cancelCtx context.CancelFunc
-	stopClose func() bool
+	ctx        context.Context
+	cancelCtx  context.CancelFunc
+	stopClose  func() bool
+	disarmOnce sync.Once
+	timedOut   bool // written once inside disarmOnce, read after
 }
 
-// Close closes the negotiating conn and the underlying connWithScope
-// This will be called in case the tls handshake or websocket upgrade fails.
+// disarm stops the handshake-timeout AfterFunc set up in Accept and reports
+// whether the connection is still alive. Concurrent callers see the same
+// result, which the HTTP/2 fallback path needs when several streams share
+// one *negotiatingConn.
+func (c *negotiatingConn) disarm() (alive bool) {
+	c.disarmOnce.Do(func() {
+		if c.stopClose != nil {
+			c.timedOut = !c.stopClose()
+			c.stopClose = nil
+		}
+	})
+	return !c.timedOut
+}
+
+// Close closes the negotiating conn and the underlying connWithScope.
+// Called when the TLS handshake or WebSocket upgrade fails.
 func (c *negotiatingConn) Close() error {
 	defer c.cancelCtx()
-	if c.stopClose != nil {
-		c.stopClose()
-	}
+	c.disarm()
 	return c.connWithScope.Close()
 }
 
 func (c *negotiatingConn) Unwrap() (connWithScope, error) {
 	defer c.cancelCtx()
-	if c.stopClose != nil {
-		if !c.stopClose() {
-			return connWithScope{}, errors.New("timed out")
-		}
-		c.stopClose = nil
+	if !c.disarm() {
+		return connWithScope{}, errors.New("timed out")
 	}
 	return c.connWithScope, nil
 }

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -14,8 +14,6 @@ import (
 
 	ws "github.com/gorilla/websocket"
 	logging "github.com/libp2p/go-libp2p/gologshim"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/transport"
@@ -68,7 +66,7 @@ func (pwma *parsedWebsocketMultiaddr) toMultiaddr() ma.Multiaddr {
 // tlsConf may be nil (for unencrypted websockets).
 // httpHandler may be nil; when non-nil it serves every request that is
 // not a WebSocket upgrade.
-func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMgr, upgrader transport.Upgrader, handshakeTimeout time.Duration, httpHandler http.Handler) (*listener, error) {
+func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMgr, upgrader transport.Upgrader, handshakeTimeout time.Duration, httpHandler http.Handler, serverConfig func(*http.Server)) (*listener, error) {
 	parsed, err := parseWebsocketMultiaddr(a)
 	if err != nil {
 		return nil, err
@@ -143,32 +141,44 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 		ConnContext: ln.ConnContext,
 		TLSConfig:   tlsConf,
 	}
-	// On a plaintext /ws listener with a fallback handler, wrap the handler
-	// so the same listener also accepts HTTP/2 cleartext (h2c). Reverse
-	// proxies that talk h2c to backends (Caddy, Traefik, nginx with the
-	// right config) get connection multiplexing for free; reverse proxies
-	// that only speak h1 to backends keep working through the same handler.
-	// On a /tls/ws listener we don't need this: h2 is negotiated via ALPN
-	// inside http.Server.ServeTLS.
-	if !parsed.isWSS && httpHandler != nil {
-		ln.server.Handler = h2c.NewHandler(ln, &http2.Server{})
+	if httpHandler != nil {
+		// A fallback request may run far longer than the handshake-timeout
+		// (HTTP/2 streams, HTTP/1.1 keep-alive), so bound connections with
+		// server-side timeouts. IdleTimeout caps idle keep-alive on both
+		// h1 and h2. ReadHeaderTimeout guards only h1 against slow-header
+		// clients; Go's HTTP/2 server ignores it. ReadTimeout and
+		// WriteTimeout are left unset on purpose, as they apply per request
+		// and would truncate large streamed responses.
+		ln.server.ReadHeaderTimeout = handshakeTimeout
+		ln.server.IdleTimeout = defaultHTTPIdleTimeout
+		if !parsed.isWSS {
+			// On a plaintext /ws listener, accept HTTP/2 cleartext (h2c)
+			// next to HTTP/1.1 so reverse proxies that speak h2c to
+			// backends (Caddy, Traefik, nginx) get HTTP/2 multiplexing.
+			// On /tls/ws, h2 is negotiated via ALPN inside ServeTLS.
+			p := new(http.Protocols)
+			p.SetHTTP1(true)
+			p.SetUnencryptedHTTP2(true)
+			ln.server.Protocols = p
+		}
+		// Let the caller tune timeouts and HTTP/2 settings; see
+		// [WithHTTPServerConfig]. The transport re-asserts the fields it
+		// must own afterwards so the hook cannot break request dispatch.
+		if serverConfig != nil {
+			serverConfig(&ln.server)
+		}
+		ln.server.Handler = ln
+		ln.server.ConnContext = ln.ConnContext
+		ln.server.TLSConfig = tlsConf
 	}
-	// Note on RFC 8441 (WebSocket-over-HTTP/2):
-	//
-	// We do NOT explicitly enable the HTTP/2 SETTINGS_ENABLE_CONNECT_PROTOCOL
-	// flag here, because Go's bundled http2 stack and golang.org/x/net/http2
-	// do not yet expose a per-server API for it (golang/go#71128). The flag
-	// is gated by a process-global GODEBUG=http2xconnect=1, which a library
-	// must not set on its own.
-	//
-	// The dispatch in ServeHTTP is, however, written to upgrade
-	// transparently: it defers the "is this a WebSocket upgrade?" decision
-	// to ws.IsWebSocketUpgrade. When upstream Go exposes the setting and
-	// gorilla/websocket adds server-side ext-CONNECT support (most likely
-	// by extending IsWebSocketUpgrade and Upgrader.Upgrade to recognise
-	// `:method=CONNECT, :protocol=websocket`), this listener will accept
-	// WS-over-HTTP/2 with no code change — only a gorilla bump and a
-	// future Go upgrade.
+	// RFC 8441 (WebSocket-over-HTTP/2) is intentionally not advertised: the
+	// server never enables SETTINGS_ENABLE_CONNECT_PROTOCOL, so browsers fall
+	// back to HTTP/1.1 for wss://, where gorilla/websocket can hijack the
+	// connection. Go gates that setting behind a process-global
+	// GODEBUG=http2xconnect=1 (golang/go#71128), which a library must not set.
+	// Dispatch in ServeHTTP defers the "is this a WebSocket upgrade?" decision
+	// to ws.IsWebSocketUpgrade, so if a future gorilla and Go add server-side
+	// ext-CONNECT support, this listener upgrades to it without code changes.
 	return ln, nil
 }
 

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -44,10 +44,10 @@ type listener struct {
 	closed    chan struct{}
 	wsurl     *url.URL
 
-	// fallbackHTTPHandler serves any request that is not a WebSocket upgrade.
+	// httpHandler serves any request that is not a WebSocket upgrade.
 	// Nil means non-upgrade requests get a 404 (the historical behaviour).
-	// See [WithFallbackHTTPHandler] for the full rationale.
-	fallbackHTTPHandler http.Handler
+	// See [WithHTTPHandler] for the full rationale.
+	httpHandler http.Handler
 }
 
 var _ transport.GatedMaListener = &listener{}
@@ -66,9 +66,9 @@ func (pwma *parsedWebsocketMultiaddr) toMultiaddr() ma.Multiaddr {
 
 // newListener creates a new listener from a raw net.Listener.
 // tlsConf may be nil (for unencrypted websockets).
-// fallbackHTTPHandler may be nil; when non-nil it serves every request that is
+// httpHandler may be nil; when non-nil it serves every request that is
 // not a WebSocket upgrade.
-func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMgr, upgrader transport.Upgrader, handshakeTimeout time.Duration, fallbackHTTPHandler http.Handler) (*listener, error) {
+func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMgr, upgrader transport.Upgrader, handshakeTimeout time.Duration, httpHandler http.Handler) (*listener, error) {
 	parsed, err := parseWebsocketMultiaddr(a)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 			},
 			HandshakeTimeout: handshakeTimeout,
 		},
-		fallbackHTTPHandler: fallbackHTTPHandler,
+		httpHandler: httpHandler,
 	}
 	ln.server = http.Server{
 		Handler: ln,
@@ -150,7 +150,7 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 	// that only speak h1 to backends keep working through the same handler.
 	// On a /tls/ws listener we don't need this: h2 is negotiated via ALPN
 	// inside http.Server.ServeTLS.
-	if !parsed.isWSS && fallbackHTTPHandler != nil {
+	if !parsed.isWSS && httpHandler != nil {
 		ln.server.Handler = h2c.NewHandler(ln, &http2.Server{})
 	}
 	// Note on RFC 8441 (WebSocket-over-HTTP/2):
@@ -213,12 +213,12 @@ func (l *listener) extractConnFromContext(ctx context.Context) (*negotiatingConn
 func (l *listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Route non-WebSocket requests to the fallback handler if one is set.
 	// This is what lets a /tls/ws listener share a port with an ordinary
-	// HTTPS site; see [WithFallbackHTTPHandler]. The handler is invoked
+	// HTTPS site; see [WithHTTPHandler]. The handler is invoked
 	// for every HTTP version the listener accepts (h1 and h2 over TLS,
 	// h1 and h2c on plaintext) so callers do not have to pre-screen
 	// clients by HTTP version.
 	if !ws.IsWebSocketUpgrade(r) {
-		if l.fallbackHTTPHandler == nil {
+		if l.httpHandler == nil {
 			http.NotFound(w, r)
 			return
 		}
@@ -236,7 +236,7 @@ func (l *listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		l.fallbackHTTPHandler.ServeHTTP(w, r)
+		l.httpHandler.ServeHTTP(w, r)
 		return
 	}
 

--- a/p2p/transport/websocket/listener.go
+++ b/p2p/transport/websocket/listener.go
@@ -14,6 +14,8 @@ import (
 
 	ws "github.com/gorilla/websocket"
 	logging "github.com/libp2p/go-libp2p/gologshim"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/transport"
@@ -41,6 +43,11 @@ type listener struct {
 	closeErr  error
 	closed    chan struct{}
 	wsurl     *url.URL
+
+	// fallbackHTTPHandler serves any request that is not a WebSocket upgrade.
+	// Nil means non-upgrade requests get a 404 (the historical behaviour).
+	// See [WithFallbackHTTPHandler] for the full rationale.
+	fallbackHTTPHandler http.Handler
 }
 
 var _ transport.GatedMaListener = &listener{}
@@ -59,7 +66,9 @@ func (pwma *parsedWebsocketMultiaddr) toMultiaddr() ma.Multiaddr {
 
 // newListener creates a new listener from a raw net.Listener.
 // tlsConf may be nil (for unencrypted websockets).
-func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMgr, upgrader transport.Upgrader, handshakeTimeout time.Duration) (*listener, error) {
+// fallbackHTTPHandler may be nil; when non-nil it serves every request that is
+// not a WebSocket upgrade.
+func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMgr, upgrader transport.Upgrader, handshakeTimeout time.Duration, fallbackHTTPHandler http.Handler) (*listener, error) {
 	parsed, err := parseWebsocketMultiaddr(a)
 	if err != nil {
 		return nil, err
@@ -124,6 +133,7 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 			},
 			HandshakeTimeout: handshakeTimeout,
 		},
+		fallbackHTTPHandler: fallbackHTTPHandler,
 	}
 	ln.server = http.Server{
 		Handler: ln,
@@ -133,6 +143,32 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config, sharedTcp *tcpreuse.ConnMg
 		ConnContext: ln.ConnContext,
 		TLSConfig:   tlsConf,
 	}
+	// On a plaintext /ws listener with a fallback handler, wrap the handler
+	// so the same listener also accepts HTTP/2 cleartext (h2c). Reverse
+	// proxies that talk h2c to backends (Caddy, Traefik, nginx with the
+	// right config) get connection multiplexing for free; reverse proxies
+	// that only speak h1 to backends keep working through the same handler.
+	// On a /tls/ws listener we don't need this: h2 is negotiated via ALPN
+	// inside http.Server.ServeTLS.
+	if !parsed.isWSS && fallbackHTTPHandler != nil {
+		ln.server.Handler = h2c.NewHandler(ln, &http2.Server{})
+	}
+	// Note on RFC 8441 (WebSocket-over-HTTP/2):
+	//
+	// We do NOT explicitly enable the HTTP/2 SETTINGS_ENABLE_CONNECT_PROTOCOL
+	// flag here, because Go's bundled http2 stack and golang.org/x/net/http2
+	// do not yet expose a per-server API for it (golang/go#71128). The flag
+	// is gated by a process-global GODEBUG=http2xconnect=1, which a library
+	// must not set on its own.
+	//
+	// The dispatch in ServeHTTP is, however, written to upgrade
+	// transparently: it defers the "is this a WebSocket upgrade?" decision
+	// to ws.IsWebSocketUpgrade. When upstream Go exposes the setting and
+	// gorilla/websocket adds server-side ext-CONNECT support (most likely
+	// by extending IsWebSocketUpgrade and Upgrader.Upgrade to recognise
+	// `:method=CONNECT, :protocol=websocket`), this listener will accept
+	// WS-over-HTTP/2 with no code change — only a gorilla bump and a
+	// future Go upgrade.
 	return ln, nil
 }
 
@@ -175,6 +211,35 @@ func (l *listener) extractConnFromContext(ctx context.Context) (*negotiatingConn
 }
 
 func (l *listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Route non-WebSocket requests to the fallback handler if one is set.
+	// This is what lets a /tls/ws listener share a port with an ordinary
+	// HTTPS site; see [WithFallbackHTTPHandler]. The handler is invoked
+	// for every HTTP version the listener accepts (h1 and h2 over TLS,
+	// h1 and h2c on plaintext) so callers do not have to pre-screen
+	// clients by HTTP version.
+	if !ws.IsWebSocketUpgrade(r) {
+		if l.fallbackHTTPHandler == nil {
+			http.NotFound(w, r)
+			return
+		}
+		// Disarm the handshake-timeout that would otherwise close the
+		// underlying connection 15s after Accept. The fallback handler may
+		// run for longer than that (HTTP/2 streams, HTTP/1.1 keep-alive),
+		// so the timer must go away once we know a request has arrived.
+		// Unwrap is idempotent; subsequent requests on a kept-alive
+		// connection are no-ops.
+		if nc, err := l.extractConnFromContext(r.Context()); err == nil {
+			if _, err := nc.Unwrap(); err != nil {
+				// The handshake-timeout fired between Accept and now; the
+				// connection is already closed. Nothing useful to send.
+				log.Debug("connection timed out before fallback request", "remote_addr", r.RemoteAddr)
+				return
+			}
+		}
+		l.fallbackHTTPHandler.ServeHTTP(w, r)
+		return
+	}
+
 	c, err := l.wsUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// The upgrader writes a response for us.

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -75,6 +75,11 @@ func WithTLSConfig(conf *tls.Config) Option {
 
 var defaultHandshakeTimeout = 15 * time.Second
 
+// defaultHTTPIdleTimeout bounds how long an idle fallback HTTP connection is
+// kept open. It applies whenever a fallback handler is configured via
+// [WithHTTPHandler], unless overridden with [WithHTTPServerConfig].
+var defaultHTTPIdleTimeout = 30 * time.Second
+
 // WithHandshakeTimeout sets a timeout for the websocket upgrade.
 func WithHandshakeTimeout(timeout time.Duration) Option {
 	return func(t *WebsocketTransport) error {
@@ -152,6 +157,31 @@ func WithHTTPHandler(h http.Handler) Option {
 	}
 }
 
+// WithHTTPServerConfig configures the [http.Server] that serves the fallback
+// handler set with [WithHTTPHandler], following the http2.ConfigureServer
+// pattern: the function tunes a server the transport owns. It runs once per
+// listener before the server starts, so callers can set timeouts and HTTP/2
+// settings:
+//
+//	websocket.WithHTTPServerConfig(func(s *http.Server) {
+//		s.IdleTimeout = 30 * time.Second
+//		s.ReadHeaderTimeout = 10 * time.Second
+//		s.HTTP2 = &http.HTTP2Config{MaxConcurrentStreams: 256}
+//	})
+//
+// The transport sets Handler, ConnContext, and TLSConfig (the latter from
+// [WithTLSConfig]) after the function runs and overwrites any change to them.
+// Avoid setting WriteTimeout or ReadTimeout if the handler streams large
+// responses, as they apply per request and would truncate it.
+//
+// This option has no effect unless [WithHTTPHandler] is also set.
+func WithHTTPServerConfig(fn func(*http.Server)) Option {
+	return func(t *WebsocketTransport) error {
+		t.httpServerConfig = fn
+		return nil
+	}
+}
+
 // WebsocketTransport is the actual go-libp2p transport
 type WebsocketTransport struct {
 	upgrader         transport.Upgrader
@@ -161,6 +191,7 @@ type WebsocketTransport struct {
 	sharedTcp        *tcpreuse.ConnMgr
 	handshakeTimeout time.Duration
 	httpHandler      http.Handler
+	httpServerConfig func(*http.Server)
 }
 
 var _ transport.Transport = (*WebsocketTransport)(nil)
@@ -321,7 +352,7 @@ func (t *WebsocketTransport) gatedMaListen(a ma.Multiaddr) (transport.GatedMaLis
 	if t.tlsConf != nil {
 		tlsConf = t.tlsConf.Clone()
 	}
-	l, err := newListener(a, tlsConf, t.sharedTcp, t.upgrader, t.handshakeTimeout, t.httpHandler)
+	l, err := newListener(a, tlsConf, t.sharedTcp, t.upgrader, t.handshakeTimeout, t.httpHandler, t.httpServerConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -88,68 +88,18 @@ func WithHandshakeTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithHTTPHandler installs an http.Handler that serves any non-upgrade
-// HTTP request that arrives on a WebSocket listener. This lets a libp2p node
-// share its WebSocket port with an ordinary HTTPS website.
+// WithHTTPHandler installs an http.Handler for requests that are not WebSocket
+// upgrades, letting a libp2p node share its WebSocket port with an ordinary
+// HTTP service behind the same TLS certificate.
 //
-// Why this matters: a /tls/ws listener is, on the wire, a normal HTTPS
-// endpoint that happens to accept WebSocket upgrades. By default the listener
-// rejects every request that is not a WebSocket upgrade, so a network observer
-// can fingerprint the port as "libp2p WSS" with a single HTTP probe. With a
-// fallback handler installed, the same port also serves real HTTP responses,
-// and the libp2p traffic looks indistinguishable from any other web traffic
-// behind the same TLS certificate. A censor that wants to block libp2p must
-// also block the website served from the fallback handler.
+// WebSocket upgrades go to the libp2p transport. Every other request
+// reaches the handler, over HTTP/1.1 or HTTP/2 on TLS listeners and over
+// HTTP/1.1 or HTTP/2 cleartext (h2c) on plaintext listeners. Without a handler,
+// non-upgrade requests get a 404.
 //
-// How requests are routed:
-//
-//   - Requests with a WebSocket upgrade (Connection: upgrade, Upgrade:
-//     websocket) go to the libp2p WebSocket transport, exactly as before.
-//   - Every other request reaches the fallback handler, regardless of
-//     HTTP version. On TLS listeners that means HTTP/1.1 and HTTP/2 (Go's
-//     http.Server.ServeTLS negotiates h2 via ALPN automatically). On
-//     plaintext listeners that means HTTP/1.1 and HTTP/2 cleartext (h2c):
-//     the listener is wrapped with [h2c.NewHandler] so reverse proxies
-//     that speak h2c to backends (Caddy, Traefik, nginx with the right
-//     config) get HTTP/2 multiplexing end-to-end, while proxies that only
-//     speak h1 keep working through the same listener.
-//   - If no fallback handler is configured, non-upgrade requests get a 404,
-//     which is the prior behaviour.
-//
-// The transport does not pre-screen clients by HTTP version. Operators that
-// want to force a specific minimum protocol can do so inside their own
-// http.Handler.
-//
-// HTTP/2 is negotiated automatically. Go's http.Server.ServeTLS calls
-// http2.ConfigureServer, which adds "h2" and "http/1.1" to the TLS ALPN list.
-// The two protocols then split cleanly:
-//
-//   - WebSocket clients only offer the "http/1.1" ALPN, so they always land
-//     on HTTP/1.1, where the gorilla/websocket Upgrader can hijack the
-//     connection.
-//   - HTTP/2 traffic cannot reach the WebSocket upgrade path: HTTP/2 forbids
-//     the Connection and Upgrade headers (RFC 7540 §8.1.2.2), and gorilla's
-//     server-side does not implement RFC 8441 (WebSockets over HTTP/2 via
-//     extended CONNECT). So gorilla.IsWebSocketUpgrade always returns false
-//     for h2 requests and they land on the fallback handler.
-//
-// If a future version of gorilla/websocket adds RFC 8441 support, the
-// dispatch automatically extends to it, because this code defers the
-// "is this a WebSocket upgrade?" decision to gorilla. The regression test
-// TestFallbackHTTPHandler_HTTP2NeverReachesWSPath pins the current
-// behaviour so any silent change is caught.
-//
-// The TLS certificate is shared. Both the WebSocket upgrade and the fallback
-// handler are served by the same http.Server with the same tls.Config (set
-// via [WithTLSConfig]), so a single certificate, for example one issued by
-// AutoTLS, covers all traffic on the port.
-//
-// The handler is invoked from many goroutines concurrently and must be safe
-// for concurrent use.
-//
-// This option also takes effect for plain /ws (non-TLS) listeners. The
-// censorship-resistance argument only applies to /tls/ws, but the routing
-// logic is the same.
+// The handler is invoked from many goroutines concurrently and must be safe for
+// concurrent use. Use [WithHTTPServerConfig] to set timeouts and HTTP/2
+// options on the underlying http.Server.
 func WithHTTPHandler(h http.Handler) Option {
 	return func(t *WebsocketTransport) error {
 		t.httpHandler = h

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -83,7 +83,7 @@ func WithHandshakeTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithFallbackHTTPHandler installs an http.Handler that serves any non-upgrade
+// WithHTTPHandler installs an http.Handler that serves any non-upgrade
 // HTTP request that arrives on a WebSocket listener. This lets a libp2p node
 // share its WebSocket port with an ordinary HTTPS website.
 //
@@ -145,22 +145,22 @@ func WithHandshakeTimeout(timeout time.Duration) Option {
 // This option also takes effect for plain /ws (non-TLS) listeners. The
 // censorship-resistance argument only applies to /tls/ws, but the routing
 // logic is the same.
-func WithFallbackHTTPHandler(h http.Handler) Option {
+func WithHTTPHandler(h http.Handler) Option {
 	return func(t *WebsocketTransport) error {
-		t.fallbackHTTPHandler = h
+		t.httpHandler = h
 		return nil
 	}
 }
 
 // WebsocketTransport is the actual go-libp2p transport
 type WebsocketTransport struct {
-	upgrader            transport.Upgrader
-	rcmgr               network.ResourceManager
-	tlsClientConf       *tls.Config
-	tlsConf             *tls.Config
-	sharedTcp           *tcpreuse.ConnMgr
-	handshakeTimeout    time.Duration
-	fallbackHTTPHandler http.Handler
+	upgrader         transport.Upgrader
+	rcmgr            network.ResourceManager
+	tlsClientConf    *tls.Config
+	tlsConf          *tls.Config
+	sharedTcp        *tcpreuse.ConnMgr
+	handshakeTimeout time.Duration
+	httpHandler      http.Handler
 }
 
 var _ transport.Transport = (*WebsocketTransport)(nil)
@@ -321,7 +321,7 @@ func (t *WebsocketTransport) gatedMaListen(a ma.Multiaddr) (transport.GatedMaLis
 	if t.tlsConf != nil {
 		tlsConf = t.tlsConf.Clone()
 	}
-	l, err := newListener(a, tlsConf, t.sharedTcp, t.upgrader, t.handshakeTimeout, t.fallbackHTTPHandler)
+	l, err := newListener(a, tlsConf, t.sharedTcp, t.upgrader, t.handshakeTimeout, t.httpHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/transport/websocket/websocket.go
+++ b/p2p/transport/websocket/websocket.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -82,14 +83,84 @@ func WithHandshakeTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithFallbackHTTPHandler installs an http.Handler that serves any non-upgrade
+// HTTP request that arrives on a WebSocket listener. This lets a libp2p node
+// share its WebSocket port with an ordinary HTTPS website.
+//
+// Why this matters: a /tls/ws listener is, on the wire, a normal HTTPS
+// endpoint that happens to accept WebSocket upgrades. By default the listener
+// rejects every request that is not a WebSocket upgrade, so a network observer
+// can fingerprint the port as "libp2p WSS" with a single HTTP probe. With a
+// fallback handler installed, the same port also serves real HTTP responses,
+// and the libp2p traffic looks indistinguishable from any other web traffic
+// behind the same TLS certificate. A censor that wants to block libp2p must
+// also block the website served from the fallback handler.
+//
+// How requests are routed:
+//
+//   - Requests with a WebSocket upgrade (Connection: upgrade, Upgrade:
+//     websocket) go to the libp2p WebSocket transport, exactly as before.
+//   - Every other request reaches the fallback handler, regardless of
+//     HTTP version. On TLS listeners that means HTTP/1.1 and HTTP/2 (Go's
+//     http.Server.ServeTLS negotiates h2 via ALPN automatically). On
+//     plaintext listeners that means HTTP/1.1 and HTTP/2 cleartext (h2c):
+//     the listener is wrapped with [h2c.NewHandler] so reverse proxies
+//     that speak h2c to backends (Caddy, Traefik, nginx with the right
+//     config) get HTTP/2 multiplexing end-to-end, while proxies that only
+//     speak h1 keep working through the same listener.
+//   - If no fallback handler is configured, non-upgrade requests get a 404,
+//     which is the prior behaviour.
+//
+// The transport does not pre-screen clients by HTTP version. Operators that
+// want to force a specific minimum protocol can do so inside their own
+// http.Handler.
+//
+// HTTP/2 is negotiated automatically. Go's http.Server.ServeTLS calls
+// http2.ConfigureServer, which adds "h2" and "http/1.1" to the TLS ALPN list.
+// The two protocols then split cleanly:
+//
+//   - WebSocket clients only offer the "http/1.1" ALPN, so they always land
+//     on HTTP/1.1, where the gorilla/websocket Upgrader can hijack the
+//     connection.
+//   - HTTP/2 traffic cannot reach the WebSocket upgrade path: HTTP/2 forbids
+//     the Connection and Upgrade headers (RFC 7540 §8.1.2.2), and gorilla's
+//     server-side does not implement RFC 8441 (WebSockets over HTTP/2 via
+//     extended CONNECT). So gorilla.IsWebSocketUpgrade always returns false
+//     for h2 requests and they land on the fallback handler.
+//
+// If a future version of gorilla/websocket adds RFC 8441 support, the
+// dispatch automatically extends to it, because this code defers the
+// "is this a WebSocket upgrade?" decision to gorilla. The regression test
+// TestFallbackHTTPHandler_HTTP2NeverReachesWSPath pins the current
+// behaviour so any silent change is caught.
+//
+// The TLS certificate is shared. Both the WebSocket upgrade and the fallback
+// handler are served by the same http.Server with the same tls.Config (set
+// via [WithTLSConfig]), so a single certificate, for example one issued by
+// AutoTLS, covers all traffic on the port.
+//
+// The handler is invoked from many goroutines concurrently and must be safe
+// for concurrent use.
+//
+// This option also takes effect for plain /ws (non-TLS) listeners. The
+// censorship-resistance argument only applies to /tls/ws, but the routing
+// logic is the same.
+func WithFallbackHTTPHandler(h http.Handler) Option {
+	return func(t *WebsocketTransport) error {
+		t.fallbackHTTPHandler = h
+		return nil
+	}
+}
+
 // WebsocketTransport is the actual go-libp2p transport
 type WebsocketTransport struct {
-	upgrader         transport.Upgrader
-	rcmgr            network.ResourceManager
-	tlsClientConf    *tls.Config
-	tlsConf          *tls.Config
-	sharedTcp        *tcpreuse.ConnMgr
-	handshakeTimeout time.Duration
+	upgrader            transport.Upgrader
+	rcmgr               network.ResourceManager
+	tlsClientConf       *tls.Config
+	tlsConf             *tls.Config
+	sharedTcp           *tcpreuse.ConnMgr
+	handshakeTimeout    time.Duration
+	fallbackHTTPHandler http.Handler
 }
 
 var _ transport.Transport = (*WebsocketTransport)(nil)
@@ -250,7 +321,7 @@ func (t *WebsocketTransport) gatedMaListen(a ma.Multiaddr) (transport.GatedMaLis
 	if t.tlsConf != nil {
 		tlsConf = t.tlsConf.Clone()
 	}
-	l, err := newListener(a, tlsConf, t.sharedTcp, t.upgrader, t.handshakeTimeout)
+	l, err := newListener(a, tlsConf, t.sharedTcp, t.upgrader, t.handshakeTimeout, t.fallbackHTTPHandler)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds `websocket.WithHTTPHandler(http.Handler)` so a `/ws` or `/tls/ws` listener answers non-WebSocket requests with the supplied handler instead of 404, on the same TCP port, plus `websocket.WithHTTPServerConfig(func(*http.Server))` to configure that server's timeouts and HTTP/2 settings.

:point_right:  Opt-in, backward-compatible, default behaviour is unchanged, but go-libp2p gains important regression tests.

## Two uses

- Share a libp2p WebSocket port with an ordinary HTTPS site. The port looks like a normal HTTPS endpoint that also accepts WebSocket upgrades. Libp2p on port 443 with regular website becomes way harder to censor.
- Expose kubo's trustless gateway on the AutoTLS-secured `/tls/ws` port. HTTP retrieval clients (`boxo/bitswap/network/httpnet`) fetch blocks directly over HTTPS using the AutoTLS cert. Improved interop of IPFS stack.

## Routing

WebSocket upgrades go to libp2p as before; everything else goes to the handler. The handler runs over HTTP/1.1 and HTTP/2 on TLS listeners (ALPN inside `http.Server.ServeTLS`) and over HTTP/1.1 and HTTP/2 cleartext on plaintext listeners (`net/http` `Protocols` with `SetUnencryptedHTTP2`). Also in `tcpreuse`: `IsHTTP` matches the `PRI` h2c preface so it routes to the HTTP demux branch.

```go
tpt, err := websocket.New(upgrader, rcmgr, sharedTCP,
    websocket.WithTLSConfig(tlsConfig),
    websocket.WithHTTPHandler(httpHandler),
    websocket.WithHTTPServerConfig(func(s *http.Server) {
        s.IdleTimeout = 30 * time.Second
        s.HTTP2 = &http.HTTP2Config{MaxConcurrentStreams: 256}
    }),
)
```

> [!IMPORTANT]
> Real-world example in ipfs/kubo#11333, where kubo uses both opt-in funcs to expose its trustless gateway on the AutoTLS-secured `/ws` and `/tls/ws` TCP ports, on one Let's Encrypt cert:
> - `WithHTTPHandler` installs the trustless gateway handler (h2 required over TLS, h1+h2c allowed cleartext).
> - `WithHTTPServerConfig` sets streaming-safe timeouts and HTTP/2 limits, deriving `WriteByteTimeout`/`SendPingTimeout` from `Gateway.RetrievalTimeout` so the gateway's own 504 fires before the connection is dropped.
>
> An in-process AutoTLS canary (Pebble + p2p-forge) exercises the full path end to end.

## Regression tests

:point_right: tests added here protect ecosystem from silently breaking `/ws`.

**gorilla/websocket has no HTTP/2 / RFC 8441 server support today.** WebSocket-over-h2 needs extended CONNECT (`:method=CONNECT, :protocol=websocket`); gorilla's `Upgrader.Upgrade` still reads HTTP/1.1 hijack-based headers, and Go's h2 stack does not advertise `SETTINGS_ENABLE_CONNECT_PROTOCOL` (gated on process-global `GODEBUG=http2xconnect=1`; per-server API tracked in `golang/go#71128`). Two tripwires added by this PR catch any future upstream shift so go-libp2p maintainers can deliberately embrace WS-over-h2 or pin the dispatch:

- `TestFallbackHTTPHandler_HTTP2NeverReachesWSPath`: every HTTP/2 request reaches the fallback handler, never the WebSocket hijack path. Fails if a future gorilla release extends `IsWebSocketUpgrade` to recognise ext-CONNECT.
- `TestModernBrowserWSSFlow`: the server's initial h2 SETTINGS frame omits `SETTINGS_ENABLE_CONNECT_PROTOCOL`. Browsers rely on its absence to fall back to HTTP/1.1 for `wss://`; the test fails if Go ever flips this flag on by default.

Plus a concurrency pin for the new fallback path:

- `TestFallbackHTTPHandler_KeepAlive` + `TestNegotiatingConnUnwrapConcurrent`: the handshake-timer is disarmed once a fallback request arrives, safely under concurrent HTTP/2 streams sharing one `*negotiatingConn`.