### PR TITLE
p2p/net/swarm: prevent shutdown hang on connectedness backpressure

### DIFF
--- a/p2p/net/swarm/connection_events_emitter.go
+++ b/p2p/net/swarm/connection_events_emitter.go
@@ -3,11 +3,15 @@ package swarm
 import (
 	"context"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
+
+const connectednessEventQueueStallTimeout = 30 * time.Second
 
 type peerConnectednessEventType int
 
@@ -24,9 +28,10 @@ type peerConnectednessEvent struct {
 // connectionEventsEmitter emits PeerConnectednessChanged events and dispatches
 // per-conn Connected / Disconnected callbacks supplied by the owner.
 //
-// We ensure that for any peer we connected to we always sent atleast 1 NotConnected Event after
-// the peer disconnects. This is because peers can observe a connection before they are notified
-// of the connection by a peer connectedness changed event.
+// Under normal operation, we ensure that for any peer we connected to we always
+// send at least 1 NotConnected Event after the peer disconnects. This is
+// because peers can observe a connection before they are notified of the
+// connection by a peer connectedness changed event.
 //
 // For the per-conn callbacks, we guarantee that for a given *Conn,
 // onDisconnected never fires before the corresponding onConnected has finished.
@@ -38,8 +43,9 @@ type peerConnectednessEvent struct {
 // from a goroutine; AddConn always runs onConnected synchronously so callers
 // see Connected fire before they continue.
 type connectionEventsEmitter struct {
-	// peerConnectednessCh carries add and remove events to the run loop, which
-	// uses them to emit PeerConnectednessChanged events.
+	// peerConnectednessCh is intentionally bounded. A slow connectedness event
+	// consumer should apply backpressure instead of allowing unbounded pending
+	// peer state to accumulate in the swarm.
 	peerConnectednessCh chan peerConnectednessEvent
 	// lastConnectednessEvent is the last connectedness event sent for a particular peer.
 	lastConnectednessEvent map[peer.ID]network.Connectedness
@@ -55,9 +61,12 @@ type connectionEventsEmitter struct {
 	// closeMu serializes the (closed-check + wg.Add) pair against Close. It is
 	// only held across that pair, never during the actual dispatch work, so
 	// Add/Remove operations across different conns still run concurrently.
-	closeMu sync.Mutex
-	closed  bool
-	wg      sync.WaitGroup
+	closeMu        sync.Mutex
+	closed         bool
+	shuttingDown   atomic.Bool
+	shutdownOnce   sync.Once
+	shutdownNotify chan struct{}
+	wg             sync.WaitGroup
 	// loopCtx / loopWG track the runEmitter goroutine separately from the
 	// in-flight Add/Remove operations.
 	loopWG sync.WaitGroup
@@ -86,6 +95,7 @@ func newConnectionEventsEmitter(
 		emitter:                emitter,
 		ctx:                    loopCtx,
 		cancel:                 loopCancel,
+		shutdownNotify:         make(chan struct{}),
 		connected:              make(map[*Conn]struct{}),
 		pendingDisconnect:      make(map[*Conn]struct{}),
 		onConnected:            onConnected,
@@ -106,10 +116,10 @@ func (c *connectionEventsEmitter) AddConn(conn *Conn) {
 	c.closeMu.Unlock()
 	defer c.wg.Done()
 
-	c.peerConnectednessCh <- peerConnectednessEvent{
+	c.enqueuePeerConnectednessEvent(peerConnectednessEvent{
 		PeerID: conn.RemotePeer(),
 		Type:   addConnEvent,
-	}
+	})
 
 	// Dispatch onConnected before touching notifsLk so that a concurrent
 	// RemoveConn cannot observe `connected[conn]` and fire onDisconnected
@@ -149,10 +159,10 @@ func (c *connectionEventsEmitter) RemoveConn(conn *Conn) {
 	c.closeMu.Unlock()
 	defer c.wg.Done()
 
-	c.peerConnectednessCh <- peerConnectednessEvent{
+	c.enqueuePeerConnectednessEvent(peerConnectednessEvent{
 		PeerID: conn.RemotePeer(),
 		Type:   removeConnEvent,
-	}
+	})
 
 	var dispatchDisconnect bool
 	c.notifsLk.Lock()
@@ -175,9 +185,56 @@ func (c *connectionEventsEmitter) Close() {
 	c.closeMu.Lock()
 	c.closed = true
 	c.closeMu.Unlock()
-	c.wg.Wait() // safe: closed=true blocks any new wg.Add
 	c.cancel()
-	c.loopWG.Wait()
+	c.wg.Wait() // safe: closed=true blocks any new wg.Add
+	// Do not make Swarm.Close wait on a slow eventbus subscriber. The loop
+	// goroutine will finish once any in-flight Emit returns.
+	go func() {
+		c.loopWG.Wait()
+		_ = c.emitter.Close()
+	}()
+}
+
+// StartShutdown switches the enqueue path from runtime backpressure to
+// best-effort delivery. During shutdown, freeing connection goroutines is more
+// important than preserving every final connectedness event.
+func (c *connectionEventsEmitter) StartShutdown() {
+	c.shuttingDown.Store(true)
+	c.shutdownOnce.Do(func() { close(c.shutdownNotify) })
+}
+
+func (c *connectionEventsEmitter) enqueuePeerConnectednessEvent(evt peerConnectednessEvent) {
+	if c.shuttingDown.Load() {
+		// Closing the swarm has already made the final peer state observable via
+		// Network.Connectedness. Avoid blocking shutdown on a full event queue.
+		select {
+		case c.peerConnectednessCh <- evt:
+		default:
+			log.Warn("dropping connectedness event during swarm shutdown because the queue is full", "peer", evt.PeerID)
+		}
+		return
+	}
+
+	timer := time.NewTimer(connectednessEventQueueStallTimeout)
+	defer timer.Stop()
+	select {
+	case c.peerConnectednessCh <- evt:
+		return
+	case <-c.shutdownNotify:
+		return
+	case <-c.ctx.Done():
+		return
+	case <-timer.C:
+		log.Error("slow connectedness event consumer, connection notification stalled", "peer", evt.PeerID)
+	}
+
+	// Preserve the existing backpressure semantics after logging. This keeps the
+	// queue bounded and avoids dropping connectedness events during normal use.
+	select {
+	case c.peerConnectednessCh <- evt:
+	case <-c.shutdownNotify:
+	case <-c.ctx.Done():
+	}
 }
 
 func (c *connectionEventsEmitter) runEmitter() {

--- a/p2p/net/swarm/connection_events_emitter_test.go
+++ b/p2p/net/swarm/connection_events_emitter_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -132,6 +133,137 @@ func TestEmitter_NormalOrder(t *testing.T) {
 	require.Empty(t, e.connected)
 	require.Empty(t, e.pendingDisconnect)
 	e.notifsLk.Unlock()
+}
+
+func TestEmitter_AddConnBackpressuresOnFullQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &connectionEventsEmitter{
+		peerConnectednessCh: make(chan peerConnectednessEvent, 1),
+		connected:           make(map[*Conn]struct{}),
+		pendingDisconnect:   make(map[*Conn]struct{}),
+		ctx:                 ctx,
+		cancel:              cancel,
+		shutdownNotify:      make(chan struct{}),
+		onConnected:         func(*Conn) {},
+		onDisconnected:      func(*Conn) {},
+	}
+	c.peerConnectednessCh <- peerConnectednessEvent{PeerID: test.RandPeerIDFatal(t), Type: addConnEvent}
+
+	done := make(chan struct{})
+	conn := newTestConn(t)
+	go func() {
+		c.AddConn(conn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("AddConn returned while the connectedness event queue was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	select {
+	case <-c.peerConnectednessCh:
+	default:
+		t.Fatal("expected the connectedness event queue to contain the blocking event")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("AddConn did not resume after connectedness event queue capacity became available")
+	}
+
+	c.notifsLk.Lock()
+	_, connected := c.connected[conn]
+	c.notifsLk.Unlock()
+	require.True(t, connected, "AddConn should dispatch Connected state after queueing the connectedness event")
+}
+
+func TestEmitter_RemoveConnBackpressuresOnFullQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn := newTestConn(t)
+	disconnected := make(chan struct{})
+	c := &connectionEventsEmitter{
+		peerConnectednessCh: make(chan peerConnectednessEvent, 1),
+		connected:           map[*Conn]struct{}{conn: {}},
+		pendingDisconnect:   make(map[*Conn]struct{}),
+		ctx:                 ctx,
+		cancel:              cancel,
+		shutdownNotify:      make(chan struct{}),
+		onConnected:         func(*Conn) {},
+		onDisconnected: func(*Conn) {
+			close(disconnected)
+		},
+	}
+	c.peerConnectednessCh <- peerConnectednessEvent{PeerID: test.RandPeerIDFatal(t), Type: removeConnEvent}
+
+	done := make(chan struct{})
+	go func() {
+		c.RemoveConn(conn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("RemoveConn returned while the connectedness event queue was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	select {
+	case <-c.peerConnectednessCh:
+	default:
+		t.Fatal("expected the connectedness event queue to contain the blocking event")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RemoveConn did not resume after connectedness event queue capacity became available")
+	}
+	select {
+	case <-disconnected:
+	case <-time.After(time.Second):
+		t.Fatal("RemoveConn did not dispatch Disconnected after queueing the connectedness event")
+	}
+}
+
+func TestEmitter_ShutdownUnblocksQueuedAddConn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &connectionEventsEmitter{
+		peerConnectednessCh: make(chan peerConnectednessEvent, 1),
+		connected:           make(map[*Conn]struct{}),
+		pendingDisconnect:   make(map[*Conn]struct{}),
+		ctx:                 ctx,
+		cancel:              cancel,
+		shutdownNotify:      make(chan struct{}),
+		onConnected:         func(*Conn) {},
+		onDisconnected:      func(*Conn) {},
+	}
+	c.peerConnectednessCh <- peerConnectednessEvent{PeerID: test.RandPeerIDFatal(t), Type: addConnEvent}
+
+	done := make(chan struct{})
+	go func() {
+		c.AddConn(newTestConn(t))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("AddConn returned before shutdown while the connectedness event queue was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	c.StartShutdown()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not unblock AddConn waiting on the connectedness event queue")
+	}
 }
 
 // TestEmitter_ConcurrentAddRemoveOrdering exercises many conns in parallel,

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -307,6 +307,10 @@ func (s *Swarm) close() {
 	s.conns.m = nil
 	s.conns.Unlock()
 
+	// From here on, RemoveConn notifications are part of shutdown cleanup. They
+	// must not keep Close blocked behind a slow connectedness event subscriber.
+	s.connectionEventsEmitter.StartShutdown()
+
 	// Lots of goroutines but we might as well do this in parallel. We want to shut down as fast as
 	// possible.
 	s.refs.Add(len(listeners))
@@ -330,11 +334,8 @@ func (s *Swarm) close() {
 	}
 
 	// Wait for everything to finish.
-	// We must wait for all the connection notifications to complete before
-	// closing the events emitter.
 	s.refs.Wait()
 	s.connectionEventsEmitter.Close()
-	s.emitter.Close()
 
 	// Now close out any transports (if necessary). Do this after closing
 	// all connections/listeners.

--- a/p2p/net/swarm/swarm_event_test.go
+++ b/p2p/net/swarm/swarm_event_test.go
@@ -49,6 +49,76 @@ func checkEvent(t *testing.T, sub event.Subscription, expected event.EvtPeerConn
 	}
 }
 
+func blockConnectednessSubscriberOnSignal(t *testing.T, bus event.Bus) (block, unblock chan struct{}) {
+	t.Helper()
+
+	sub, err := bus.Subscribe(new(event.EvtPeerConnectednessChanged), eventbus.BufSize(1))
+	require.NoError(t, err)
+	t.Cleanup(func() { sub.Close() })
+
+	block = make(chan struct{})
+	unblock = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-block:
+				<-sub.Out()
+				<-unblock
+				return
+			case _, ok := <-sub.Out():
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+	return block, unblock
+}
+
+func connectSwarmPeers(t *testing.T, dialer *Swarm, count int) []*Swarm {
+	t.Helper()
+
+	peers := make([]*Swarm, 0, count)
+	for range count {
+		listener := swarmt.GenSwarm(t)
+		dialer.Peerstore().AddAddrs(listener.LocalPeer(), []ma.Multiaddr{listener.ListenAddresses()[0]}, time.Hour)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, err := dialer.DialPeer(ctx, listener.LocalPeer())
+		cancel()
+		require.NoError(t, err)
+
+		peers = append(peers, listener)
+	}
+	return peers
+}
+
+func TestConnectednessBackpressureAllowsSwarmClose(t *testing.T) {
+	bus := eventbus.NewBus()
+	sw := swarmt.GenSwarm(t, swarmt.EventBus(bus))
+
+	block, unblock := blockConnectednessSubscriberOnSignal(t, bus)
+	t.Cleanup(func() { close(unblock) })
+
+	peers := connectSwarmPeers(t, sw, 40)
+	for _, peer := range peers {
+		t.Cleanup(func() { peer.Close() })
+	}
+
+	close(block)
+	closeDone := make(chan struct{})
+	go func() {
+		sw.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Swarm.Close blocked on connectedness event backpressure")
+	}
+}
+
 func TestConnectednessEventsSingleConn(t *testing.T) {
 	s1, sub1 := newSwarmWithSubscription(t)
 	s2, sub2 := newSwarmWithSubscription(t)


### PR DESCRIPTION
## Issue

While reviewing the swarm connection lifecycle, found that connectedness event backpressure can stall connection notification paths. When a connection is added or removed, the swarm queues a `PeerConnectednessChanged` event through the connection events emitter. That queue is bounded. If the connectedness emitter goroutine is blocked, for example because an eventbus subscriber is slow or stuck, the queue can fill up and later callers can block while trying to enqueue another connectedness event.

That runtime backpressure is intentional. The swarm should not silently drop connectedness events, reject otherwise valid connections, or replace the bounded queue with unbounded pending state during normal operation.

The issue fixed here is the shutdown/lifecycle side of that behavior. During `Swarm.Close`, connection cleanup can also try to enqueue connectedness events. If the queue is full and event delivery is blocked, those cleanup goroutines can remain stuck, which can cause `Swarm.Close` to wait forever.

## Fix

This change keeps the normal runtime behavior conservative and bounded.

During normal operation:

- the connectedness event queue remains bounded,
- `AddConn` / `RemoveConn` still apply backpressure when the queue is full,
- connectedness events are not dropped,
- valid connections are not rejected,
- and no unbounded pending queue is introduced.

To make the runtime stall visible, enqueueing now logs an error if a connection notification remains blocked for 30 seconds, then continues waiting. This preserves the existing semantics while making slow connectedness event consumers easier to diagnose.

During shutdown, the behavior changes intentionally. `Swarm.Close` now marks the connection events emitter as shutting down before closing active connections. In shutdown mode, enqueueing connectedness events becomes best-effort, so cleanup goroutines are not held forever behind a full event queue.

This does not fully remove runtime connection setup backpressure. I stopped short of that because the safer behavior here is to preserve the existing ordering and bounded memory guarantees. The alternatives are not good tradeoffs:

- dropping runtime connectedness events can hide real connection state,
- rejecting valid connections when a small queue is full is too aggressive,
- using an unbounded pending queue can grow badly under churn,
- moving `c.start()` before notification changes existing ordering semantics.

So this patch keeps the safe runtime behavior and fixes the shutdown hang case.

## Tests
Added focused coverage in the existing swarm test files:

- `TestEmitter_AddConnBackpressuresOnFullQueue`
- `TestEmitter_RemoveConnBackpressuresOnFullQueue`
- `TestEmitter_ShutdownUnblocksQueuedAddConn`
- `TestConnectednessBackpressureAllowsSwarmClose`

These tests verify that runtime backpressure is preserved, queued operations resume when capacity is available, shutdown unblocks queued connection notifications, and `Swarm.Close` completes even when connectedness event delivery is backpressured.