### PR TITLE
feat(webrtc): stable /certhash across restarts

### DIFF
--- a/p2p/transport/webrtc/cert.go
+++ b/p2p/transport/webrtc/cert.go
@@ -70,11 +70,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/hkdf"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -139,11 +139,12 @@ func newDeterministicCertificate(key ic.PrivKey) (*webrtc.Certificate, error) {
 		SignatureAlgorithm: x509.ECDSAWithSHA256,
 	}
 
-	// CreateCertificate forwards rand only to the signer (the supplied non-nil
-	// SerialNumber means it never draws rand for that). deterministicSigner
-	// ignores the reader and signs with nil, the Go 1.24+ deterministic ECDSA
-	// path, so the DER bytes are reproducible regardless of the reader here.
-	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, priv.Public(), deterministicSigner{priv})
+	// CreateCertificate must not draw entropy here: SerialNumber is set (so no
+	// random serial) and deterministicSigner signs with nil rand. failingReader
+	// keeps that invariant local to the call: if a future stdlib change starts
+	// consuming rand, cert creation fails loudly instead of silently producing a
+	// non-deterministic cert that rotates every /certhash.
+	der, err := x509.CreateCertificate(failingReader{}, tpl, tpl, priv.Public(), deterministicSigner{priv})
 	if err != nil {
 		return nil, fmt.Errorf("create x509 certificate: %w", err)
 	}
@@ -172,4 +173,14 @@ func (ds deterministicSigner) Public() crypto.PublicKey { return ds.priv.Public(
 
 func (ds deterministicSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	return ds.priv.Sign(nil, digest, opts)
+}
+
+// failingReader is the rand source passed to x509.CreateCertificate. A
+// deterministic cert must consume no entropy, so any Read here means a code or
+// stdlib change started drawing randomness and would silently rotate the
+// /certhash. Failing the Read turns that into an error at cert creation.
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("deterministic cert creation must not consume entropy")
 }

--- a/p2p/transport/webrtc/cert.go
+++ b/p2p/transport/webrtc/cert.go
@@ -8,37 +8,32 @@ package libp2pwebrtc
 //
 // Why this is safe:
 //
-//   - The DTLS cert is not the identity credential. Peer identity comes from
+//   - The DTLS cert is not the identity credential: peer identity comes from
 //     a Noise XX handshake run inside DTLS, with both cert fingerprints
 //     bound into the Noise prologue.
 //     webrtc-direct: https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md
 //     noise: https://github.com/libp2p/specs/blob/master/noise/README.md
 //
-//   - The libp2p spec tells the server to disable DTLS fingerprint
-//     verification, since the server does not know the client cert in
-//     advance. The server therefore inspects no cert details beyond the
-//     handshake.
+//   - The server disables DTLS fingerprint verification: per the libp2p spec
+//     it does not know the client cert in advance, so it inspects no cert
+//     details beyond the handshake.
 //
-//   - Browser DTLS verifies the server cert only by matching its SHA-256
-//     against the SDP a=fingerprint line the browser builds from /certhash.
-//     Self-signed peer certs have no trust chain; NotBefore and NotAfter are
-//     not part of the check. RFC 8122 (which defines a=fingerprint) requires
-//     only the fingerprint match.
+//   - The browser verifies the server cert by SHA-256 fingerprint alone: it
+//     matches the cert against the SDP a=fingerprint line built from
+//     /certhash. Self-signed peer certs have no trust chain, and RFC 8122
+//     (which defines a=fingerprint) requires only the fingerprint match, not
+//     NotBefore or NotAfter.
 //     https://datatracker.ietf.org/doc/html/rfc8122
 //
-//   - The 365-day validity cap in the W3C WebRTC spec applies only to certs
-//     the browser generates for itself, not to the remote peer cert /certhash
-//     points to.
-//     https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-generatecertificate
-//
-//   - Pion rejects a local cert whose NotAfter has already passed when
-//     constructing a PeerConnection. It does not check NotBefore. The
+//   - Pion checks only NotAfter, not NotBefore: it rejects a local cert whose
+//     NotAfter has already passed when constructing a PeerConnection. The
 //     hardcoded NotAfter below stays valid into the next century.
 //
-//   - Browser interop is empirically robust across very different cert
-//     lifetimes. js-libp2p rotates every 14 days, rust-libp2p has its own
-//     scheme, and earlier go-libp2p used pion's ~30-day default. All three
-//     interoperate with Chrome, Firefox, and Safari today.
+//   - No lifetime cap touches the remote peer cert: the W3C WebRTC 365-day
+//     cap applies only to certs the browser generates for itself, not to the
+//     cert /certhash points to. With no check enforcing a maximum lifetime,
+//     the static window below interoperates with Chrome, Firefox, and Safari.
+//     https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-generatecertificate
 //
 // Compared to p2p/transport/webtransport/crypto.go, WebTransport must rotate
 // every 14 days because the W3C WebTransport spec hard-caps
@@ -104,8 +99,9 @@ var (
 
 // newDeterministicCertificate returns a webrtc.Certificate whose SHA-256
 // fingerprint (the /certhash component) depends only on the host private
-// key. The cert uses ECDSA P-256, the only ECDSA curve Chromium accepts in
-// WebRTC DTLS; RSA works but produces larger, slower certs.
+// key. The cert uses ECDSA P-256, the curve RFC 8827 mandates for WebRTC DTLS
+// and the most interoperable choice across browsers; RSA works but produces
+// larger, slower certs.
 func newDeterministicCertificate(key ic.PrivKey) (*webrtc.Certificate, error) {
 	keyBytes, err := key.Raw()
 	if err != nil {

--- a/p2p/transport/webrtc/cert.go
+++ b/p2p/transport/webrtc/cert.go
@@ -1,0 +1,160 @@
+package libp2pwebrtc
+
+// Deterministic webrtc-direct certificate.
+//
+// The DTLS cert is built from the libp2p host private key with HKDF. Same
+// key in, same cert out, same /certhash every time. Restarting a node does
+// not change its webrtc-direct multiaddr.
+//
+// Why this is safe:
+//
+//   - The DTLS cert is not the identity credential. Peer identity comes from
+//     a Noise XX handshake run inside DTLS, with both cert fingerprints
+//     bound into the Noise prologue.
+//     webrtc-direct: https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md
+//     noise: https://github.com/libp2p/specs/blob/master/noise/README.md
+//
+//   - The libp2p spec tells the server to disable DTLS fingerprint
+//     verification, since the server does not know the client cert in
+//     advance. The server therefore inspects no cert details beyond the
+//     handshake.
+//
+//   - Browser DTLS verifies the server cert only by matching its SHA-256
+//     against the SDP a=fingerprint line the browser builds from /certhash.
+//     Self-signed peer certs have no trust chain; NotBefore and NotAfter are
+//     not part of the check. RFC 8122 (which defines a=fingerprint) requires
+//     only the fingerprint match.
+//     https://datatracker.ietf.org/doc/html/rfc8122
+//
+//   - The 365-day validity cap in the W3C WebRTC spec applies only to certs
+//     the browser generates for itself, not to the remote peer cert /certhash
+//     points to.
+//     https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-generatecertificate
+//
+//   - Pion rejects a local cert whose NotAfter has already passed when
+//     constructing a PeerConnection. It does not check NotBefore. The
+//     hardcoded NotAfter below stays valid into the next century.
+//
+//   - Browser interop is empirically robust across very different cert
+//     lifetimes. js-libp2p rotates every 14 days, rust-libp2p has its own
+//     scheme, and earlier go-libp2p used pion's ~30-day default. All three
+//     interoperate with Chrome, Firefox, and Safari today.
+//
+// Compared to p2p/transport/webtransport/crypto.go, WebTransport must rotate
+// every 14 days because the W3C WebTransport spec hard-caps
+// serverCertificateHashes certs to under 14 days. WebRTC has no such cap, so
+// the window is static and rotation is skipped.
+// https://www.w3.org/TR/webtransport/#dom-webtransport-servercertificatehashes
+//
+// Every input to x509.CreateCertificate (serial, dates, public key, signature
+// nonce) must be deterministic so the DER bytes, and therefore /certhash,
+// are stable. The ECDSA key is HKDF-derived; signing goes through
+// deterministicSigner, which signs with nil rand. Go 1.24+ guarantees
+// deterministic ECDSA in that case.
+// https://go.dev/doc/go1.24#cryptoecdsapkgcryptoecdsa
+//
+// If a future browser starts validating remote DTLS cert dates, add rotation
+// using p2p/transport/webtransport/cert_manager.go as the template.
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/big"
+	"time"
+
+	"filippo.io/keygen"
+	"golang.org/x/crypto/hkdf"
+
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+
+	"github.com/pion/webrtc/v4"
+)
+
+const deterministicCertHKDFInfo = "libp2p webrtc-direct deterministic cert"
+
+// Fixed validity window. DER bytes must be identical across runs, so the
+// dates cannot depend on time.Now(). A century is well beyond any realistic
+// deployment horizon and any pion NotAfter check.
+var (
+	deterministicCertNotBefore = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	deterministicCertNotAfter  = time.Date(2120, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// newDeterministicCertificate returns a webrtc.Certificate whose SHA-256
+// fingerprint (the /certhash component) depends only on the host private
+// key. The cert uses ECDSA P-256, the only ECDSA curve Chromium accepts in
+// WebRTC DTLS; RSA works but produces larger, slower certs.
+func newDeterministicCertificate(key ic.PrivKey) (*webrtc.Certificate, error) {
+	keyBytes, err := key.Raw()
+	if err != nil {
+		return nil, fmt.Errorf("read host key bytes: %w", err)
+	}
+	r := hkdf.New(sha256.New, keyBytes, nil, []byte(deterministicCertHKDFInfo))
+
+	serialBytes := make([]byte, 8)
+	if _, err := io.ReadFull(r, serialBytes); err != nil {
+		return nil, fmt.Errorf("derive cert serial: %w", err)
+	}
+	serial := int64(binary.BigEndian.Uint64(serialBytes))
+	if serial < 0 {
+		serial = -serial
+	}
+
+	ecdsaSeed := make([]byte, 192/8) // 192 bits of entropy for P-256, per filippo.io/keygen
+	if _, err := io.ReadFull(r, ecdsaSeed); err != nil {
+		return nil, fmt.Errorf("derive ECDSA seed: %w", err)
+	}
+	priv, err := keygen.ECDSA(elliptic.P256(), ecdsaSeed)
+	if err != nil {
+		return nil, fmt.Errorf("derive ECDSA key: %w", err)
+	}
+
+	tpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(serial),
+		Subject:            pkix.Name{CommonName: "libp2p-webrtc-direct"},
+		Issuer:             pkix.Name{CommonName: "libp2p-webrtc-direct"},
+		NotBefore:          deterministicCertNotBefore,
+		NotAfter:           deterministicCertNotAfter,
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+
+	// x509.CreateCertificate forwards its rand reader to the signer for the
+	// ECDSA nonce. deterministicSigner ignores that reader and signs with nil,
+	// which Go 1.24+ guarantees is deterministic. The HKDF stream is passed in
+	// as belt-and-braces, in case CreateCertificate ever reads rand for
+	// something else.
+	der, err := x509.CreateCertificate(r, tpl, tpl, priv.Public(), deterministicSigner{priv})
+	if err != nil {
+		return nil, fmt.Errorf("create x509 certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated certificate: %w", err)
+	}
+
+	wrapped := webrtc.CertificateFromX509(priv, cert)
+	return &wrapped, nil
+}
+
+// deterministicSigner wraps an ecdsa.PrivateKey so the cert signature is
+// reproducible. Signing with rand=nil triggers Go 1.24+'s deterministic
+// ECDSA path:
+// https://go.dev/doc/go1.24#cryptoecdsapkgcryptoecdsa
+type deterministicSigner struct {
+	priv *ecdsa.PrivateKey
+}
+
+var _ crypto.Signer = deterministicSigner{}
+
+func (ds deterministicSigner) Public() crypto.PublicKey { return ds.priv.Public() }
+
+func (ds deterministicSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return ds.priv.Sign(nil, digest, opts)
+}

--- a/p2p/transport/webrtc/cert.go
+++ b/p2p/transport/webrtc/cert.go
@@ -46,12 +46,26 @@ package libp2pwebrtc
 // the window is static and rotation is skipped.
 // https://www.w3.org/TR/webtransport/#dom-webtransport-servercertificatehashes
 //
+// The serial/key derivation and deterministicSigner below are deliberately
+// kept local to this transport rather than shared with webtransport, even
+// though the two look similar today. WebRTC and WebTransport are independent on
+// the wire and in their browser implementations, and their cert requirements
+// may diverge; keeping each self-contained avoids coupling one transport's
+// behavior to the other.
+//
 // Every input to x509.CreateCertificate (serial, dates, public key, signature
-// nonce) must be deterministic so the DER bytes, and therefore /certhash,
-// are stable. The ECDSA key is HKDF-derived; signing goes through
-// deterministicSigner, which signs with nil rand. Go 1.24+ guarantees
-// deterministic ECDSA in that case.
+// nonce) must be deterministic so the DER bytes, and therefore /certhash, are
+// stable. The ECDSA key is HKDF-derived; signing goes through
+// deterministicSigner, which signs with nil rand, the Go 1.24+ deterministic
+// ECDSA path.
 // https://go.dev/doc/go1.24#cryptoecdsapkgcryptoecdsa
+//
+// DER byte-stability spans a single Go toolchain plus a fixed set of these
+// dependencies (filippo.io/keygen in particular documents that its output may
+// change before v1.0.0). TestDeterministicCertificateGoldenVector pins the
+// fingerprint for a fixed key so any keygen, bigmod, or x509 encoding change
+// that would rotate every node's /certhash fails CI instead of shipping
+// silently. Changing that golden value is a breaking, network-visible event.
 //
 // If a future browser starts validating remote DTLS cert dates, add rotation
 // using p2p/transport/webtransport/cert_manager.go as the template.
@@ -60,6 +74,8 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/hkdf"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -70,7 +86,6 @@ import (
 	"time"
 
 	"filippo.io/keygen"
-	"golang.org/x/crypto/hkdf"
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 
@@ -96,28 +111,31 @@ func newDeterministicCertificate(key ic.PrivKey) (*webrtc.Certificate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read host key bytes: %w", err)
 	}
-	r := hkdf.New(sha256.New, keyBytes, nil, []byte(deterministicCertHKDFInfo))
 
-	serialBytes := make([]byte, 8)
-	if _, err := io.ReadFull(r, serialBytes); err != nil {
-		return nil, fmt.Errorf("derive cert serial: %w", err)
-	}
-	serial := int64(binary.BigEndian.Uint64(serialBytes))
-	if serial < 0 {
-		serial = -serial
+	// HKDF expands the host key into the serial bytes followed by the ECDSA
+	// seed. The same key always yields the same bytes (RFC 5869), so every
+	// derived input below is deterministic.
+	const serialLen = 8
+	const seedLen = 192 / 8 // 192 bits of entropy for P-256, per filippo.io/keygen
+	material, err := hkdf.Key(sha256.New, keyBytes, nil, deterministicCertHKDFInfo, serialLen+seedLen)
+	if err != nil {
+		return nil, fmt.Errorf("derive cert material: %w", err)
 	}
 
-	ecdsaSeed := make([]byte, 192/8) // 192 bits of entropy for P-256, per filippo.io/keygen
-	if _, err := io.ReadFull(r, ecdsaSeed); err != nil {
-		return nil, fmt.Errorf("derive ECDSA seed: %w", err)
-	}
-	priv, err := keygen.ECDSA(elliptic.P256(), ecdsaSeed)
+	priv, err := keygen.ECDSA(elliptic.P256(), material[serialLen:])
 	if err != nil {
 		return nil, fmt.Errorf("derive ECDSA key: %w", err)
 	}
 
+	// Read the serial bytes as unsigned so the serial is never negative:
+	// x509.CreateCertificate rejects a negative SerialNumber, and an int64
+	// abs() cannot fix math.MinInt64 (negating it overflows back to itself).
+	// max(_, 1) keeps it positive when the bytes are all zero, as RFC 5280
+	// section 4.1.2.2 requires.
+	serial := new(big.Int).SetUint64(max(binary.BigEndian.Uint64(material[:serialLen]), 1))
+
 	tpl := &x509.Certificate{
-		SerialNumber:       big.NewInt(serial),
+		SerialNumber:       serial,
 		Subject:            pkix.Name{CommonName: "libp2p-webrtc-direct"},
 		Issuer:             pkix.Name{CommonName: "libp2p-webrtc-direct"},
 		NotBefore:          deterministicCertNotBefore,
@@ -125,12 +143,11 @@ func newDeterministicCertificate(key ic.PrivKey) (*webrtc.Certificate, error) {
 		SignatureAlgorithm: x509.ECDSAWithSHA256,
 	}
 
-	// x509.CreateCertificate forwards its rand reader to the signer for the
-	// ECDSA nonce. deterministicSigner ignores that reader and signs with nil,
-	// which Go 1.24+ guarantees is deterministic. The HKDF stream is passed in
-	// as belt-and-braces, in case CreateCertificate ever reads rand for
-	// something else.
-	der, err := x509.CreateCertificate(r, tpl, tpl, priv.Public(), deterministicSigner{priv})
+	// CreateCertificate forwards rand only to the signer (the supplied non-nil
+	// SerialNumber means it never draws rand for that). deterministicSigner
+	// ignores the reader and signs with nil, the Go 1.24+ deterministic ECDSA
+	// path, so the DER bytes are reproducible regardless of the reader here.
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, priv.Public(), deterministicSigner{priv})
 	if err != nil {
 		return nil, fmt.Errorf("create x509 certificate: %w", err)
 	}
@@ -147,6 +164,8 @@ func newDeterministicCertificate(key ic.PrivKey) (*webrtc.Certificate, error) {
 // reproducible. Signing with rand=nil triggers Go 1.24+'s deterministic
 // ECDSA path:
 // https://go.dev/doc/go1.24#cryptoecdsapkgcryptoecdsa
+//
+// Kept local to this transport on purpose; see the file-level note above.
 type deterministicSigner struct {
 	priv *ecdsa.PrivateKey
 }

--- a/p2p/transport/webrtc/cert_test.go
+++ b/p2p/transport/webrtc/cert_test.go
@@ -2,12 +2,35 @@ package libp2pwebrtc
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 
+	"github.com/pion/webrtc/v4"
 	"github.com/stretchr/testify/require"
 )
+
+// x509FromCert recovers the parsed x509 certificate from a webrtc.Certificate.
+// pion's PEM() base64-encodes the DER before PEM-wrapping it, so the block body
+// has to be base64-decoded once more before parsing.
+func x509FromCert(t *testing.T, c *webrtc.Certificate) *x509.Certificate {
+	t.Helper()
+	pemStr, err := c.PEM()
+	require.NoError(t, err)
+	block, _ := pem.Decode([]byte(pemStr))
+	require.NotNil(t, block)
+	require.Equal(t, "CERTIFICATE", block.Type)
+	der := make([]byte, base64.StdEncoding.DecodedLen(len(block.Bytes)))
+	n, err := base64.StdEncoding.Decode(der, block.Bytes)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der[:n])
+	require.NoError(t, err)
+	return cert
+}
 
 // A fixed host key must always map to this exact /certhash. The fingerprint is
 // SHA-256 over the cert DER, so it is the value other peers cache and pin. This
@@ -31,6 +54,7 @@ func TestDeterministicCertificateGoldenVector(t *testing.T) {
 
 	fps, err := cert.GetFingerprints()
 	require.NoError(t, err)
+	require.NotEmpty(t, fps)
 	require.Equal(t, "sha-256", fps[0].Algorithm)
 	require.Equal(t,
 		"dd:6e:2d:63:b0:f0:61:9e:18:7a:03:1f:64:77:16:37:a0:41:8a:71:dc:d8:b9:d7:8c:6c:69:b1:f4:25:64:91",
@@ -83,6 +107,8 @@ func TestDeterministicCertificateDiffersBetweenKeys(t *testing.T) {
 	require.NoError(t, err)
 	fp2, err := c2.GetFingerprints()
 	require.NoError(t, err)
+	require.NotEmpty(t, fp1)
+	require.NotEmpty(t, fp2)
 	require.NotEqual(t, fp1[0].Value, fp2[0].Value)
 }
 
@@ -120,4 +146,31 @@ func TestDeterministicCertificateNotExpired(t *testing.T) {
 
 	require.False(t, cert.Expires().IsZero())
 	require.True(t, cert.Expires().Year() >= 2100, "NotAfter must stay valid for the foreseeable life of go-libp2p")
+}
+
+// The derivation must yield an ECDSA P-256 key, the curve RFC 8827 mandates for
+// WebRTC DTLS. The golden vector pins this implicitly, but a direct check fails
+// with a readable message if keygen ever defaults to a different curve.
+func TestDeterministicCertificateUsesP256(t *testing.T) {
+	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	require.NoError(t, err)
+
+	cert, err := newDeterministicCertificate(privKey)
+	require.NoError(t, err)
+
+	pub, ok := x509FromCert(t, cert).PublicKey.(*ecdsa.PublicKey)
+	require.True(t, ok, "cert public key must be ECDSA")
+	require.Equal(t, "P-256", pub.Curve.Params().Name)
+}
+
+// Domain separation: webrtc and webtransport both HKDF over the same host key,
+// so their cert derivations must use distinct HKDF info strings or a node would
+// derive (and advertise) the same DTLS fingerprint on both transports. The two
+// constants live in separate packages, so pin the webtransport literal here.
+// If this ever fails, the two derivations have collided.
+func TestDeterministicCertificateHKDFInfoDiffersFromWebTransport(t *testing.T) {
+	// libp2pwebtransport.deterministicCertInfo. The misspelling is load-bearing
+	// (it is wire-visible HKDF input) and must not be "fixed".
+	const webtransportInfo = "determinisitic cert"
+	require.NotEqual(t, webtransportInfo, deterministicCertHKDFInfo)
 }

--- a/p2p/transport/webrtc/cert_test.go
+++ b/p2p/transport/webrtc/cert_test.go
@@ -1,12 +1,42 @@
 package libp2pwebrtc
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 
 	"github.com/stretchr/testify/require"
 )
+
+// A fixed host key must always map to this exact /certhash. The fingerprint is
+// SHA-256 over the cert DER, so it is the value other peers cache and pin. This
+// vector catches any change in the derivation (HKDF, filippo.io/keygen, the
+// x509 encoder, or this code) that would silently rotate every node's
+// webrtc-direct multiaddr. filippo.io/keygen in particular documents that its
+// output may change before v1.0.0.
+//
+// Updating this value is a breaking, network-visible event: do not do it to
+// make a red test green without understanding why the derivation changed.
+func TestDeterministicCertificateGoldenVector(t *testing.T) {
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	privKey, _, err := crypto.GenerateEd25519Key(bytes.NewReader(seed))
+	require.NoError(t, err)
+
+	cert, err := newDeterministicCertificate(privKey)
+	require.NoError(t, err)
+
+	fps, err := cert.GetFingerprints()
+	require.NoError(t, err)
+	require.Equal(t, "sha-256", fps[0].Algorithm)
+	require.Equal(t,
+		"dd:6e:2d:63:b0:f0:61:9e:18:7a:03:1f:64:77:16:37:a0:41:8a:71:dc:d8:b9:d7:8c:6c:69:b1:f4:25:64:91",
+		fps[0].Value,
+	)
+}
 
 // Same host key, same cert, same /certhash. This is the property restart
 // stability depends on.

--- a/p2p/transport/webrtc/cert_test.go
+++ b/p2p/transport/webrtc/cert_test.go
@@ -1,0 +1,93 @@
+package libp2pwebrtc
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Same host key, same cert, same /certhash. This is the property restart
+// stability depends on.
+func TestDeterministicCertificateIsStableForSameKey(t *testing.T) {
+	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	require.NoError(t, err)
+
+	c1, err := newDeterministicCertificate(privKey)
+	require.NoError(t, err)
+	c2, err := newDeterministicCertificate(privKey)
+	require.NoError(t, err)
+
+	require.True(t, c1.Equals(*c2), "two derivations from the same host key produced different certs")
+
+	fp1, err := c1.GetFingerprints()
+	require.NoError(t, err)
+	fp2, err := c2.GetFingerprints()
+	require.NoError(t, err)
+	require.Equal(t, fp1, fp2)
+
+	// PEM wraps the DER bytes, so equal PEMs prove every input to /certhash
+	// (cert template, public key, and signature) is byte-stable.
+	pem1, err := c1.PEM()
+	require.NoError(t, err)
+	pem2, err := c2.PEM()
+	require.NoError(t, err)
+	require.Equal(t, pem1, pem2)
+}
+
+// Different host keys must yield different /certhash values, or the
+// derivation has collapsed to a constant.
+func TestDeterministicCertificateDiffersBetweenKeys(t *testing.T) {
+	k1, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	require.NoError(t, err)
+	k2, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	require.NoError(t, err)
+
+	c1, err := newDeterministicCertificate(k1)
+	require.NoError(t, err)
+	c2, err := newDeterministicCertificate(k2)
+	require.NoError(t, err)
+
+	fp1, err := c1.GetFingerprints()
+	require.NoError(t, err)
+	fp2, err := c2.GetFingerprints()
+	require.NoError(t, err)
+	require.NotEqual(t, fp1[0].Value, fp2[0].Value)
+}
+
+// /certhash is sha256(DER), so the DER bytes need to be byte-stable across
+// runs. A non-deterministic ECDSA nonce, an unstable x509 field, or hidden
+// entropy in the cert template would all break this. Looping catches a flaky
+// entropy source that might pass a one-shot check.
+func TestDeterministicCertificateDERIsStable(t *testing.T) {
+	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	require.NoError(t, err)
+
+	first, err := newDeterministicCertificate(privKey)
+	require.NoError(t, err)
+	firstPEM, err := first.PEM()
+	require.NoError(t, err)
+
+	for i := range 16 {
+		next, err := newDeterministicCertificate(privKey)
+		require.NoError(t, err)
+		nextPEM, err := next.PEM()
+		require.NoError(t, err)
+		require.Equal(t, firstPEM, nextPEM, "DER changed across calls (iteration %d)", i)
+	}
+}
+
+// Pion rejects a cert whose NotAfter is in the past when handed to
+// PeerConnection. The hardcoded window has to stay valid for the foreseeable
+// life of go-libp2p.
+func TestDeterministicCertificateNotExpired(t *testing.T) {
+	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	require.NoError(t, err)
+
+	cert, err := newDeterministicCertificate(privKey)
+	require.NoError(t, err)
+
+	require.False(t, cert.Expires().IsZero())
+	require.True(t, cert.Expires().Year() >= 2100, "NotAfter must stay valid for the foreseeable life of go-libp2p")
+}

--- a/p2p/transport/webrtc/transport.go
+++ b/p2p/transport/webrtc/transport.go
@@ -5,8 +5,6 @@ package libp2pwebrtc
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"errors"
@@ -120,22 +118,10 @@ func New(privKey ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater, rcmgr 
 	if err != nil {
 		return nil, fmt.Errorf("get local peer ID: %w", err)
 	}
-	// We use elliptic P-256 since it is widely supported by browsers.
-	//
-	// Implementation note: Testing with the browser,
-	// it seems like Chromium only supports ECDSA P-256 or RSA key signatures in the webrtc TLS certificate.
-	// We tried using P-228 and P-384 which caused the DTLS handshake to fail with Illegal Parameter
-	//
-	// Please refer to this is a list of suggested algorithms for the WebCrypto API.
-	// The algorithm for generating a certificate for an RTCPeerConnection
-	// must adhere to the WebCrpyto API. From my observation,
-	// RSA and ECDSA P-256 is supported on almost all browsers.
-	// Ed25519 is not present on the list.
-	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf("generate key for cert: %w", err)
-	}
-	cert, err := webrtc.GenerateCertificate(pk)
+	// Derive the DTLS cert from the host key so the /certhash multiaddr
+	// component stays the same across restarts. cert.go explains why this is
+	// safe under the libp2p webrtc-direct spec and current browser behavior.
+	cert, err := newDeterministicCertificate(privKey)
 	if err != nil {
 		return nil, fmt.Errorf("generate certificate: %w", err)
 	}

--- a/p2p/transport/webtransport/crypto.go
+++ b/p2p/transport/webtransport/crypto.go
@@ -59,12 +59,13 @@ func generateCert(key ic.PrivKey, start, end time.Time) (*x509.Certificate, *ecd
 	if _, err := deterministicHKDFReader.Read(b); err != nil {
 		return nil, nil, err
 	}
-	serial := int64(binary.BigEndian.Uint64(b))
-	if serial < 0 {
-		serial = -serial
-	}
+	// Read the serial bytes as unsigned so the serial is never negative:
+	// x509.CreateCertificate rejects a negative SerialNumber, and an int64
+	// abs() cannot fix math.MinInt64. max(_, 1) keeps it positive when the
+	// bytes are all zero, as RFC 5280 section 4.1.2.2 requires.
+	serial := new(big.Int).SetUint64(max(binary.BigEndian.Uint64(b), 1))
 	certTempl := &x509.Certificate{
-		SerialNumber:          big.NewInt(serial),
+		SerialNumber:          serial,
 		Subject:               pkix.Name{},
 		NotBefore:             start,
 		NotAfter:              end,
@@ -152,6 +153,11 @@ func newDeterministicReader(seed []byte, salt []byte, info string) io.Reader {
 // that will produce deterministic signatures by ignoring the rand reader.
 // Go 1.24 produces deterministic ecdsa signatures when passed a nil random source.
 // See: https://go.dev/doc/go1.24#cryptoecdsapkgcryptoecdsa
+//
+// This and the serial derivation in generateCert are deliberately duplicated
+// here rather than shared with p2p/transport/webrtc. The two transports are
+// independent on the wire and in their browser implementations and may diverge;
+// keeping each self-contained avoids coupling their cert behavior.
 type deterministicSigner struct {
 	priv *ecdsa.PrivateKey
 }

--- a/p2p/transport/webtransport/crypto_test.go
+++ b/p2p/transport/webtransport/crypto_test.go
@@ -33,12 +33,9 @@ func sha256Multihash(t *testing.T, b []byte) multihash.DecodedMultihash {
 
 func generateCertWithKey(t *testing.T, key crypto.PrivateKey, start, end time.Time) *x509.Certificate {
 	t.Helper()
-	serial := int64(mrand.Uint64())
-	if serial < 0 {
-		serial = -serial
-	}
+	serial := new(big.Int).SetUint64(max(mrand.Uint64(), 1))
 	certTempl := &x509.Certificate{
-		SerialNumber:          big.NewInt(serial),
+		SerialNumber:          serial,
 		Subject:               pkix.Name{},
 		NotBefore:             start,
 		NotAfter:              end,


### PR DESCRIPTION
## Problem

webrtc-direct minted a fresh random ECDSA cert on every process start. The cert's SHA-256 is the `/certhash` in the listen multiaddr, so the advertised address changed on every restart and invalidated anything that had pinned it: peerstore TTLs, DHT records, external address books, dialer caches.

## Fix

Derive the DTLS cert deterministically from the libp2p host key, so the `/certhash` depends only on that key and stays put across restarts:

- HKDF (stdlib `crypto/hkdf`) over the host key yields the serial and the ECDSA P-256 key; signing with a nil rand source is deterministic on Go 1.24+.
- A fixed `2020-01-01` to `2120-01-01` window keeps the DER byte-stable.
- The serial is read unsigned so it's always positive, as RFC 5280 requires. The old signed-then-negate left `math.MinInt64` negative, which `x509.CreateCertificate` rejects; I caught it fuzzing the serial against the RFC. webtransport shared the bug, so it's fixed here too.
  - I think we did not notice this before because new cert on each restart hid this as an ephemeral hiccup.
- A golden-vector test pins the `/certhash` for a fixed key, so any drift in the derivation fails CI instead of silently changing every node's address.

The DTLS cert isn't the identity credential (Noise XX inside DTLS handles that), so a stable cert is safe. Full rationale and spec links live in `p2p/transport/webrtc/cert.go`.