### PR TITLE
fix(peer): Allow `AddrInfo` with empty `ID` field to round-trip through JSON

### DIFF
--- a/core/peer/addrinfo_serde.go
+++ b/core/peer/addrinfo_serde.go
@@ -10,7 +10,7 @@ import (
 
 // Helper struct for decoding as we can't unmarshal into an interface (Multiaddr).
 type addrInfoJson struct {
-	ID    ID
+	ID    ID `json:",omitempty"`
 	Addrs []string
 }
 

--- a/core/peer/addrinfo_test.go
+++ b/core/peer/addrinfo_test.go
@@ -164,3 +164,15 @@ func TestAddrInfoJSON(t *testing.T) {
 		t.Fatalf("expected addrs to match %v, got %v", maddrFull, addrInfo.Addrs)
 	}
 }
+
+func TestAddrInfoJSONEmptyID(t *testing.T) {
+	ai := AddrInfo{Addrs: []ma.Multiaddr{maddrTpt}}
+	out, err := ai.MarshalJSON()
+	require.NoError(t, err)
+
+	var addrInfo AddrInfo
+	require.NoError(t, addrInfo.UnmarshalJSON(out))
+	require.Equal(t, ID(""), addrInfo.ID)
+	require.Len(t, addrInfo.Addrs, 1)
+	require.True(t, addrInfo.Addrs[0].Equal(maddrTpt))
+}


### PR DESCRIPTION
The `AddrInfo.MarshalJSON` successfully serialise objects with empty `ID` field, but `AddrInfo.UnmarshalJSON` then failed because `peer.ID.UnmarshalJSON` rejects empty string.

The `ID` field in the `addrInfoJson` is tag with json:",omitempty" so an empty ID is omitted on marshal and left as the zero value on unmarshal.