### PR TITLE
fix(autonatv2): honor forced reachability

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -572,7 +572,11 @@ func (cfg *Config) NewNode() (host.Host, error) {
 			if !cfg.DisableMetrics {
 				mt = autonatv2.NewMetricsTracer(cfg.PrometheusRegisterer)
 			}
-			autoNATv2, err := autonatv2.New(ah, autonatv2.WithMetricsTracer(mt))
+			opts := []autonatv2.AutoNATOption{autonatv2.WithMetricsTracer(mt)}
+			if cfg.AutoNATConfig.ForceReachability != nil {
+				opts = append(opts, autonatv2.WithReachability(*cfg.AutoNATConfig.ForceReachability))
+			}
+			autoNATv2, err := autonatv2.New(ah, opts...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create autonatv2: %w", err)
 			}

--- a/libp2p_test.go
+++ b/libp2p_test.go
@@ -423,6 +423,24 @@ func TestAutoNATv2Service(t *testing.T) {
 	h.Close()
 }
 
+func TestAutoNATv2ForcedReachability(t *testing.T) {
+	client, err := New(
+		EnableAutoNATv2(),
+		ForceReachabilityPrivate(),
+	)
+	require.NoError(t, err)
+	defer client.Close()
+
+	confirmedAddrsHost, ok := client.(interface {
+		ConfirmedAddrs() (reachable, unreachable, unknown []ma.Multiaddr)
+	})
+	require.True(t, ok)
+	require.Eventually(t, func() bool {
+		reachable, unreachable, unknown := confirmedAddrsHost.ConfirmedAddrs()
+		return len(reachable) == 0 && len(unreachable) > 0 && len(unknown) == 0
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
 func TestDisableIdentifyAddressDiscovery(t *testing.T) {
 	h, err := New(DisableIdentifyAddressDiscovery())
 	require.NoError(t, err)

--- a/p2p/protocol/autonatv2/autonat.go
+++ b/p2p/protocol/autonatv2/autonat.go
@@ -90,6 +90,7 @@ type AutoNAT struct {
 	// allowPrivateAddrs enables using private and localhost addresses for reachability checks.
 	// This is only useful for testing.
 	allowPrivateAddrs bool
+	forceReachability *network.Reachability
 }
 
 // New returns a new AutoNAT instance.
@@ -110,6 +111,7 @@ func New(dialerHost host.Host, opts ...AutoNATOption) (*AutoNAT, error) {
 		srv:                  newServer(dialerHost, s),
 		cli:                  newClient(s),
 		allowPrivateAddrs:    s.allowPrivateAddrs,
+		forceReachability:    s.forceReachability,
 		peers:                newPeersMap(),
 		throttlePeer:         make(map[peer.ID]time.Time),
 		throttlePeerDuration: s.throttlePeerDuration,
@@ -181,6 +183,9 @@ func (an *AutoNAT) Close() {
 
 // GetReachability makes a single dial request for checking reachability for requested addresses
 func (an *AutoNAT) GetReachability(ctx context.Context, reqs []Request) (Result, error) {
+	if an.forceReachability != nil && len(reqs) > 0 {
+		return Result{Addr: reqs[0].Addr, Idx: 0, Reachability: *an.forceReachability}, nil
+	}
 	var filteredReqs []Request
 	if !an.allowPrivateAddrs {
 		filteredReqs = make([]Request, 0, len(reqs))

--- a/p2p/protocol/autonatv2/autonat_test.go
+++ b/p2p/protocol/autonatv2/autonat_test.go
@@ -107,6 +107,24 @@ func TestGetReachabilityAfterClose(t *testing.T) {
 	require.Equal(t, Result{}, res)
 }
 
+func TestForcedReachability(t *testing.T) {
+	addr := ma.StringCast("/ip4/192.168.0.1/udp/10/quic-v1")
+	for _, reachability := range []network.Reachability{
+		network.ReachabilityPrivate,
+		network.ReachabilityPublic,
+	} {
+		t.Run(reachability.String(), func(t *testing.T) {
+			an := newAutoNAT(t, nil, WithReachability(reachability))
+			defer an.Close()
+			defer an.host.Close()
+
+			res, err := an.GetReachability(context.Background(), []Request{{Addr: addr}})
+			require.NoError(t, err)
+			require.Equal(t, Result{Addr: addr, Reachability: reachability}, res)
+		})
+	}
+}
+
 func TestClientRequest(t *testing.T) {
 	an := newAutoNAT(t, nil, AllowPrivateAddrs)
 	defer an.Close()

--- a/p2p/protocol/autonatv2/options.go
+++ b/p2p/protocol/autonatv2/options.go
@@ -1,6 +1,10 @@
 package autonatv2
 
-import "time"
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+)
 
 // autoNATSettings is used to configure AutoNAT
 type autoNATSettings struct {
@@ -14,6 +18,7 @@ type autoNATSettings struct {
 	amplificatonAttackPreventionDialWait time.Duration
 	metricsTracer                        MetricsTracer
 	throttlePeerDuration                 time.Duration
+	forceReachability                    *network.Reachability
 }
 
 func defaultSettings() *autoNATSettings {
@@ -45,6 +50,15 @@ func WithServerRateLimit(rpm, perPeerRPM, dialDataRPM int, maxConcurrentRequests
 func WithMetricsTracer(m MetricsTracer) AutoNATOption {
 	return func(s *autoNATSettings) error {
 		s.metricsTracer = m
+		return nil
+	}
+}
+
+// WithReachability overrides automatic reachability detection with a fixed status.
+// The AutoNAT service continues to handle requests from other peers.
+func WithReachability(reachability network.Reachability) AutoNATOption {
+	return func(s *autoNATSettings) error {
+		s.forceReachability = &reachability
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

Make AutoNAT v2 honor the existing `ForceReachabilityPublic` and `ForceReachabilityPrivate` options.

This change:

- adds an AutoNAT v2 `WithReachability` option;
- passes the configured reachability override to AutoNAT v2;
- returns the forced result without waiting for peers or performing dial-back checks;
- keeps the AutoNAT v2 server active so the host can still serve requests from other peers;
- adds unit and top-level regression coverage.

Fixes #3515.

## Root cause

The top-level forced reachability value was only passed to AutoNAT v1.

When AutoNAT v2 was enabled, the basic host also used its per-address reachability tracker. That tracker never received the configured override, so addresses could remain unknown or be classified by automatic dial-back checks even though the host had explicitly been forced private or public.

## Behavior after this change

When forced reachability is configured, AutoNAT v2 reports that fixed status for local address checks. AutoNAT v2 server functionality remains enabled for remote peers.

Existing behavior is unchanged when no reachability override is configured.

## Testing

```text
go test ./config ./p2p/host/basic ./p2p/protocol/autonatv2 . -count=1
go test -race . ./p2p/protocol/autonatv2 -run '^(TestAutoNATv2ForcedReachability|TestForcedReachability)$' -count=1
go vet ./config ./p2p/host/basic ./p2p/protocol/autonatv2 .
```