### PR TITLE
refactor: require go1.26 and apply go modernizers

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -9,9 +9,9 @@ runs:
       shell: bash
       # This matches only tests with "NoCover" in their test name to avoid running all tests again.
       run: go test -tags nocover -run NoCover -v ./...
-    - name: Run synctests tests. These are tests that require go 1.25 and the experimental testing/synctest package
+    - name: Run synctests tests. These are tests that require go 1.26 and the experimental testing/synctest package
       shell: bash
-      if: ${{ contains(matrix.go, '1.25') }}
+      if: ${{ contains(matrix.go, '1.26') }}
       run: go test -run "_synctest$" -v ./...
     - name: Install testing tools
       shell: bash

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,6 +17,6 @@ jobs:
   go-test:
     uses: ./.github/workflows/go-test-template.yml
     with:
-      go-versions: '["1.25.x", "1.26.x"]'
+      go-versions: '["1.26.x", "1.27.x"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="http://libp2p.io/"><img src="https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square" /></a>
   <a href="https://pkg.go.dev/github.com/libp2p/go-libp2p"><img src="https://pkg.go.dev/badge/github.com/libp2p/go-libp2p.svg" alt="Go Reference"></a>
   <a href="https://discuss.libp2p.io"><img src="https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg"/></a>
-  <a href="https://marcopolo.github.io/FlakyTests/"><img src="https://marcopolo.github.io/FlakyTests/current-score.svg"/></a>
 </p>
 
 # Table of Contents <!-- omit in toc -->
@@ -146,7 +145,6 @@ Some notable users of go-libp2p are:
 - [EdgeVPN](https://github.com/mudler/edgevpn) - A decentralized, immutable, portable VPN and reverse proxy over p2p.
 - [Kairos](https://github.com/kairos-io/kairos) - A Kubernetes-focused, Cloud Native Linux meta-distribution.
 - [Oasis Core](https://github.com/oasisprotocol/oasis-core) - The consensus and runtime layers of the [Oasis protocol](https://oasisprotocol.org/).
-- [Spacemesh](https://github.com/spacemeshos/go-spacemesh/) - The Go implementation of the [Spacemesh protocol](https://spacemesh.io/), a novel layer one blockchain
 - [Tau](https://github.com/taubyte/tau/) - Open source distributed Platform as a Service (PaaS)
 
 Please open a pull request if you want your project (min. 250 GitHub stars) to be added here.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p/examples
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/caddyserver/certmagic v0.25.3

--- a/examples/metrics-and-dashboards/main.go
+++ b/examples/metrics-and-dashboards/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Make a bunch of clients that all ping the server at various times
 	wg := sync.WaitGroup{}
-	for i := 0; i < ClientCount; i++ {
+	for i := range ClientCount {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/examples/multipro/main.go
+++ b/examples/multipro/main.go
@@ -55,7 +55,7 @@ func run(h1, h2 *Node, done <-chan bool) {
 	h2.Echo(h1.Host)
 
 	// block until all responses have been processed
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		<-done
 	}
 }

--- a/examples/testutils/net.go
+++ b/examples/testutils/net.go
@@ -14,7 +14,7 @@ func FindFreePort(t *testing.T, host string, maxAttempts int) (int, error) {
 		host = "localhost"
 	}
 
-	for i := 0; i < maxAttempts; i++ {
+	for range maxAttempts {
 		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, "0"))
 		if err != nil {
 			t.Logf("unable to resolve tcp addr: %v", err)

--- a/examples/testutils/net.go
+++ b/examples/testutils/net.go
@@ -22,7 +22,9 @@ func FindFreePort(t *testing.T, host string, maxAttempts int) (int, error) {
 		}
 		l, err := net.ListenTCP("tcp", addr)
 		if err != nil {
-			l.Close()
+			if l != nil {
+				l.Close()
+			}
 			t.Logf("unable to listen on addr %q: %v", addr, err)
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p
 
-go 1.25.7
+go 1.26
 
 retract v0.26.1 // Tag was applied incorrectly due to a bug in the release workflow.
 

--- a/p2p/canonicallog/canonicallog.go
+++ b/p2p/canonicallog/canonicallog.go
@@ -78,11 +78,12 @@ func LogMisbehavingPeerNetAddr(p peer.ID, peerAddr net.Addr, component string, o
 // like fail2ban to action on the log.
 func LogPeerStatus(sampleRate int, p peer.ID, peerAddr multiaddr.Multiaddr, keyVals ...string) {
 	if rand.Intn(sampleRate) == 0 {
-		args := []any{
+		args := make([]any, 0, 6+len(keyVals))
+		args = append(args,
 			"peer", p,
 			"addr", peerAddr.String(),
 			"sample_rate", sampleRate,
-		}
+		)
 		// Add the additional key-value pairs
 		for _, kv := range keyVals {
 			args = append(args, kv)

--- a/p2p/host/autorelay/autorelay.go
+++ b/p2p/host/autorelay/autorelay.go
@@ -64,11 +64,9 @@ func (r *AutoRelay) IsPeerInBackoff(peerID peer.ID) bool {
 }
 
 func (r *AutoRelay) Start() {
-	r.refCount.Add(1)
-	go func() {
-		defer r.refCount.Done()
+	r.refCount.Go(func() {
 		r.background()
-	}()
+	})
 }
 
 func (r *AutoRelay) background() {

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -529,11 +529,11 @@ func TestMinInterval(t *testing.T) {
 }
 
 func TestNoBusyLoop0MinInterval(t *testing.T) {
-	var calledTimes uint64
+	var calledTimes atomic.Uint64
 	cl := newMockClock()
 	h := newPrivateNode(t,
 		func(context.Context, int) <-chan peer.AddrInfo {
-			atomic.AddUint64(&calledTimes, 1)
+			calledTimes.Add(1)
 			peerChan := make(chan peer.AddrInfo, 1)
 			defer close(peerChan)
 			r1 := newRelay(t)
@@ -552,10 +552,10 @@ func TestNoBusyLoop0MinInterval(t *testing.T) {
 
 	require.Never(t, func() bool {
 		cl.AdvanceBy(time.Second)
-		val := atomic.LoadUint64(&calledTimes)
+		val := calledTimes.Load()
 		return val >= 2
 	}, 500*time.Millisecond, 100*time.Millisecond)
-	val := atomic.LoadUint64(&calledTimes)
+	val := calledTimes.Load()
 	require.Less(t, val, uint64(2))
 }
 func TestAutoRelayAddrsEvent(t *testing.T) {

--- a/p2p/host/autorelay/autorelay_test.go
+++ b/p2p/host/autorelay/autorelay_test.go
@@ -622,7 +622,7 @@ func TestAutoRelayAddrsEvent(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		e := <-sub.Out()
 		evt := e.(event.EvtAutoRelayAddrsUpdated)
-		relayIds := []peer.ID{}
+		relayIds := make([]peer.ID, 0, len(relays)-1)
 		for _, r := range relays[1:] {
 			relayIds = append(relayIds, r.ID())
 		}

--- a/p2p/host/autorelay/metrics.go
+++ b/p2p/host/autorelay/metrics.go
@@ -275,8 +275,7 @@ func getReservationRequestStatus(err error) string {
 	}
 
 	status := "err other"
-	var re client.ReservationError
-	if errors.As(err, &re) {
+	if re, ok := errors.AsType[client.ReservationError](err); ok {
 		switch re.Status {
 		case pbv2.Status_CONNECTION_FAILED:
 			return "connection failed"

--- a/p2p/host/autorelay/relay_finder.go
+++ b/p2p/host/autorelay/relay_finder.go
@@ -167,17 +167,13 @@ func (rf *relayFinder) cleanupDisconnectedPeers(ctx context.Context) {
 
 func (rf *relayFinder) background(ctx context.Context) {
 	peerSourceRateLimiter := make(chan struct{}, 1)
-	rf.refCount.Add(1)
-	go func() {
-		defer rf.refCount.Done()
+	rf.refCount.Go(func() {
 		rf.findNodes(ctx, peerSourceRateLimiter)
-	}()
+	})
 
-	rf.refCount.Add(1)
-	go func() {
-		defer rf.refCount.Done()
+	rf.refCount.Go(func() {
 		rf.handleNewCandidates(ctx)
-	}()
+	})
 
 	now := rf.conf.clock.Now()
 	bootDelayTimer := rf.conf.clock.InstantTimer(now.Add(rf.conf.bootDelay))
@@ -779,11 +775,9 @@ func (rf *relayFinder) Start() error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	rf.ctxCancel = cancel
-	rf.refCount.Add(1)
-	go func() {
-		defer rf.refCount.Done()
+	rf.refCount.Go(func() {
 		rf.background(ctx)
-	}()
+	})
 	return nil
 }
 

--- a/p2p/host/basic/addrs_manager_test.go
+++ b/p2p/host/basic/addrs_manager_test.go
@@ -283,7 +283,8 @@ func TestAddrsManager(t *testing.T) {
 			ListenAddrs: func() []ma.Multiaddr { return []ma.Multiaddr{lhquic} },
 		})
 		am.updateAddrsSync()
-		expected := []ma.Multiaddr{lhquic}
+		expected := make([]ma.Multiaddr, 1, 1+maxObservedAddrsPerListenAddr)
+		expected[0] = lhquic
 		expected = append(expected, quicAddrs[:maxObservedAddrsPerListenAddr]...)
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			matest.AssertMultiaddrsMatch(collect, expected, am.Addrs())

--- a/p2p/host/basic/addrs_reachability_tracker.go
+++ b/p2p/host/basic/addrs_reachability_tracker.go
@@ -254,15 +254,13 @@ func (r *addrsReachabilityTracker) refreshReachability() reachabilityTask {
 	}
 	resCh := make(chan bool, 1)
 	ctx, cancel := context.WithTimeout(r.ctx, 5*time.Minute)
-	r.wg.Add(1)
 	// We run probes provided by addrsTracker. It stops probing when any
 	// of the following happens:
 	// - there are no more probes to run
 	// - context is completed
 	// - there are too many consecutive failures from the client
 	// - the client has no valid peers to probe
-	go func() {
-		defer r.wg.Done()
+	r.wg.Go(func() {
 		defer cancel()
 		client := &errCountingClient{autonatv2Client: r.client, MaxConsecutiveErrors: maxConsecutiveErrors}
 		var backoff atomic.Bool
@@ -293,7 +291,7 @@ func (r *addrsReachabilityTracker) refreshReachability() reachabilityTask {
 		}
 		wg.Wait()
 		resCh <- backoff.Load()
-	}()
+	})
 	return reachabilityTask{Cancel: cancel, BackoffCh: resCh}
 }
 

--- a/p2p/host/basic/addrs_reachability_tracker_test.go
+++ b/p2p/host/basic/addrs_reachability_tracker_test.go
@@ -82,7 +82,7 @@ func TestProbeManager(t *testing.T) {
 
 	t.Run("refusals", func(t *testing.T) {
 		pm := makeNewProbeManager([]ma.Multiaddr{pub1, pub2})
-		var probes [][]autonatv2.Request
+		probes := make([][]autonatv2.Request, 0, targetConfidence)
 		for range targetConfidence {
 			reqs := nextProbe(pm)
 			require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}, {Addr: pub2, SendDialData: true}})
@@ -93,7 +93,7 @@ func TestProbeManager(t *testing.T) {
 			pm.CompleteProbe(p, autonatv2.Result{Addr: pub2, Idx: 1, Reachability: network.ReachabilityPublic}, nil)
 		}
 		// the second address is validated!
-		probes = nil
+		probes = probes[:0]
 		for range targetConfidence {
 			reqs := nextProbe(pm)
 			require.Equal(t, reqs, []autonatv2.Request{{Addr: pub1, SendDialData: true}})
@@ -202,7 +202,7 @@ func TestProbeManager(t *testing.T) {
 		pm := makeNewProbeManager([]ma.Multiaddr{tcp, websocket, webrtc, quic})
 
 		extractAddrs := func(reqs probe) []ma.Multiaddr {
-			var res []ma.Multiaddr
+			res := make([]ma.Multiaddr, 0, len(reqs))
 			for _, r := range reqs {
 				res = append(res, r.Addr)
 			}
@@ -380,7 +380,7 @@ func TestAddrsReachabilityTracker(t *testing.T) {
 			},
 		}
 		tr := newTracker(mockClient, nil)
-		var addrs []ma.Multiaddr
+		addrs := make([]ma.Multiaddr, 0, 10)
 		for i := range 10 {
 			addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/1.1.1.1/tcp/%d", i)))
 		}

--- a/p2p/host/basic/basic_host_synctest_test.go
+++ b/p2p/host/basic/basic_host_synctest_test.go
@@ -1,5 +1,3 @@
-//go:build go1.25
-
 package basichost_test
 
 import (

--- a/p2p/host/eventbus/basic_synctest_test.go
+++ b/p2p/host/eventbus/basic_synctest_test.go
@@ -1,5 +1,3 @@
-//go:build go1.25
-
 package eventbus
 
 import (

--- a/p2p/host/eventbus/basic_test.go
+++ b/p2p/host/eventbus/basic_test.go
@@ -76,13 +76,11 @@ func TestSub(t *testing.T) {
 	var event EventB
 
 	var wait sync.WaitGroup
-	wait.Add(1)
 
-	go func() {
+	wait.Go(func() {
 		defer sub.Close()
 		event = (<-sub.Out()).(EventB)
-		wait.Done()
-	}()
+	})
 
 	em, err := bus.Emitter(new(EventB))
 	if err != nil {
@@ -111,15 +109,15 @@ func TestGetAllEventTypes(t *testing.T) {
 
 	evts := bus.GetAllEventTypes()
 	require.Len(t, evts, 1)
-	require.Equal(t, reflect.TypeOf((*EventB)(nil)).Elem(), evts[0])
+	require.Equal(t, reflect.TypeFor[EventB](), evts[0])
 
 	_, err = bus.Emitter(new(EventA))
 	require.NoError(t, err)
 
 	evts = bus.GetAllEventTypes()
 	require.Len(t, evts, 2)
-	require.Contains(t, evts, reflect.TypeOf((*EventB)(nil)).Elem())
-	require.Contains(t, evts, reflect.TypeOf((*EventA)(nil)).Elem())
+	require.Contains(t, evts, reflect.TypeFor[EventB]())
+	require.Contains(t, evts, reflect.TypeFor[EventA]())
 }
 
 func TestEmitNoSubNoBlock(t *testing.T) {
@@ -382,13 +380,11 @@ func TestSubType(t *testing.T) {
 	var event fmt.Stringer
 
 	var wait sync.WaitGroup
-	wait.Add(1)
 
-	go func() {
+	wait.Go(func() {
 		defer sub.Close()
 		event = (<-sub.Out()).(EventA)
-		wait.Done()
-	}()
+	})
 
 	em, err := bus.Emitter(new(EventA))
 	if err != nil {

--- a/p2p/host/observedaddrs/manager_test.go
+++ b/p2p/host/observedaddrs/manager_test.go
@@ -511,7 +511,7 @@ func TestObservedAddrsManager(t *testing.T) {
 			o.maybeRecordObservation(webTransport6Conns[i], resWebTransportAddrs[idx])
 			idx++
 		}
-		var allAddrs []ma.Multiaddr
+		allAddrs := make([]ma.Multiaddr, 0, len(resTCPAddrs)+len(resQuicAddrs)+len(resWebTransportWithCertHashAddrs))
 		allAddrs = append(allAddrs, resTCPAddrs[:]...)
 		allAddrs = append(allAddrs, resQuicAddrs[:]...)
 		allAddrs = append(allAddrs, resWebTransportWithCertHashAddrs[:]...)

--- a/p2p/host/peerstore/pstoremem/addr_book_test.go
+++ b/p2p/host/peerstore/pstoremem/addr_book_test.go
@@ -170,7 +170,7 @@ func TestPeerAddrsExpiry(t *testing.T) {
 			}
 			got = append(got, ea.Addr)
 		}
-		expiries := []int{}
+		expiries := make([]int, 0, N)
 		for i := range N {
 			expiries = append(expiries, expiringAddrs[i].Expiry.Second())
 		}

--- a/p2p/host/peerstore/test/peerstore_suite.go
+++ b/p2p/host/peerstore/test/peerstore_suite.go
@@ -291,8 +291,8 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 
 func testBasicPeerstore(ps pstore.Peerstore) func(t *testing.T) {
 	return func(t *testing.T) {
-		var pids []peer.ID
 		addrs := getAddrs(t, 10)
+		pids := make([]peer.ID, 0, len(addrs))
 
 		for _, a := range addrs {
 			priv, _, err := crypto.GenerateKeyPair(crypto.RSA, 2048)

--- a/p2p/host/resource-manager/error.go
+++ b/p2p/host/resource-manager/error.go
@@ -22,8 +22,7 @@ func logValuesStreamLimit(scope, edge string, dir network.Direction, stat networ
 		logValues = append(logValues, "edge", edge)
 	}
 	logValues = append(logValues, "direction", dir)
-	var e *ErrStreamOrConnLimitExceeded
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*ErrStreamOrConnLimitExceeded](err); ok {
 		logValues = append(logValues,
 			"current", e.current,
 			"attempted", e.attempted,
@@ -41,8 +40,7 @@ func logValuesConnLimit(scope, edge string, dir network.Direction, usefd bool, s
 		logValues = append(logValues, "edge", edge)
 	}
 	logValues = append(logValues, "direction", dir, "usefd", usefd)
-	var e *ErrStreamOrConnLimitExceeded
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*ErrStreamOrConnLimitExceeded](err); ok {
 		logValues = append(logValues,
 			"current", e.current,
 			"attempted", e.attempted,
@@ -68,8 +66,7 @@ func logValuesMemoryLimit(scope, edge string, stat network.ScopeStat, err error)
 	if edge != "" {
 		logValues = append(logValues, "edge", edge)
 	}
-	var e *ErrMemoryLimitExceeded
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*ErrMemoryLimitExceeded](err); ok {
 		logValues = append(logValues,
 			"current", e.current,
 			"attempted", e.attempted,

--- a/p2p/http/auth/auth_test.go
+++ b/p2p/http/auth/auth_test.go
@@ -386,9 +386,7 @@ func TestConcurrentAuth(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	for i := range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			clientKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
 			require.NoError(t, err)
 
@@ -405,7 +403,7 @@ func TestConcurrentAuth(t *testing.T) {
 			respBody, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, reqBody, respBody)
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/p2p/http/libp2phttp.go
+++ b/p2p/http/libp2phttp.go
@@ -570,7 +570,7 @@ func locationHeaderToMultiaddrURI(original *url.URL, locationHeader string) (*ur
 		return nil, errors.New("network path reference not supported")
 	}
 
-	firstSegment := strings.SplitN(locationHeader, "/", 2)[0]
+	firstSegment, _, _ := strings.Cut(locationHeader, "/")
 	if strings.Contains(firstSegment, ":") {
 		// This location contains a scheme, so it's an absolute uri.
 		return url.Parse(locationHeader)

--- a/p2p/muxer/testsuite/mux.go
+++ b/p2p/muxer/testsuite/mux.go
@@ -403,16 +403,14 @@ func SubtestStreamOpenStress(t *testing.T, tr network.Multiplexer) {
 			if err != nil {
 				break
 			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				str.Close()
 				select {
 				case recv <- struct{}{}:
 				default:
 					t.Error("too many stream")
 				}
-			}()
+			})
 		}
 	}()
 

--- a/p2p/net/connmgr/bench_test.go
+++ b/p2p/net/connmgr/bench_test.go
@@ -27,9 +27,7 @@ func BenchmarkLockContention(b *testing.B) {
 	var wg sync.WaitGroup
 
 	for range 16 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-kill:
@@ -38,7 +36,7 @@ func BenchmarkLockContention(b *testing.B) {
 					cm.TagPeer(conns[rand.Intn(len(conns))].RemotePeer(), "another-tag", 1)
 				}
 			}
-		}()
+		})
 	}
 
 	b.ResetTimer()

--- a/p2p/net/connmgr/connmgr.go
+++ b/p2p/net/connmgr/connmgr.go
@@ -43,7 +43,7 @@ type BasicConnMgr struct {
 	connCount atomic.Int32
 	// to be accessed atomically. This is mimicking the implementation of a sync.Once.
 	// Take care of correct alignment when modifying this struct.
-	trimCount uint64
+	trimCount atomic.Uint64
 
 	lastTrimMu sync.RWMutex
 	lastTrim   time.Time
@@ -165,7 +165,7 @@ func (cm *BasicConnMgr) ForceTrim() {
 	}
 
 	cm.trimMutex.Lock()
-	defer atomic.AddUint64(&cm.trimCount, 1)
+	defer cm.trimCount.Add(1)
 	defer cm.trimMutex.Unlock()
 
 	// Trim connections without paying attention to the silence period.
@@ -368,15 +368,15 @@ func (cm *BasicConnMgr) background() {
 
 func (cm *BasicConnMgr) doTrim() {
 	// This logic is mimicking the implementation of sync.Once in the standard library.
-	count := atomic.LoadUint64(&cm.trimCount)
+	count := cm.trimCount.Load()
 	cm.trimMutex.Lock()
 	defer cm.trimMutex.Unlock()
-	if count == atomic.LoadUint64(&cm.trimCount) {
+	if count == cm.trimCount.Load() {
 		cm.trim()
 		cm.lastTrimMu.Lock()
 		cm.lastTrim = cm.clock.Now()
 		cm.lastTrimMu.Unlock()
-		atomic.AddUint64(&cm.trimCount, 1)
+		cm.trimCount.Add(1)
 	}
 }
 

--- a/p2p/net/connmgr/connmgr_test.go
+++ b/p2p/net/connmgr/connmgr_test.go
@@ -24,12 +24,12 @@ type tconn struct {
 	network.Conn
 
 	peer             peer.ID
-	closed           uint32 // to be used atomically. Closed if 1
+	closed           atomic.Uint32 // to be used atomically. Closed if 1
 	disconnectNotify func(net network.Network, conn network.Conn)
 }
 
 func (c *tconn) Close() error {
-	atomic.StoreUint32(&c.closed, 1)
+	c.closed.Store(1)
 	if c.disconnectNotify != nil {
 		c.disconnectNotify(nil, c)
 	}
@@ -37,7 +37,7 @@ func (c *tconn) Close() error {
 }
 
 func (c *tconn) CloseWithError(_ network.ConnErrorCode) error {
-	atomic.StoreUint32(&c.closed, 1)
+	c.closed.Store(1)
 	if c.disconnectNotify != nil {
 		c.disconnectNotify(nil, c)
 	}
@@ -45,7 +45,7 @@ func (c *tconn) CloseWithError(_ network.ConnErrorCode) error {
 }
 
 func (c *tconn) isClosed() bool {
-	return atomic.LoadUint32(&c.closed) == 1
+	return c.closed.Load() == 1
 }
 
 func (c *tconn) RemotePeer() peer.ID {
@@ -951,8 +951,7 @@ func TestSafeConcurrency(t *testing.T) {
 		const concurrency = 10
 		var wg sync.WaitGroup
 		for range concurrency {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				// add conns. This mimics new connection events
 				pis := peerInfos{p1, p2}
 				for i := range runs {
@@ -962,17 +961,14 @@ func TestSafeConcurrency(t *testing.T) {
 					s.peers[pi.id].conns[randConn(t, nil)] = cl.Now()
 					s.Unlock()
 				}
-				wg.Done()
-			}()
+			})
 
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				pis := peerInfos{p1, p2}
 				for range runs {
 					pis.SortByValueAndStreams(ss, false)
 				}
-				wg.Done()
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/p2p/net/nat/nat.go
+++ b/p2p/net/nat/nat.go
@@ -75,11 +75,9 @@ func DiscoverNAT(ctx context.Context) (*NAT, error) {
 		ctxCancel: cancel,
 	}
 	nat.extAddr.Store(&extAddr)
-	nat.refCount.Add(1)
-	go func() {
-		defer nat.refCount.Done()
+	nat.refCount.Go(func() {
 		nat.background()
-	}()
+	})
 	return nat, nil
 }
 

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -82,8 +82,7 @@ func makeSwarmWithNoListenAddrs(t *testing.T, opts ...Option) *Swarm {
 	require.NoError(t, err)
 
 	upgrader := makeUpgrader(t, s)
-	var tcpOpts []tcp.Option
-	tcpOpts = append(tcpOpts, tcp.DisableReuseport())
+	tcpOpts := []tcp.Option{tcp.DisableReuseport()}
 	tcpTransport, err := tcp.NewTCPTransport(upgrader, nil, nil, tcpOpts...)
 	require.NoError(t, err)
 	if err := s.AddTransport(tcpTransport); err != nil {
@@ -388,7 +387,7 @@ func TestDialWorkerLoopConcurrentFailureStress(t *testing.T) {
 }
 
 func TestDialQueueNextBatch(t *testing.T) {
-	addrs := make([]ma.Multiaddr, 0)
+	addrs := make([]ma.Multiaddr, 0, 10)
 	for i := range 10 {
 		addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/1.2.3.4/tcp/%d", i)))
 	}

--- a/p2p/net/swarm/dial_worker_test.go
+++ b/p2p/net/swarm/dial_worker_test.go
@@ -203,9 +203,7 @@ func TestDialWorkerLoopConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	resch := make(chan dialResponse, dials)
 	for range dials {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			reschgo := make(chan dialResponse, 1)
 			reqch <- dialRequest{ctx: context.Background(), resch: reschgo}
 			select {
@@ -214,7 +212,7 @@ func TestDialWorkerLoopConcurrent(t *testing.T) {
 			case <-time.After(time.Minute):
 				resch <- dialResponse{err: errors.New("timed out!")}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -271,9 +269,7 @@ func TestDialWorkerLoopConcurrentFailure(t *testing.T) {
 	var wg sync.WaitGroup
 	resch := make(chan dialResponse, dials)
 	for range dials {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			reschgo := make(chan dialResponse, 1)
 			reqch <- dialRequest{ctx: context.Background(), resch: reschgo}
 
@@ -283,7 +279,7 @@ func TestDialWorkerLoopConcurrentFailure(t *testing.T) {
 			case <-time.After(time.Minute):
 				resch <- dialResponse{err: errTimeout}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -318,9 +314,7 @@ func TestDialWorkerLoopConcurrentMix(t *testing.T) {
 	var wg sync.WaitGroup
 	resch := make(chan dialResponse, dials)
 	for range dials {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			reschgo := make(chan dialResponse, 1)
 			reqch <- dialRequest{ctx: context.Background(), resch: reschgo}
 			select {
@@ -329,7 +323,7 @@ func TestDialWorkerLoopConcurrentMix(t *testing.T) {
 			case <-time.After(time.Minute):
 				resch <- dialResponse{err: errors.New("timed out!")}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -365,9 +359,7 @@ func TestDialWorkerLoopConcurrentFailureStress(t *testing.T) {
 	var wg sync.WaitGroup
 	resch := make(chan dialResponse, dials)
 	for range dials {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			reschgo := make(chan dialResponse, 1)
 			reqch <- dialRequest{ctx: context.Background(), resch: reschgo}
 			select {
@@ -377,7 +369,7 @@ func TestDialWorkerLoopConcurrentFailureStress(t *testing.T) {
 			case <-time.After(15 * time.Second):
 				resch <- dialResponse{err: errTimeout}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/p2p/net/swarm/resolve_test.go
+++ b/p2p/net/swarm/resolve_test.go
@@ -35,8 +35,8 @@ func TestSwarmResolver(t *testing.T) {
 	require.Equal(t, "/ip4/127.0.0.1", res[0].String())
 
 	t.Run("Test Limits", func(t *testing.T) {
-		var ipaddrs []net.IPAddr
-		var manyDNSAddrs []string
+		ipaddrs := make([]net.IPAddr, 0, 255)
+		manyDNSAddrs := make([]string, 0, 255)
 		for i := range 255 {
 			ip := "1.2.3." + strconv.Itoa(i)
 			ipaddrs = append(ipaddrs, net.IPAddr{IP: net.ParseIP(ip)})

--- a/p2p/net/swarm/swarm_dial_test.go
+++ b/p2p/net/swarm/swarm_dial_test.go
@@ -393,8 +393,7 @@ func TestBlackHoledAddrBlocked(t *testing.T) {
 	defer cancel()
 	conn, err := s.DialPeer(ctx, p)
 	require.Nil(t, conn)
-	var de *DialError
-	if !errors.As(err, &de) {
+	if _, ok := errors.AsType[*DialError](err); !ok {
 		t.Fatalf("expected to receive an error of type *DialError, got %s of type %T", err, err)
 	}
 	require.ErrorIs(t, err, ErrDialRefusedBlackHole)

--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -171,9 +171,7 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 			}
 
 			log.Debug("swarm listener accepted connection", "local_multiaddr", c.LocalMultiaddr(), "remote_multiaddr", c.RemoteMultiaddr())
-			s.refs.Add(1)
-			go func() {
-				defer s.refs.Done()
+			s.refs.Go(func() {
 				_, err := s.addConn(c, network.DirInbound)
 				switch err {
 				case nil:
@@ -184,7 +182,7 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 					log.Warn("adding connection failed", "to", a, "err", err)
 					return
 				}
-			}()
+			})
 		}
 	}()
 	return nil

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -600,7 +600,7 @@ func TestAddCertHashes(t *testing.T) {
 		if !ok {
 			continue
 		}
-		var publicAddrs []ma.Multiaddr
+		publicAddrs := make([]ma.Multiaddr, 0, len(publicIPPort))
 		for _, tc := range publicIPPort {
 			publicAddrs = append(publicAddrs, addrWithNewIPPort(prefix, tc))
 		}
@@ -612,7 +612,7 @@ func TestAddCertHashes(t *testing.T) {
 		}
 
 		// if the addr has a certhash already, check it isn't modified
-		publicAddrs = nil
+		publicAddrs = publicAddrs[:0]
 		for _, tc := range publicIPPort {
 			a := addrWithNewIPPort(prefix, tc)
 			a = append(a, certHashComponent...)

--- a/p2p/net/upgrader/listener.go
+++ b/p2p/net/upgrader/listener.go
@@ -102,9 +102,7 @@ func (l *listener) handleIncoming() {
 			"local_multiaddr", maconn.LocalMultiaddr(),
 			"remote_multiaddr", maconn.RemoteMultiaddr())
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			ctx, cancel := context.WithTimeout(l.ctx, l.upgrader.acceptTimeout)
 			defer cancel()
@@ -142,7 +140,7 @@ func (l *listener) handleIncoming() {
 				}
 				conn.CloseWithError(network.ConnRateLimited)
 			}
-		}()
+		})
 	}
 }
 

--- a/p2p/net/upgrader/listener_test.go
+++ b/p2p/net/upgrader/listener_test.go
@@ -229,9 +229,7 @@ func TestConcurrentAccept(t *testing.T) {
 	errCh := make(chan error, num)
 	var wg sync.WaitGroup
 	for range num {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			conn, err := dial(t, u, ln.Multiaddr(), id, &network.NullScope{})
 			if err != nil {
@@ -242,7 +240,7 @@ func TestConcurrentAccept(t *testing.T) {
 
 			_, err = conn.AcceptStream() // wait for conn to be accepted.
 			errCh <- err
-		}()
+		})
 	}
 
 	time.Sleep(200 * time.Millisecond)

--- a/p2p/protocol/autonatv2/autonat_test.go
+++ b/p2p/protocol/autonatv2/autonat_test.go
@@ -54,7 +54,7 @@ func newAutoNAT(t testing.TB, dialer host.Host, opts ...AutoNATOption) *AutoNAT 
 func parseAddrs(t *testing.T, msg *pb.Message) []ma.Multiaddr {
 	t.Helper()
 	req := msg.GetDialRequest()
-	addrs := make([]ma.Multiaddr, 0)
+	addrs := make([]ma.Multiaddr, 0, len(req.Addrs))
 	for _, ab := range req.Addrs {
 		a, err := ma.NewMultiaddrBytes(ab)
 		if err != nil {
@@ -697,7 +697,7 @@ func TestPeerMap(t *testing.T) {
 	pm.Delete(peer.ID("2"))
 
 	contains := []peer.ID{"1", "4"}
-	elems := make([]peer.ID, 0)
+	elems := make([]peer.ID, 0, 8)
 	for p := range pm.Shuffled() {
 		elems = append(elems, p)
 	}

--- a/p2p/protocol/autonatv2/server_test.go
+++ b/p2p/protocol/autonatv2/server_test.go
@@ -105,7 +105,7 @@ func TestServerInvalidAddrsRejected(t *testing.T) {
 		defer an.Close()
 		defer an.host.Close()
 
-		var addrs []ma.Multiaddr
+		addrs := make([]ma.Multiaddr, 0, 100)
 		for i := range 100 {
 			addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", 2000+i)))
 		}
@@ -124,7 +124,7 @@ func TestServerInvalidAddrsRejected(t *testing.T) {
 		defer an.Close()
 		defer an.host.Close()
 
-		var addrs []ma.Multiaddr
+		addrs := make([]ma.Multiaddr, 0, 10000)
 		for i := range 10000 {
 			addrs = append(addrs, ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", 2000+i)))
 		}

--- a/p2p/protocol/autonatv2/server_test.go
+++ b/p2p/protocol/autonatv2/server_test.go
@@ -433,9 +433,7 @@ func TestRateLimiterStress(t *testing.T) {
 		var success, dialDataSuccesses atomic.Int64
 		var wg sync.WaitGroup
 		for range 5 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for range 2 * 60 {
 					for j, p := range peers {
 						if r.Accept(p) {
@@ -449,7 +447,7 @@ func TestRateLimiterStress(t *testing.T) {
 					}
 					cl.AdvanceBy(time.Second)
 				}
-			}()
+			})
 		}
 		wg.Wait()
 		if int(success.Load()) > 10*r.RPM || int(success.Load()) < 9*r.RPM {
@@ -481,16 +479,14 @@ func TestReadDialData(t *testing.T) {
 			r, w := io.Pipe()
 			msg := &pb.Message{}
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				mw := pbio.NewDelimitedWriter(w)
 				err := sendDialData(make([]byte, msgSize), N, mw, msg)
 				if err != nil {
 					t.Error(err)
 				}
 				mw.Close()
-			}()
+			})
 			err := readDialData(N, r)
 			require.NoError(t, err)
 			wg.Wait()
@@ -500,16 +496,14 @@ func TestReadDialData(t *testing.T) {
 			r, w := io.Pipe()
 			msg := &pb.Message{}
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				mw := pbio.NewDelimitedWriter(w)
 				err := sendDialData(make([]byte, msgSize), N, mw, msg)
 				if err != nil {
 					t.Error(err)
 				}
 				mw.Close()
-			}()
+			})
 			err := readDialData(N, r)
 			require.NoError(t, err)
 			wg.Wait()

--- a/p2p/protocol/holepunch/holepuncher.go
+++ b/p2p/protocol/holepunch/holepuncher.go
@@ -279,9 +279,7 @@ func (nn *netNotifiee) Connected(_ network.Network, conn network.Conn) {
 	// Hole punch if it's an inbound proxy connection.
 	// If we already have a direct connection with the remote peer, this will be a no-op.
 	if conn.Stat().Direction == network.DirInbound && isRelayAddress(conn.RemoteMultiaddr()) {
-		hs.refCount.Add(1)
-		go func() {
-			defer hs.refCount.Done()
+		hs.refCount.Go(func() {
 
 			select {
 			// waiting for Identify here will allow us to access the peer's public and observed addresses
@@ -295,7 +293,7 @@ func (nn *netNotifiee) Connected(_ network.Network, conn network.Conn) {
 			if err != nil {
 				log.Debug("attempt to perform DirectConnect failed", "remote_peer", conn.RemotePeer(), "err", err)
 			}
-		}()
+		})
 	}
 }
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -272,9 +272,7 @@ func (ids *idService) loop(ctx context.Context) {
 	// * this Go routine busy looping over all peers in sendPushes
 	// * another push being queued in the triggerPush channel
 	triggerPush := make(chan struct{}, 1)
-	ids.refCount.Add(1)
-	go func() {
-		defer ids.refCount.Done()
+	ids.refCount.Go(func() {
 
 		for {
 			select {
@@ -284,7 +282,7 @@ func (ids *idService) loop(ctx context.Context) {
 				ids.sendPushes(ctx)
 			}
 		}
-	}()
+	})
 
 	for {
 		select {

--- a/p2p/protocol/identify/protocol_limit_test.go
+++ b/p2p/protocol/identify/protocol_limit_test.go
@@ -120,7 +120,7 @@ func TestChunkedMergeMemoryCost(t *testing.T) {
 	w := pbio.NewDelimitedWriter(&buf)
 	for chunk := range numChunks {
 		msg := &pb.Identify{}
-		for i := 0; i < protocolsPerChunk; i++ {
+		for i := range protocolsPerChunk {
 			msg.Protocols = append(msg.Protocols, fmt.Sprintf("/x/%d/%d", chunk, i))
 		}
 		if err := w.WriteMsg(msg); err != nil {

--- a/p2p/test/resource-manager/rcmgr_test.go
+++ b/p2p/test/resource-manager/rcmgr_test.go
@@ -238,9 +238,7 @@ func TestResourceManagerServicePeerInbound(t *testing.T) {
 	var once sync.Once
 	for range 3 {
 		eg.Add(1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			err := echos[2].Echo(echos[0].Host.ID(), "hello libp2p")
 			if err != nil {
@@ -249,7 +247,7 @@ func TestResourceManagerServicePeerInbound(t *testing.T) {
 					close(ready)
 				})
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	eg.Wait()

--- a/p2p/test/transport/transport_test.go
+++ b/p2p/test/transport/transport_test.go
@@ -862,8 +862,7 @@ func TestDiscoverPeerIDFromSecurityNegotiation(t *testing.T) {
 		}
 		innerErr := dialErr.DialErrors[0].Cause
 
-		var peerIDMismatchErr sec.ErrPeerIDMismatch
-		if errors.As(innerErr, &peerIDMismatchErr) {
+		if peerIDMismatchErr, ok := errors.AsType[sec.ErrPeerIDMismatch](innerErr); ok {
 			return peerIDMismatchErr.Actual, nil
 		}
 

--- a/p2p/transport/quic/conn_test.go
+++ b/p2p/transport/quic/conn_test.go
@@ -579,8 +579,8 @@ func testStatelessReset(t *testing.T, tc *connTestCase) {
 	defer serverTransport.(io.Closer).Close()
 	ln := runServer(t, serverTransport, "/ip4/127.0.0.1/udp/0/quic-v1")
 
-	var drop uint32
-	dropCallback := func(quicproxy.Direction, net.Addr, net.Addr, []byte) bool { return atomic.LoadUint32(&drop) > 0 }
+	var drop atomic.Uint32
+	dropCallback := func(quicproxy.Direction, net.Addr, net.Addr, []byte) bool { return drop.Load() > 0 }
 	proxyConn, cleanup := newUDPConnLocalhost(t, 0)
 	proxy := quicproxy.Proxy{
 		Conn:       proxyConn,
@@ -617,7 +617,7 @@ func testStatelessReset(t *testing.T, tc *connTestCase) {
 
 	// Stop forwarding packets and close the server.
 	// This prevents the CONNECTION_CLOSE from reaching the client.
-	atomic.StoreUint32(&drop, 1)
+	drop.Store(1)
 	ln.Close()
 	(<-connChan).Close()
 	proxyLocalPort := proxy.LocalAddr().(*net.UDPAddr).Port
@@ -629,7 +629,7 @@ func testStatelessReset(t *testing.T, tc *connTestCase) {
 	require.NoError(t, err)
 	defer ln.Close()
 	// Now that the new server is up, re-enable packet forwarding.
-	atomic.StoreUint32(&drop, 0)
+	drop.Store(0)
 
 	proxyConn, cleanup = newUDPConnLocalhost(t, proxyLocalPort)
 	defer cleanup()

--- a/p2p/transport/quic/listener_test.go
+++ b/p2p/transport/quic/listener_test.go
@@ -46,7 +46,7 @@ func TestListenAddr(t *testing.T) {
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
 
-		var multiaddrsStrings []string
+		multiaddrsStrings := make([]string, 0, 1)
 		for _, a := range []ma.Multiaddr{ln.Multiaddr()} {
 			multiaddrsStrings = append(multiaddrsStrings, a.String())
 		}
@@ -60,7 +60,7 @@ func TestListenAddr(t *testing.T) {
 		defer ln.Close()
 		port := ln.Addr().(*net.UDPAddr).Port
 		require.NotZero(t, port)
-		var multiaddrsStrings []string
+		multiaddrsStrings := make([]string, 0, 1)
 		for _, a := range []ma.Multiaddr{ln.Multiaddr()} {
 			multiaddrsStrings = append(multiaddrsStrings, a.String())
 		}

--- a/p2p/transport/tcpreuse/listener_test.go
+++ b/p2p/transport/tcpreuse/listener_test.go
@@ -119,9 +119,7 @@ func TestListenerSingle(t *testing.T) {
 			for range N {
 				c, _, err := l.Accept()
 				require.NoError(t, err)
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					cc := multistream.NewMSSelect(c, "a")
 					defer cc.Close()
 					buf := make([]byte, 30)
@@ -132,7 +130,7 @@ func TestListenerSingle(t *testing.T) {
 					if !assert.Equal(t, "hello-multistream", string(buf[:n])) {
 						return
 					}
-				}()
+				})
 			}
 			wg.Wait()
 		})
@@ -170,9 +168,7 @@ func TestListenerSingle(t *testing.T) {
 			var wg sync.WaitGroup
 			for range N {
 				c := <-wh.conns
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
 					if !assert.NoError(t, err) {
@@ -184,7 +180,7 @@ func TestListenerSingle(t *testing.T) {
 					if !assert.Equal(t, "hello", string(buf)) {
 						return
 					}
-				}()
+				})
 			}
 			wg.Wait()
 		})
@@ -224,9 +220,7 @@ func TestListenerSingle(t *testing.T) {
 			var wg sync.WaitGroup
 			for range N {
 				c := <-wh.conns
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
 					if !assert.NoError(t, err) {
@@ -238,7 +232,7 @@ func TestListenerSingle(t *testing.T) {
 					if !assert.Equal(t, "hello", string(buf)) {
 						return
 					}
-				}()
+				})
 			}
 			wg.Wait()
 		})
@@ -348,17 +342,13 @@ func TestListenerMultiplexed(t *testing.T) {
 		}()
 
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range N {
 				c, _, err := msl.Accept()
 				if !assert.NoError(t, err) {
 					return
 				}
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					cc := multistream.NewMSSelect(c, "a")
 					defer cc.Close()
 					buf := make([]byte, 20)
@@ -369,18 +359,14 @@ func TestListenerMultiplexed(t *testing.T) {
 					if !assert.Equal(t, "multistream", string(buf[:n])) {
 						return
 					}
-				}()
+				})
 			}
-		}()
+		})
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range N {
 				c := <-wh.conns
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
 					if !assert.NoError(t, err) {
@@ -392,18 +378,14 @@ func TestListenerMultiplexed(t *testing.T) {
 					if !assert.Equal(t, "websocket", string(buf)) {
 						return
 					}
-				}()
+				})
 			}
-		}()
+		})
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range N {
 				c := <-whs.conns
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					defer c.Close()
 					msgType, buf, err := c.ReadMessage()
 					if !assert.NoError(t, err) {
@@ -415,9 +397,9 @@ func TestListenerMultiplexed(t *testing.T) {
 					if !assert.Equal(t, "websocket-tls", string(buf)) {
 						return
 					}
-				}()
+				})
 			}
-		}()
+		})
 		wg.Wait()
 	}
 }

--- a/p2p/transport/testsuite/stream_suite.go
+++ b/p2p/transport/testsuite/stream_suite.go
@@ -92,12 +92,10 @@ func echo(t *testing.T, c transport.CapableConn) {
 		if err != nil {
 			break
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer str.Close()
 			echoStream(t, str)
-		}()
+		})
 	}
 }
 
@@ -112,11 +110,9 @@ func serve(t *testing.T, l transport.Listener) {
 		}
 		defer c.Close()
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			echo(t, c)
-		}()
+		})
 	}
 }
 
@@ -191,11 +187,9 @@ func SubtestStress(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr,
 		}
 		defer l.Close()
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			serve(t, l)
-		}()
+		})
 
 		c, err := tb.Dial(context.Background(), l.Multiaddr(), peerA)
 		if err != nil {
@@ -206,11 +200,9 @@ func SubtestStress(t *testing.T, ta, tb transport.Transport, maddr ma.Multiaddr,
 
 		// serve the outgoing conn, because some muxers assume
 		// that we _always_ call serve. (this is an error?)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			echo(t, c)
-		}()
+		})
 
 		var openWg sync.WaitGroup
 		for i := 0; i < opt.StreamNum; i++ {
@@ -278,44 +270,34 @@ func SubtestStreamOpenStress(t *testing.T, ta, tb transport.Transport, maddr ma.
 	}()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range workers {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for i := 0; i < count; i++ {
 					s, err := connA.OpenStream(context.Background())
 					if err != nil {
 						t.Error(err)
 						return
 					}
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						fullClose(t, s)
-					}()
+					})
 				}
-			}()
+			})
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; i < count*workers; i++ {
 			str, err := connB.AcceptStream()
 			if err != nil {
 				break
 			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				fullClose(t, str)
-			}()
+			})
 		}
-	}()
+	})
 
 	timeout := time.After(StressTestTimeout)
 	done := make(chan struct{})
@@ -342,9 +324,7 @@ func SubtestStreamReset(t *testing.T, ta, tb transport.Transport, maddr ma.Multi
 	}
 	defer l.Close()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		muxa, err := l.Accept()
 		if err != nil {
@@ -371,7 +351,7 @@ func SubtestStreamReset(t *testing.T, ta, tb transport.Transport, maddr ma.Multi
 			t.Error("should have failed to write")
 		}
 
-	}()
+	})
 
 	muxb, err := tb.Dial(context.Background(), l.Multiaddr(), peerA)
 	if err != nil {

--- a/p2p/transport/testsuite/transport_suite.go
+++ b/p2p/transport/testsuite/transport_suite.go
@@ -182,9 +182,7 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		var err error
 		connA, err = list.Accept()
 		if err != nil {
@@ -200,9 +198,7 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 				return
 			}
 
-			sWg.Add(1)
-			go func() {
-				defer sWg.Done()
+			sWg.Go(func() {
 
 				data, err := io.ReadAll(s)
 				if err != nil {
@@ -227,10 +223,10 @@ func SubtestPingPong(t *testing.T, ta, tb transport.Transport, maddr ma.Multiadd
 					return
 				}
 				s.Close()
-			}()
+			})
 		}
 		sWg.Wait()
-	}()
+	})
 
 	if !tb.CanDial(list.Multiaddr()) {
 		t.Error("CanDial should have returned true")

--- a/p2p/transport/webrtc/listener.go
+++ b/p2p/transport/webrtc/listener.go
@@ -97,11 +97,9 @@ func newListener(transport *WebRTCTransport, laddr ma.Multiaddr, socket net.Pack
 	l.mux = udpmux.NewUDPMux(socket)
 	l.mux.Start()
 
-	l.wg.Add(1)
-	go func() {
-		defer l.wg.Done()
+	l.wg.Go(func() {
 		l.listen()
-	}()
+	})
 
 	return l, err
 }

--- a/p2p/transport/webrtc/transport_test.go
+++ b/p2p/transport/webrtc/transport_test.go
@@ -3,9 +3,11 @@ package libp2pwebrtc
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha3"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"net"
 	"os"
@@ -26,7 +28,6 @@ import (
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/sha3"
 )
 
 var netListenUDP ListenUDPFn = func(network string, laddr *net.UDPAddr) (net.PacketConn, error) {
@@ -177,7 +178,7 @@ func TestTransportWebRTC_ListenFailsOnNonWebRTCMultiaddr(t *testing.T) {
 // using assert inside goroutines, refer: https://github.com/stretchr/testify/issues/772#issuecomment-945166599
 func TestTransportWebRTC_DialFailsOnUnsupportedHashFunction(t *testing.T) {
 	tr, _ := getTransport(t)
-	hash := sha3.New512()
+	hash := hash.Hash(sha3.New512())
 	certhash := func() string {
 		_, err := hash.Write([]byte("test-data"))
 		require.NoError(t, err)
@@ -372,9 +373,7 @@ func TestTransportWebRTC_CanListenMultiple(t *testing.T) {
 	}()
 
 	for range count {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ctr, _ := getTransport(t)
 			conn, err := ctr.Dial(ctx, listener.Multiaddr(), listeningPeer)
 			select {
@@ -384,7 +383,7 @@ func TestTransportWebRTC_CanListenMultiple(t *testing.T) {
 				assert.NotNil(t, conn)
 				t.Cleanup(func() { conn.Close() })
 			}
-		}()
+		})
 	}
 
 	select {
@@ -541,9 +540,7 @@ func TestTransportWebRTC_DialerCanCreateStreamsMultiple(t *testing.T) {
 		var wg sync.WaitGroup
 		var doneStreams atomic.Int32
 		for range numListeners {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for {
 					var nn int32
 					if nn = doneStreams.Add(1); nn > int32(numStreams) {
@@ -556,7 +553,7 @@ func TestTransportWebRTC_DialerCanCreateStreamsMultiple(t *testing.T) {
 					require.NoError(t, err)
 					s.Close()
 				}
-			}()
+			})
 		}
 		wg.Wait()
 		readerDone <- struct{}{}
@@ -570,9 +567,7 @@ func TestTransportWebRTC_DialerCanCreateStreamsMultiple(t *testing.T) {
 	var cnt atomic.Int32
 	var streamsStarted atomic.Int32
 	for range numWriters {
-		writerWG.Add(1)
-		go func() {
-			defer writerWG.Done()
+		writerWG.Go(func() {
 			buf := make([]byte, size)
 			for {
 				var nn int32
@@ -597,7 +592,7 @@ func TestTransportWebRTC_DialerCanCreateStreamsMultiple(t *testing.T) {
 				s.Close()
 				t.Log("completed stream: ", cnt.Add(1), s.(*stream).id)
 			}
-		}()
+		})
 	}
 	writerWG.Wait()
 	select {
@@ -834,9 +829,7 @@ func TestTransportWebRTC_Close(t *testing.T) {
 
 	t.Run("RemoteClosesStream", func(t *testing.T) {
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			lconn, err := listener.Accept()
 			require.NoError(t, err)
 			t.Cleanup(func() { lconn.Close() })
@@ -845,7 +838,7 @@ func TestTransportWebRTC_Close(t *testing.T) {
 			require.NoError(t, err)
 			time.Sleep(100 * time.Millisecond)
 			_ = stream.Close()
-		}()
+		})
 
 		buf := make([]byte, 2)
 
@@ -990,9 +983,7 @@ func TestMaxInFlightRequests(t *testing.T) {
 	var wg sync.WaitGroup
 	var success, fails atomic.Int32
 	for range count + 1 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			dialer, _ := getTransport(t)
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
@@ -1003,7 +994,7 @@ func TestMaxInFlightRequests(t *testing.T) {
 				t.Log("failed to dial:", err)
 				fails.Add(1)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	require.Equal(t, count, int(success.Load()), "expected exactly 3 dial successes")
@@ -1140,9 +1131,7 @@ func TestConnectionClosedWhenRemoteCloses(t *testing.T) {
 	accepted := make(chan struct{})
 	dialer, _ := getTransport(t)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		c, err := listener.Accept()
 		close(accepted)
 		if !assert.NoError(t, err) {
@@ -1151,7 +1140,7 @@ func TestConnectionClosedWhenRemoteCloses(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			return c.IsClosed()
 		}, 5*time.Second, 50*time.Millisecond)
-	}()
+	})
 
 	c, err := dialer.Dial(context.Background(), listener.Multiaddr(), p)
 	require.NoError(t, err)

--- a/p2p/transport/webrtc/udpmux/mux.go
+++ b/p2p/transport/webrtc/udpmux/mux.go
@@ -100,11 +100,9 @@ func NewUDPMux(socket net.PacketConn) *UDPMux {
 }
 
 func (mux *UDPMux) Start() {
-	mux.wg.Add(1)
-	go func() {
-		defer mux.wg.Done()
+	mux.wg.Go(func() {
 		mux.readLoop()
-	}()
+	})
 }
 
 // GetListenAddresses implements ice.UDPMux

--- a/p2p/transport/webtransport/cert_manager.go
+++ b/p2p/transport/webtransport/cert_manager.go
@@ -129,10 +129,8 @@ func (m *certManager) background(hostKey ic.PrivKey) {
 	d := m.currentConfig.End().Add(-clockSkewAllowance).Sub(m.clock.Now())
 	log.Debug("setting timer", "duration", d.String())
 	t := m.clock.Timer(d)
-	m.refCount.Add(1)
 
-	go func() {
-		defer m.refCount.Done()
+	m.refCount.Go(func() {
 		defer t.Stop()
 
 		for {
@@ -151,7 +149,7 @@ func (m *certManager) background(hostKey ic.PrivKey) {
 				m.mx.Unlock()
 			}
 		}
-	}()
+	})
 }
 
 func (m *certManager) GetConfig() *tls.Config {

--- a/p2p/transport/webtransport/stream.go
+++ b/p2p/transport/webtransport/stream.go
@@ -37,8 +37,7 @@ var _ network.MuxedStream = stream{}
 func (s stream) Read(b []byte) (n int, err error) {
 	n, err = s.Stream.Read(b)
 	if err != nil {
-		var streamErr *webtransport.StreamError
-		if errors.As(err, &streamErr) {
+		if streamErr, ok := errors.AsType[*webtransport.StreamError](err); ok {
 			err = &network.StreamError{
 				ErrorCode:      0,
 				Remote:         streamErr.Remote,
@@ -52,8 +51,7 @@ func (s stream) Read(b []byte) (n int, err error) {
 func (s stream) Write(b []byte) (n int, err error) {
 	n, err = s.Stream.Write(b)
 	if err != nil {
-		var streamErr *webtransport.StreamError
-		if errors.As(err, &streamErr) {
+		if streamErr, ok := errors.AsType[*webtransport.StreamError](err); ok {
 			err = &network.StreamError{
 				ErrorCode:      0,
 				Remote:         streamErr.Remote,

--- a/scripts/test_analysis/main.go
+++ b/scripts/test_analysis/main.go
@@ -99,23 +99,24 @@ func (t *tester) runTests(passThruFlags []string) error {
 }
 
 func (t *tester) goTestAll(extraFlags []string) error {
-	flags := []string{"./..."}
+	flags := make([]string, 0, 1+len(extraFlags))
+	flags = append(flags, "./...")
 	flags = append(flags, extraFlags...)
 	return t.goTest(flags)
 }
 
 func (t *tester) goTestPkgTest(pkg, testname string, extraFlags []string) error {
-	flags := []string{
-		pkg, "-run", "^" + testname + "$", "-count", "1",
-	}
+	flags := make([]string, 0, 5+len(extraFlags))
+	flags = append(flags,
+		pkg, "-run", "^"+testname+"$", "-count", "1",
+	)
 	flags = append(flags, extraFlags...)
 	return t.goTest(flags)
 }
 
 func (t *tester) goTest(extraFlags []string) error {
-	flags := []string{
-		"test", "-json",
-	}
+	flags := make([]string, 0, 2+len(extraFlags))
+	flags = append(flags, "test", "-json")
 	flags = append(flags, extraFlags...)
 	cmd := exec.Command("go", flags...)
 	cmd.Dir = t.Dir

--- a/test-plans/PingDockerfile
+++ b/test-plans/PingDockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # This is run from the parent directory to copy the whole go-libp2p codebase
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 WORKDIR /app/
 

--- a/test-plans/go.mod
+++ b/test-plans/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p/test-plans/m/v2
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/x/simlibp2p/synctest_test.go
+++ b/x/simlibp2p/synctest_test.go
@@ -1,5 +1,3 @@
-//go:build go1.25
-
 package simlibp2p_test
 
 import (


### PR DESCRIPTION
- Update minimum required go version to 1.26
- Run latest go modernizers (go fix ./...)
- Fix lint prealloc suggestions
- Update test-plans `PingDockerfile` to use go1.27
- Update workflows and actions to use go1.26
- Remove broken links from `README.md`

@sukunrt @MarcoPolo: Merging this PR might make updating [quic-go](https://github.com/quic-go/quic-go/releases/tag/v0.62.0) easier since it requires go1.26