### PR TITLE
fix(http/auth): reject oversized opaque

### DIFF
--- a/p2p/http/auth/auth_test.go
+++ b/p2p/http/auth/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
@@ -408,4 +409,40 @@ func TestConcurrentAuth(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestServerPeerIDAuth_OversizedClientPublicKey rejects a client-initiated
+// handshake whose public key would overflow the opaque scratch buffer, without panicking.
+func TestServerPeerIDAuth_OversizedClientPublicKey(t *testing.T) {
+	serverKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+
+	auth := ServerPeerIDAuth{
+		PrivKey: serverKey,
+		ValidHostnameFn: func(s string) bool {
+			return s == "example.com"
+		},
+		TokenTTL: time.Hour,
+		NoTLS:    true,
+	}
+	ts := httptest.NewServer(&auth)
+	t.Cleanup(ts.Close)
+
+	largeKey := bytes.Repeat([]byte{0xAB}, 900)
+	challenge := bytes.Repeat([]byte{0x11}, 32)
+	authHeader := fmt.Sprintf(
+		`libp2p-PeerID challenge-server="%s", public-key="%s"`,
+		base64.URLEncoding.EncodeToString(challenge),
+		base64.URLEncoding.EncodeToString(largeKey),
+	)
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	require.NoError(t, err)
+	req.Host = "example.com"
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }

--- a/p2p/http/auth/internal/handshake/handshake_test.go
+++ b/p2p/http/auth/internal/handshake/handshake_test.go
@@ -337,6 +337,34 @@ func FuzzServerHandshakeNoPanic(f *testing.F) {
 	})
 }
 
+// TestClientInitiatedOversizedPublicKeyNoPanic ensures a client-initiated
+// handshake with a large public-key param returns an error instead of
+// panicking when the opaque value would exceed the server's fixed scratch buffer.
+func TestClientInitiatedOversizedPublicKeyNoPanic(t *testing.T) {
+	serverKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+
+	// Large enough that opaque JSON (HMAC + client-public-key + metadata) exceeds
+	// the 1024-byte scratch buffer, but the Authorization header stays under maxHeaderSize.
+	largeKey := bytes.Repeat([]byte{0xAB}, 900)
+	challenge := bytes.Repeat([]byte{0x11}, challengeLen)
+	hdr := fmt.Sprintf(
+		`libp2p-PeerID challenge-server="%s", public-key="%s"`,
+		base64.URLEncoding.EncodeToString(challenge),
+		base64.URLEncoding.EncodeToString(largeKey),
+	)
+	require.LessOrEqual(t, len(hdr), maxHeaderSize)
+
+	h := PeerIDAuthHandshakeServer{
+		Hostname: "example.com",
+		PrivKey:  serverKey,
+		Hmac:     hmac.New(sha256.New, make([]byte, 32)),
+	}
+	require.NoError(t, h.ParseHeaderVal([]byte(hdr)))
+	err = h.Run()
+	require.ErrorIs(t, err, errTooBig)
+}
+
 func BenchmarkOpaqueStateWrite(b *testing.B) {
 	zeroBytes := [32]byte{}
 	hmac := hmac.New(sha256.New, zeroBytes[:])

--- a/p2p/http/auth/internal/handshake/server.go
+++ b/p2p/http/auth/internal/handshake/server.go
@@ -280,6 +280,11 @@ func (h *PeerIDAuthHandshakeServer) addOpaqueParam() error {
 	if err != nil {
 		return err
 	}
+	// Reject when Marshal grew past the fixed scratch buffer; otherwise
+	// h.buf[len(opaqueVal):] panics (e.g. client-initiated large public keys).
+	if len(opaqueVal) > len(h.buf) {
+		return errTooBig
+	}
 	h.hb.writeParamB64(h.buf[len(opaqueVal):], "opaque", opaqueVal)
 	return nil
 }
@@ -304,6 +309,9 @@ func (h *PeerIDAuthHandshakeServer) addBearerParam() error {
 	bearerToken, err := h.opaque.Marshal(h.Hmac, h.buf[:0])
 	if err != nil {
 		return err
+	}
+	if len(bearerToken) > len(h.buf) {
+		return errTooBig
 	}
 	h.hb.writeParamB64(h.buf[len(bearerToken):], "bearer", bearerToken)
 	return nil


### PR DESCRIPTION
Client-initiated PeerID auth could embed a large public key in the server opaque blob. When that blob exceeded the 1024-byte scratch buffer, slicing the buffer paniced. Return errTooBig instead.

Co-authored-by: Marco Munizaga <git@marcopolo.io>

Reported-by: <sahilsojitra4555@gmail.com>